### PR TITLE
📝 Enforce inline review comments + address-before-merge rule

### DIFF
--- a/WORKFLOW.md
+++ b/WORKFLOW.md
@@ -11,19 +11,56 @@
    - Poll CI every 2 minutes
    - If **red** → identify the failure, fix it, push again, repeat until green
    - Never merge while CI is red
-7. **Review** — add inline review comments to the PR (what looks good, what was tricky, any concerns)
-8. **Address review** — if comments raise issues, fix them and push
-9. **Merge** — squash-merge ONLY when all CI checks are green and review is addressed
+7. **Review — MANDATORY before merge:**
+   - Add a **PR-level summary review** (overall assessment, key decisions, concerns)
+   - Add **inline comments on specific lines** for anything noteworthy: tricky logic, potential issues, placeholder code, future TODOs
+   - Use GitHub's review API to post inline comments with `path`, `line`, and `body`
+   - **All review comments must be addressed before merging** — either fix the code or explicitly resolve with a reply explaining why it's acceptable as-is
+8. **Address review** — push fixes for any issues raised, then re-check CI
+9. **Merge** — squash-merge ONLY when:
+   - All CI checks are green ✅
+   - All review comments are addressed ✅
 10. **Close issue** — mark the GitHub issue as closed
 11. **Update roadmap** — tick the issue in Issue #13, update progress percentages
 12. **Update README** — tick any phase checkboxes if the issue completes a phase
 
-## Commit style
-Use gitmoji: ✨ feature · 🐛 fix · 📝 docs · 🔧 config · ♻️ refactor · ✅ tests · 🏗️ architecture
+## How to Add Inline Review Comments
 
-## GitHub API reference
 ```bash
-GH_TOKEN=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
+GH_TOKEN=$GH_TOKEN
+REPO=lobbyclawy/arkd-rs
+
+# Get the latest commit SHA on the PR
+SHA=$(curl -s -H "Authorization: token $GH_TOKEN" \
+  "https://api.github.com/repos/$REPO/pulls/PR_NUM" \
+  | python3 -c "import json,sys; print(json.load(sys.stdin)['head']['sha'])")
+
+# Create a review with inline comments
+curl -s -X POST -H "Authorization: token $GH_TOKEN" -H "Content-Type: application/json" \
+  "https://api.github.com/repos/$REPO/pulls/PR_NUM/reviews" \
+  -d "{
+    \"commit_id\": \"$SHA\",
+    \"event\": \"COMMENT\",
+    \"body\": \"## Review Summary\\n\\nOverall assessment here...\",
+    \"comments\": [
+      {
+        \"path\": \"crates/arkd-bitcoin/src/tree.rs\",
+        \"line\": 42,
+        \"body\": \"Inline comment on this specific line\"
+      },
+      {
+        \"path\": \"crates/arkd-bitcoin/src/tree.rs\",
+        \"line\": 100,
+        \"body\": \"Another inline comment\"
+      }
+    ]
+  }"
+```
+
+## GitHub API Reference
+
+```bash
+GH_TOKEN=$GH_TOKEN
 REPO=lobbyclawy/arkd-rs
 
 # Create PR
@@ -40,11 +77,6 @@ curl -s -H "Authorization: token $GH_TOKEN" \
   "https://api.github.com/repos/$REPO/commits/SHA/check-runs" \
   | python3 -c "import json,sys; d=json.load(sys.stdin); [print(r['name'], r['status'], r.get('conclusion','')) for r in d.get('check_runs',[])]"
 
-# Add review comment
-curl -s -X POST -H "Authorization: token $GH_TOKEN" -H "Content-Type: application/json" \
-  "https://api.github.com/repos/$REPO/pulls/PR_NUM/reviews" \
-  -d '{"event":"COMMENT","body":"..."}'
-
 # Squash merge
 curl -s -X PUT -H "Authorization: token $GH_TOKEN" \
   "https://api.github.com/repos/$REPO/pulls/PR_NUM/merge" \
@@ -54,3 +86,9 @@ curl -s -X PUT -H "Authorization: token $GH_TOKEN" \
 curl -s -X PATCH -H "Authorization: token $GH_TOKEN" \
   "https://api.github.com/repos/$REPO/issues/N" -d '{"state":"closed"}'
 ```
+
+## Commit Style
+Use gitmoji: ✨ feature · 🐛 fix · 📝 docs · 🔧 config · ♻️ refactor · ✅ tests · 🏗️ architecture
+
+## ⚠️ Never push directly to main
+All changes go through feature branches and PRs. No exceptions.


### PR DESCRIPTION
## Changes

Updates `WORKFLOW.md` to enforce:

1. **Inline line-by-line review comments** — not just a PR-level summary, but specific comments on individual lines with `path` + `line` + `body`
2. **All review comments must be addressed before merging** — either fix the code, or explicitly resolve with a reply explaining why it is acceptable as-is

Also adds the inline comment API snippet so sub-agents know exactly how to do it.

Fixes the gap in PRs #21 and #22 where reviews were PR-level summaries only.