### PR TITLE
✨ Event stream: GetEventStream + EventBroker (#43)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -115,6 +115,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arkd-core",
+ "async-stream",
  "async-trait",
  "axum",
  "base64 0.22.1",

--- a/crates/arkd-api/Cargo.toml
+++ b/crates/arkd-api/Cargo.toml
@@ -19,6 +19,8 @@ tower-http = { version = "0.6", features = ["cors", "trace"] }
 # Async runtime
 tokio = { version = "1.42", features = ["sync", "macros"] }
 tokio-util = "0.7"
+async-stream = "0.3"
+tokio-stream = "0.1"
 
 # Error handling
 anyhow = "1.0"

--- a/crates/arkd-api/src/grpc/ark_service.rs
+++ b/crates/arkd-api/src/grpc/ark_service.rs
@@ -1,7 +1,10 @@
 //! ArkService gRPC implementation — user-facing API.
 
+use std::pin::Pin;
 use std::sync::Arc;
 
+use async_stream::stream;
+use tokio_stream::Stream;
 use tonic::{Request, Response, Status};
 use tracing::{info, warn};
 
@@ -9,11 +12,14 @@ use arkd_core::ports::RoundRepository;
 
 use crate::proto::ark_v1::ark_service_server::ArkService as ArkServiceTrait;
 use crate::proto::ark_v1::{
-    GetInfoRequest, GetInfoResponse, GetRoundRequest, GetRoundResponse, GetVtxosRequest,
-    GetVtxosResponse, ListRoundsRequest, ListRoundsResponse, RegisterForRoundRequest,
-    RegisterForRoundResponse, RequestExitRequest, RequestExitResponse, ServiceStatus,
+    GetEventStreamRequest, GetInfoRequest, GetInfoResponse, GetRoundRequest, GetRoundResponse,
+    GetVtxosRequest, GetVtxosResponse, ListRoundsRequest, ListRoundsResponse,
+    RegisterForRoundRequest, RegisterForRoundResponse, RequestExitRequest, RequestExitResponse,
+    RoundEvent, RoundHeartbeatEvent, ServiceStatus, UpdateStreamTopicsRequest,
+    UpdateStreamTopicsResponse,
 };
 
+use super::broker::SharedEventBroker;
 use super::convert;
 use super::middleware::{get_authenticated_user, require_authenticated_user};
 
@@ -21,12 +27,21 @@ use super::middleware::{get_authenticated_user, require_authenticated_user};
 pub struct ArkGrpcService {
     core: Arc<arkd_core::ArkService>,
     round_repo: Arc<dyn RoundRepository>,
+    broker: SharedEventBroker,
 }
 
 impl ArkGrpcService {
-    /// Create a new ArkGrpcService wrapping the core service and round repository.
-    pub fn new(core: Arc<arkd_core::ArkService>, round_repo: Arc<dyn RoundRepository>) -> Self {
-        Self { core, round_repo }
+    /// Create a new ArkGrpcService wrapping the core service, round repository, and event broker.
+    pub fn new(
+        core: Arc<arkd_core::ArkService>,
+        round_repo: Arc<dyn RoundRepository>,
+        broker: SharedEventBroker,
+    ) -> Self {
+        Self {
+            core,
+            round_repo,
+            broker,
+        }
     }
 
     /// Verify that the authenticated user owns all the specified VTXOs
@@ -67,8 +82,13 @@ impl ArkGrpcService {
     }
 }
 
+/// Server-streaming response type for GetEventStream.
+type GetEventStreamStream =
+    Pin<Box<dyn Stream<Item = Result<RoundEvent, Status>> + Send + 'static>>;
+
 #[tonic::async_trait]
 impl ArkServiceTrait for ArkGrpcService {
+    type GetEventStreamStream = GetEventStreamStream;
     async fn get_info(
         &self,
         _request: Request<GetInfoRequest>,
@@ -316,6 +336,53 @@ impl ArkServiceTrait for ArkGrpcService {
             ))),
             Err(e) => Err(Status::internal(e.to_string())),
         }
+    }
+
+    async fn get_event_stream(
+        &self,
+        _request: Request<GetEventStreamRequest>,
+    ) -> Result<Response<Self::GetEventStreamStream>, Status> {
+        info!("GetEventStream called");
+        let mut rx = self.broker.subscribe();
+
+        let output = stream! {
+            // Yield an initial heartbeat so the client knows the stream is alive
+            let now = std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap_or_default()
+                .as_secs() as i64;
+            yield Ok(RoundEvent {
+                event: Some(crate::proto::ark_v1::round_event::Event::Heartbeat(
+                    RoundHeartbeatEvent { timestamp: now },
+                )),
+            });
+
+            // Forward events from the broker
+            loop {
+                match rx.recv().await {
+                    Ok(event) => yield Ok(event),
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(skipped = n, "Event stream client lagged, skipped events");
+                        // Continue receiving — don't break
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
+                }
+            }
+        };
+
+        Ok(Response::new(Box::pin(output)))
+    }
+
+    async fn update_stream_topics(
+        &self,
+        request: Request<UpdateStreamTopicsRequest>,
+    ) -> Result<Response<UpdateStreamTopicsResponse>, Status> {
+        let req = request.into_inner();
+        info!(topics = ?req.topics, "UpdateStreamTopics called");
+        // Topic filtering is a future enhancement; accept and acknowledge
+        Ok(Response::new(UpdateStreamTopicsResponse {}))
     }
 }
 

--- a/crates/arkd-api/src/grpc/broker.rs
+++ b/crates/arkd-api/src/grpc/broker.rs
@@ -1,0 +1,31 @@
+//! Event broker for streaming round lifecycle events to clients.
+
+use std::sync::Arc;
+use tokio::sync::broadcast;
+
+/// Broadcasts round lifecycle events to connected stream clients.
+#[derive(Clone)]
+pub struct EventBroker {
+    sender: broadcast::Sender<crate::proto::ark_v1::RoundEvent>,
+}
+
+impl EventBroker {
+    /// Create a new EventBroker with the given channel capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender }
+    }
+
+    /// Publish an event to all connected subscribers.
+    pub fn publish(&self, event: crate::proto::ark_v1::RoundEvent) {
+        let _ = self.sender.send(event);
+    }
+
+    /// Subscribe to the event stream.
+    pub fn subscribe(&self) -> broadcast::Receiver<crate::proto::ark_v1::RoundEvent> {
+        self.sender.subscribe()
+    }
+}
+
+/// Shared reference to an EventBroker.
+pub type SharedEventBroker = Arc<EventBroker>;

--- a/crates/arkd-api/src/grpc/mod.rs
+++ b/crates/arkd-api/src/grpc/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod admin_service;
 pub mod ark_service;
+pub mod broker;
 pub mod convert;
 pub mod middleware;

--- a/crates/arkd-api/src/lib.rs
+++ b/crates/arkd-api/src/lib.rs
@@ -34,6 +34,7 @@ pub mod proto {
 }
 
 pub use config::ServerConfig;
+pub use grpc::broker::{EventBroker, SharedEventBroker};
 pub use monitoring::{spawn_monitoring_server, MonitoringConfig};
 pub use server::Server;
 

--- a/crates/arkd-api/src/server.rs
+++ b/crates/arkd-api/src/server.rs
@@ -12,6 +12,7 @@ use arkd_core::ports::RoundRepository;
 use crate::auth::Authenticator;
 use crate::grpc::admin_service::AdminGrpcService;
 use crate::grpc::ark_service::ArkGrpcService;
+use crate::grpc::broker::SharedEventBroker;
 use crate::grpc::middleware::AuthInterceptor;
 use crate::proto::ark_v1::admin_service_server::AdminServiceServer;
 use crate::proto::ark_v1::ark_service_server::ArkServiceServer;
@@ -29,6 +30,7 @@ pub struct Server {
     config: ServerConfig,
     core: Arc<arkd_core::ArkService>,
     round_repo: Arc<dyn RoundRepository>,
+    broker: SharedEventBroker,
     authenticator: Arc<Authenticator>,
     cancel: CancellationToken,
 }
@@ -56,10 +58,13 @@ impl Server {
             Arc::new(Authenticator::new(vec![0u8; 32]))
         });
 
+        let broker = Arc::new(crate::grpc::broker::EventBroker::new(256));
+
         Ok(Self {
             config,
             core,
             round_repo,
+            broker,
             authenticator,
             cancel: CancellationToken::new(),
         })
@@ -114,7 +119,11 @@ impl Server {
             .parse()
             .map_err(|e| crate::ApiError::StartupError(format!("Invalid gRPC address: {e}")))?;
 
-        let ark_service = ArkGrpcService::new(Arc::clone(&self.core), Arc::clone(&self.round_repo));
+        let ark_service = ArkGrpcService::new(
+            Arc::clone(&self.core),
+            Arc::clone(&self.round_repo),
+            Arc::clone(&self.broker),
+        );
 
         // Create auth interceptor
         // In production, use AuthInterceptor::strict()

--- a/crates/arkd-api/tests/grpc_integration.rs
+++ b/crates/arkd-api/tests/grpc_integration.rs
@@ -13,8 +13,9 @@ use arkd_api::proto::ark_v1::admin_service_server::AdminServiceServer;
 use arkd_api::proto::ark_v1::ark_service_client::ArkServiceClient;
 use arkd_api::proto::ark_v1::ark_service_server::ArkServiceServer;
 use arkd_api::proto::ark_v1::{
-    GetInfoRequest, GetRoundRequest, GetStatusRequest, GetVtxosRequest, ListRoundsRequest,
-    Outpoint, RegisterForRoundRequest, RequestExitRequest,
+    GetEventStreamRequest, GetInfoRequest, GetRoundRequest, GetStatusRequest, GetVtxosRequest,
+    ListRoundsRequest, Outpoint, RegisterForRoundRequest, RequestExitRequest,
+    UpdateStreamTopicsRequest,
 };
 
 use arkd_api::grpc::admin_service::AdminGrpcService;
@@ -202,7 +203,8 @@ async fn start_ark_server() -> ArkServiceClient<Channel> {
 
     let core = build_test_core();
     let round_repo: Arc<dyn arkd_core::ports::RoundRepository> = Arc::new(MockRoundRepo);
-    let svc = ArkServiceServer::new(ArkGrpcService::new(core, round_repo));
+    let broker = Arc::new(arkd_api::EventBroker::new(64));
+    let svc = ArkServiceServer::new(ArkGrpcService::new(core, round_repo, broker));
 
     tokio::spawn(async move {
         Server::builder()
@@ -520,4 +522,40 @@ async fn test_admin_get_round_details_validation() {
         .await;
     assert!(result.is_err());
     assert_eq!(result.unwrap_err().code(), tonic::Code::InvalidArgument);
+}
+
+// ─── Event stream tests ─────────────────────────────────────────────
+
+#[tokio::test]
+async fn test_event_stream_initial_heartbeat() {
+    use tokio_stream::StreamExt;
+
+    let mut client = start_ark_server().await;
+
+    let response = client
+        .get_event_stream(GetEventStreamRequest {})
+        .await
+        .expect("get_event_stream should succeed");
+
+    let mut stream = response.into_inner();
+    let first = stream.next().await.expect("stream should yield an item");
+    let event = first.expect("first item should be Ok");
+
+    match event.event {
+        Some(arkd_api::proto::ark_v1::round_event::Event::Heartbeat(hb)) => {
+            assert!(hb.timestamp > 0, "heartbeat timestamp should be positive");
+        }
+        other => panic!("Expected heartbeat event, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_update_stream_topics_noop() {
+    let mut client = start_ark_server().await;
+
+    let response = client
+        .update_stream_topics(UpdateStreamTopicsRequest { topics: vec![] })
+        .await;
+
+    assert!(response.is_ok(), "update_stream_topics should succeed");
 }

--- a/proto/ark/v1/ark_service.proto
+++ b/proto/ark/v1/ark_service.proto
@@ -23,6 +23,12 @@ service ArkService {
 
   // GetRound returns details for a specific round.
   rpc GetRound(GetRoundRequest) returns (GetRoundResponse);
+
+  // GetEventStream opens a server-streaming connection for round lifecycle events.
+  rpc GetEventStream(GetEventStreamRequest) returns (stream RoundEvent);
+
+  // UpdateStreamTopics updates the set of event topics the client subscribes to.
+  rpc UpdateStreamTopics(UpdateStreamTopicsRequest) returns (UpdateStreamTopicsResponse);
 }
 
 message GetInfoRequest {}
@@ -88,4 +94,47 @@ message GetRoundRequest {
 }
 message GetRoundResponse {
   RoundDetails round = 1;
+}
+
+message GetEventStreamRequest {}
+
+message UpdateStreamTopicsRequest {
+  repeated string topics = 1;
+}
+
+message UpdateStreamTopicsResponse {}
+
+message RoundEvent {
+  oneof event {
+    BatchStartedEvent batch_started = 1;
+    BatchFinalizationEvent batch_finalization = 2;
+    BatchFinalizedEvent batch_finalized = 3;
+    BatchFailedEvent batch_failed = 4;
+    RoundHeartbeatEvent heartbeat = 5;
+  }
+}
+
+message BatchStartedEvent {
+  string round_id = 1;
+  int64 timestamp = 2;
+}
+
+message BatchFinalizationEvent {
+  string round_id = 1;
+  int64 timestamp = 2;
+  int64 min_relay_fee_rate = 3;
+}
+
+message BatchFinalizedEvent {
+  string round_id = 1;
+  string txid = 2;
+}
+
+message BatchFailedEvent {
+  string round_id = 1;
+  string reason = 2;
+}
+
+message RoundHeartbeatEvent {
+  int64 timestamp = 1;
 }


### PR DESCRIPTION
## Summary

Implements Issue #43: Event stream — GetEventStream streaming RPC.

### Changes

- **Proto**: Added `GetEventStream` (server-streaming) and `UpdateStreamTopics` RPCs to `ArkService`, plus `RoundEvent` oneof with 5 event types (BatchStarted, BatchFinalization, BatchFinalized, BatchFailed, RoundHeartbeat)
- **EventBroker** (`broker.rs`): New `tokio::sync::broadcast`-based pub/sub broker for round lifecycle events, shared via `Arc<EventBroker>`
- **ArkGrpcService**: Wired broker into the service struct; `get_event_stream` yields an initial heartbeat then forwards broker events; `update_stream_topics` is a no-op placeholder for future topic filtering
- **Server**: Auto-creates broker (capacity 256) and passes to ArkGrpcService
- **Tests**: 2 new integration tests (heartbeat verification, topics noop)
- **Dependencies**: Added `async-stream` and `tokio-stream` to arkd-api

Closes #43