### PR TITLE
✨ PostgreSQL adapter for database layer (#47)

### DIFF
--- a/crates/arkd-db/Cargo.toml
+++ b/crates/arkd-db/Cargo.toml
@@ -5,9 +5,14 @@ edition = "2021"
 description = "Database layer for arkd-rs (PostgreSQL, SQLite, Redis)"
 license = "MIT"
 
+[features]
+default = ["sqlite"]
+sqlite = ["sqlx/sqlite"]
+postgres = ["sqlx/postgres"]
+
 [dependencies]
 # Database
-sqlx = { version = "0.8", features = ["postgres", "sqlite", "runtime-tokio", "macros", "uuid", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "macros", "uuid", "chrono"] }
 
 # Cache
 redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }

--- a/crates/arkd-db/migrations/pg/001_initial.sql
+++ b/crates/arkd-db/migrations/pg/001_initial.sql
@@ -1,0 +1,107 @@
+-- Initial schema for arkd-rs database layer (PostgreSQL)
+-- Ported from SQLite migrations/001_initial.sql
+
+-- Rounds table
+CREATE TABLE IF NOT EXISTS rounds (
+    id                  TEXT PRIMARY KEY,
+    starting_timestamp  BIGINT NOT NULL DEFAULT 0,
+    ending_timestamp    BIGINT NOT NULL DEFAULT 0,
+    stage_code          INTEGER NOT NULL DEFAULT 0,
+    stage_ended         BOOLEAN NOT NULL DEFAULT FALSE,
+    stage_failed        BOOLEAN NOT NULL DEFAULT FALSE,
+    commitment_txid     TEXT NOT NULL DEFAULT '',
+    commitment_tx       TEXT NOT NULL DEFAULT '',
+    connector_address   TEXT NOT NULL DEFAULT '',
+    version             INTEGER NOT NULL DEFAULT 0,
+    swept               BOOLEAN NOT NULL DEFAULT FALSE,
+    vtxo_tree_expiration BIGINT NOT NULL DEFAULT 0,
+    fail_reason         TEXT NOT NULL DEFAULT ''
+);
+
+-- Round transactions (forfeit, connector tree, vtxo tree, sweep, commitment)
+CREATE TABLE IF NOT EXISTS round_txs (
+    id          BIGSERIAL PRIMARY KEY,
+    round_id    TEXT NOT NULL REFERENCES rounds(id),
+    txid        TEXT NOT NULL DEFAULT '',
+    tx          TEXT NOT NULL DEFAULT '',
+    type        TEXT NOT NULL DEFAULT '',
+    position    INTEGER NOT NULL DEFAULT 0,
+    children    TEXT NOT NULL DEFAULT '{}'
+);
+
+CREATE INDEX IF NOT EXISTS idx_round_txs_round_id ON round_txs(round_id);
+CREATE INDEX IF NOT EXISTS idx_round_txs_type ON round_txs(round_id, type);
+
+-- Intents
+CREATE TABLE IF NOT EXISTS intents (
+    id          TEXT PRIMARY KEY,
+    round_id    TEXT NOT NULL REFERENCES rounds(id),
+    proof       TEXT NOT NULL DEFAULT '',
+    message     TEXT NOT NULL DEFAULT '',
+    txid        TEXT NOT NULL DEFAULT '',
+    leaf_tx_asset_packet TEXT NOT NULL DEFAULT '',
+    confirmation_status TEXT NOT NULL DEFAULT 'pending'
+);
+
+CREATE INDEX IF NOT EXISTS idx_intents_round_id ON intents(round_id);
+
+-- Intent receivers
+CREATE TABLE IF NOT EXISTS intent_receivers (
+    id              BIGSERIAL PRIMARY KEY,
+    intent_id       TEXT NOT NULL REFERENCES intents(id),
+    amount          BIGINT NOT NULL DEFAULT 0,
+    onchain_address TEXT NOT NULL DEFAULT '',
+    pubkey          TEXT NOT NULL DEFAULT ''
+);
+
+CREATE INDEX IF NOT EXISTS idx_intent_receivers_intent_id ON intent_receivers(intent_id);
+
+-- VTXOs table
+CREATE TABLE IF NOT EXISTS vtxos (
+    txid                TEXT NOT NULL,
+    vout                INTEGER NOT NULL,
+    pubkey              TEXT NOT NULL DEFAULT '',
+    amount              BIGINT NOT NULL DEFAULT 0,
+    root_commitment_txid TEXT NOT NULL DEFAULT '',
+    settled_by          TEXT,
+    spent_by            TEXT,
+    ark_txid            TEXT,
+    spent               BOOLEAN NOT NULL DEFAULT FALSE,
+    unrolled            BOOLEAN NOT NULL DEFAULT FALSE,
+    swept               BOOLEAN NOT NULL DEFAULT FALSE,
+    preconfirmed        BOOLEAN NOT NULL DEFAULT FALSE,
+    expires_at          BIGINT NOT NULL DEFAULT 0,
+    created_at          BIGINT NOT NULL DEFAULT 0,
+    PRIMARY KEY (txid, vout)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vtxos_pubkey ON vtxos(pubkey);
+CREATE INDEX IF NOT EXISTS idx_vtxos_spent ON vtxos(spent);
+CREATE INDEX IF NOT EXISTS idx_vtxos_ark_txid ON vtxos(ark_txid);
+
+-- VTXO commitment txids (chain of commitment transactions)
+CREATE TABLE IF NOT EXISTS vtxo_commitment_txids (
+    vtxo_txid       TEXT NOT NULL,
+    vtxo_vout       INTEGER NOT NULL,
+    commitment_txid TEXT NOT NULL,
+    position        INTEGER NOT NULL DEFAULT 0,
+    PRIMARY KEY (vtxo_txid, vtxo_vout, commitment_txid),
+    FOREIGN KEY (vtxo_txid, vtxo_vout) REFERENCES vtxos(txid, vout)
+);
+
+-- VTXO intent association
+CREATE TABLE IF NOT EXISTS vtxo_intents (
+    vtxo_txid   TEXT NOT NULL,
+    vtxo_vout   INTEGER NOT NULL,
+    intent_id   TEXT NOT NULL REFERENCES intents(id),
+    PRIMARY KEY (vtxo_txid, vtxo_vout, intent_id),
+    FOREIGN KEY (vtxo_txid, vtxo_vout) REFERENCES vtxos(txid, vout)
+);
+
+-- Sweep transactions mapping
+CREATE TABLE IF NOT EXISTS round_sweep_txs (
+    round_id    TEXT NOT NULL REFERENCES rounds(id),
+    txid        TEXT NOT NULL,
+    tx          TEXT NOT NULL DEFAULT '',
+    PRIMARY KEY (round_id, txid)
+);

--- a/crates/arkd-db/migrations/pg/002_offchain_txs.sql
+++ b/crates/arkd-db/migrations/pg/002_offchain_txs.sql
@@ -1,0 +1,15 @@
+-- Offchain transactions table (PostgreSQL)
+
+CREATE TABLE IF NOT EXISTS offchain_txs (
+    id TEXT PRIMARY KEY,
+    stage TEXT NOT NULL DEFAULT 'Requested',
+    inputs_json TEXT NOT NULL,
+    outputs_json TEXT NOT NULL,
+    txid TEXT,
+    rejection_reason TEXT,
+    created_at BIGINT NOT NULL,
+    updated_at BIGINT NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_offchain_txs_stage ON offchain_txs(stage);
+CREATE INDEX IF NOT EXISTS idx_offchain_txs_created_at ON offchain_txs(created_at);

--- a/crates/arkd-db/src/lib.rs
+++ b/crates/arkd-db/src/lib.rs
@@ -18,12 +18,22 @@ use thiserror::Error;
 pub mod cache;
 pub mod config;
 pub mod migrations;
+#[cfg(feature = "sqlite")]
 pub mod pool;
+#[cfg(feature = "postgres")]
+pub mod pool_postgres;
 pub mod repos;
 
 pub use config::DatabaseConfig;
+#[cfg(feature = "sqlite")]
 pub use pool::Database;
+#[cfg(feature = "sqlite")]
 pub use repos::SqliteOffchainTxRepository;
+
+#[cfg(feature = "postgres")]
+pub use pool_postgres::{create_postgres_pool, run_postgres_migrations};
+#[cfg(feature = "postgres")]
+pub use repos::{PgOffchainTxRepository, PgRoundRepository, PgVtxoRepository};
 
 /// Database-specific errors
 #[derive(Error, Debug)]

--- a/crates/arkd-db/src/migrations.rs
+++ b/crates/arkd-db/src/migrations.rs
@@ -11,6 +11,7 @@ use tracing::info;
 /// Note: In practice, migrations are run automatically by `Database::connect()`
 /// when `run_migrations` is true in the config. This function is provided for
 /// manual/CLI use.
+#[cfg(feature = "sqlite")]
 pub async fn run_migrations(database_url: &str) -> DatabaseResult<()> {
     info!(url = %database_url, "Running database migrations");
     // Migrations are applied by Database::run_migrations() using the embedded SQL.
@@ -18,6 +19,13 @@ pub async fn run_migrations(database_url: &str) -> DatabaseResult<()> {
     let db = crate::Database::connect(crate::DatabaseConfig::sqlite(database_url)).await?;
     db.run_migrations().await?;
     Ok(())
+}
+
+/// Run all pending PostgreSQL migrations against the given pool
+#[cfg(feature = "postgres")]
+pub async fn run_pg_migrations(pool: &sqlx::PgPool) -> DatabaseResult<()> {
+    info!("Running PostgreSQL migrations via migrations module");
+    crate::pool_postgres::run_postgres_migrations(pool).await
 }
 
 /// Check migration status

--- a/crates/arkd-db/src/pool_postgres.rs
+++ b/crates/arkd-db/src/pool_postgres.rs
@@ -1,0 +1,88 @@
+//! PostgreSQL connection pool and migration runner
+//!
+//! # Usage
+//!
+//! ```rust,no_run
+//! # #[cfg(feature = "postgres")]
+//! # async fn example() -> Result<(), Box<dyn std::error::Error>> {
+//! use arkd_db::pool_postgres::{create_postgres_pool, run_postgres_migrations};
+//!
+//! let pool = create_postgres_pool("postgres://user:pass@localhost/arkd").await?;
+//! run_postgres_migrations(&pool).await?;
+//! # Ok(())
+//! # }
+//! ```
+//!
+//! # Integration Testing
+//!
+//! To run integration tests against a real PostgreSQL instance:
+//! ```bash
+//! DATABASE_URL=postgres://user:pass@localhost/arkd_test cargo test --features postgres
+//! ```
+
+use crate::{DatabaseError, DatabaseResult};
+use sqlx::postgres::PgPoolOptions;
+use sqlx::PgPool;
+use tracing::info;
+
+/// Create a PostgreSQL connection pool
+///
+/// Configures the pool with:
+/// - max_connections: 10
+/// - connection timeout: 30 seconds
+pub async fn create_postgres_pool(url: &str) -> DatabaseResult<PgPool> {
+    info!(url = %url, "Creating PostgreSQL connection pool");
+
+    let pool = PgPoolOptions::new()
+        .max_connections(10)
+        .connect(url)
+        .await
+        .map_err(|e| {
+            DatabaseError::ConnectionError(format!("PostgreSQL connection failed: {e}"))
+        })?;
+
+    info!("PostgreSQL connection pool created successfully");
+    Ok(pool)
+}
+
+/// Run PostgreSQL migrations
+///
+/// Executes embedded migration SQL files in order against the given pool.
+pub async fn run_postgres_migrations(pool: &PgPool) -> DatabaseResult<()> {
+    info!("Running PostgreSQL migrations");
+
+    let migration_001 = include_str!("../migrations/pg/001_initial.sql");
+    sqlx::query(migration_001)
+        .execute(pool)
+        .await
+        .map_err(|e| DatabaseError::MigrationError(format!("PG migration 001 failed: {e}")))?;
+
+    let migration_002 = include_str!("../migrations/pg/002_offchain_txs.sql");
+    sqlx::query(migration_002)
+        .execute(pool)
+        .await
+        .map_err(|e| DatabaseError::MigrationError(format!("PG migration 002 failed: {e}")))?;
+
+    info!("PostgreSQL migrations applied successfully");
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_postgres_feature_compiles() {
+        // Verifies that the postgres feature gate works and PgPoolOptions is available
+        let _opts = PgPoolOptions::new().max_connections(10);
+    }
+
+    #[test]
+    fn test_migration_sql_embedded() {
+        // Verify migration SQL files are properly embedded at compile time
+        let sql_001 = include_str!("../migrations/pg/001_initial.sql");
+        assert!(sql_001.contains("CREATE TABLE"));
+        let sql_002 = include_str!("../migrations/pg/002_offchain_txs.sql");
+        assert!(sql_002.contains("offchain_txs"));
+    }
+}

--- a/crates/arkd-db/src/repos/mod.rs
+++ b/crates/arkd-db/src/repos/mod.rs
@@ -1,12 +1,32 @@
 //! Repository implementations for arkd-core port traits
 //!
 //! Each repository implements the corresponding trait from `arkd_core::ports`
-//! using SQLite (via sqlx) as the backing store.
+//! using SQLite or PostgreSQL (via sqlx) as the backing store.
 
+#[cfg(feature = "sqlite")]
 pub mod offchain_tx_repo;
+#[cfg(feature = "sqlite")]
 pub mod round_repo;
+#[cfg(feature = "sqlite")]
 pub mod vtxo_repo;
 
+#[cfg(feature = "postgres")]
+pub mod offchain_tx_repo_pg;
+#[cfg(feature = "postgres")]
+pub mod round_repo_pg;
+#[cfg(feature = "postgres")]
+pub mod vtxo_repo_pg;
+
+#[cfg(feature = "sqlite")]
 pub use offchain_tx_repo::SqliteOffchainTxRepository;
+#[cfg(feature = "sqlite")]
 pub use round_repo::SqliteRoundRepository;
+#[cfg(feature = "sqlite")]
 pub use vtxo_repo::SqliteVtxoRepository;
+
+#[cfg(feature = "postgres")]
+pub use offchain_tx_repo_pg::PgOffchainTxRepository;
+#[cfg(feature = "postgres")]
+pub use round_repo_pg::PgRoundRepository;
+#[cfg(feature = "postgres")]
+pub use vtxo_repo_pg::PgVtxoRepository;

--- a/crates/arkd-db/src/repos/offchain_tx_repo_pg.rs
+++ b/crates/arkd-db/src/repos/offchain_tx_repo_pg.rs
@@ -1,0 +1,183 @@
+//! Offchain transaction repository — PostgreSQL implementation
+
+use arkd_core::domain::{OffchainTx, OffchainTxStage, VtxoInput, VtxoOutput};
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::OffchainTxRepository;
+use async_trait::async_trait;
+use sqlx::PgPool;
+use std::time::{SystemTime, UNIX_EPOCH};
+use tracing::debug;
+
+/// PostgreSQL-backed offchain transaction repository
+pub struct PgOffchainTxRepository {
+    pool: PgPool,
+}
+
+impl PgOffchainTxRepository {
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+
+    #[allow(clippy::type_complexity)]
+    fn row_to_offchain_tx(row: PgOffchainTxRow) -> ArkResult<OffchainTx> {
+        let (id, stage, inputs_json, outputs_json, txid, rejection_reason, created_at, updated_at) =
+            row;
+        let inputs: Vec<VtxoInput> = serde_json::from_str(&inputs_json)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        let outputs: Vec<VtxoOutput> = serde_json::from_str(&outputs_json)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let stage = match stage.as_str() {
+            "Requested" => OffchainTxStage::Requested,
+            "Accepted" => OffchainTxStage::Accepted {
+                accepted_at: updated_at as u64,
+            },
+            "Finalized" => OffchainTxStage::Finalized {
+                txid: txid.unwrap_or_default(),
+                finalized_at: updated_at as u64,
+            },
+            "Rejected" => OffchainTxStage::Rejected {
+                reason: rejection_reason.unwrap_or_default(),
+            },
+            other => {
+                return Err(ArkError::DatabaseError(format!(
+                    "Unknown offchain tx stage: {other}"
+                )));
+            }
+        };
+
+        Ok(OffchainTx {
+            id,
+            inputs,
+            outputs,
+            stage,
+            created_at: created_at as u64,
+            updated_at: updated_at as u64,
+        })
+    }
+}
+
+type PgOffchainTxRow = (
+    String,
+    String,
+    String,
+    String,
+    Option<String>,
+    Option<String>,
+    i64,
+    i64,
+);
+
+#[async_trait]
+impl OffchainTxRepository for PgOffchainTxRepository {
+    async fn create(&self, tx: &OffchainTx) -> ArkResult<()> {
+        debug!(id = %tx.id, "Creating offchain tx (PG)");
+
+        let inputs_json = serde_json::to_string(&tx.inputs)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        let outputs_json = serde_json::to_string(&tx.outputs)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        let stage_str = tx.stage.to_string();
+        let created_at = tx.created_at as i64;
+        let updated_at = tx.updated_at as i64;
+
+        sqlx::query(
+            "INSERT INTO offchain_txs (id, stage, inputs_json, outputs_json, created_at, updated_at) VALUES ($1, $2, $3, $4, $5, $6)",
+        )
+        .bind(&tx.id)
+        .bind(&stage_str)
+        .bind(&inputs_json)
+        .bind(&outputs_json)
+        .bind(created_at)
+        .bind(updated_at)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get(&self, id: &str) -> ArkResult<Option<OffchainTx>> {
+        debug!(id = %id, "Getting offchain tx (PG)");
+
+        let row = sqlx::query_as::<_, PgOffchainTxRow>(
+            "SELECT id, stage, inputs_json, outputs_json, txid, rejection_reason, created_at, updated_at FROM offchain_txs WHERE id = $1",
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        match row {
+            Some(row) => Ok(Some(Self::row_to_offchain_tx(row)?)),
+            None => Ok(None),
+        }
+    }
+
+    async fn get_pending(&self) -> ArkResult<Vec<OffchainTx>> {
+        debug!("Getting pending offchain txs (PG)");
+
+        let rows = sqlx::query_as::<_, PgOffchainTxRow>(
+            "SELECT id, stage, inputs_json, outputs_json, txid, rejection_reason, created_at, updated_at FROM offchain_txs WHERE stage IN ('Requested', 'Accepted') ORDER BY created_at ASC",
+        )
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        rows.into_iter().map(Self::row_to_offchain_tx).collect()
+    }
+
+    async fn update_stage(&self, id: &str, stage: &OffchainTxStage) -> ArkResult<()> {
+        debug!(id = %id, stage = %stage, "Updating offchain tx stage (PG)");
+
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        let stage_str = stage.to_string();
+        let (txid, rejection_reason): (Option<String>, Option<String>) = match stage {
+            OffchainTxStage::Finalized { txid, .. } => (Some(txid.clone()), None),
+            OffchainTxStage::Rejected { reason } => (None, Some(reason.clone())),
+            _ => (None, None),
+        };
+
+        let result = sqlx::query(
+            "UPDATE offchain_txs SET stage = $1, txid = COALESCE($2, txid), rejection_reason = COALESCE($3, rejection_reason), updated_at = $4 WHERE id = $5",
+        )
+        .bind(&stage_str)
+        .bind(&txid)
+        .bind(&rejection_reason)
+        .bind(now)
+        .bind(id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(ArkError::Internal(format!(
+                "Offchain tx {id} not found for stage update"
+            )));
+        }
+
+        Ok(())
+    }
+}
+
+impl PgOffchainTxRepository {
+    /// List offchain transactions that reference a specific VTXO (not part of the trait).
+    pub async fn list_by_vtxo(&self, vtxo_id: &str) -> ArkResult<Vec<OffchainTx>> {
+        debug!(vtxo_id = %vtxo_id, "Listing offchain txs by VTXO (PG)");
+
+        let pattern = format!("%\"{vtxo_id}\"%");
+        let rows = sqlx::query_as::<_, PgOffchainTxRow>(
+            "SELECT id, stage, inputs_json, outputs_json, txid, rejection_reason, created_at, updated_at FROM offchain_txs WHERE inputs_json LIKE $1 ORDER BY created_at ASC",
+        )
+        .bind(&pattern)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        rows.into_iter().map(Self::row_to_offchain_tx).collect()
+    }
+}

--- a/crates/arkd-db/src/repos/round_repo_pg.rs
+++ b/crates/arkd-db/src/repos/round_repo_pg.rs
@@ -1,0 +1,607 @@
+//! Round repository — PostgreSQL implementation of `arkd_core::ports::RoundRepository`
+
+use arkd_core::domain::{
+    ConfirmationStatus, ForfeitTx, Intent, Receiver, Round, RoundStage, RoundStats, Stage,
+    TxTreeNode, Vtxo, VtxoOutpoint,
+};
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::RoundRepository;
+use async_trait::async_trait;
+use sqlx::PgPool;
+use std::collections::HashMap;
+use tracing::debug;
+
+/// PostgreSQL-backed round repository
+pub struct PgRoundRepository {
+    pool: PgPool,
+}
+
+impl PgRoundRepository {
+    /// Create a new repository backed by the given PostgreSQL pool
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl RoundRepository for PgRoundRepository {
+    async fn add_or_update_round(&self, round: &Round) -> ArkResult<()> {
+        debug!(round_id = %round.id, "Upserting round (PG)");
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let stage_code = match round.stage.code {
+            RoundStage::Undefined => 0i32,
+            RoundStage::Registration => 1,
+            RoundStage::Finalization => 2,
+        };
+
+        // Upsert the round itself
+        sqlx::query(
+            r#"
+            INSERT INTO rounds (id, starting_timestamp, ending_timestamp, stage_code,
+                stage_ended, stage_failed, commitment_txid, commitment_tx,
+                connector_address, version, swept, vtxo_tree_expiration, fail_reason)
+            VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)
+            ON CONFLICT(id) DO UPDATE SET
+                starting_timestamp = EXCLUDED.starting_timestamp,
+                ending_timestamp = EXCLUDED.ending_timestamp,
+                stage_code = EXCLUDED.stage_code,
+                stage_ended = EXCLUDED.stage_ended,
+                stage_failed = EXCLUDED.stage_failed,
+                commitment_txid = EXCLUDED.commitment_txid,
+                commitment_tx = EXCLUDED.commitment_tx,
+                connector_address = EXCLUDED.connector_address,
+                version = EXCLUDED.version,
+                swept = EXCLUDED.swept,
+                vtxo_tree_expiration = EXCLUDED.vtxo_tree_expiration,
+                fail_reason = EXCLUDED.fail_reason
+            "#,
+        )
+        .bind(&round.id)
+        .bind(round.starting_timestamp)
+        .bind(round.ending_timestamp)
+        .bind(stage_code)
+        .bind(round.stage.ended)
+        .bind(round.stage.failed)
+        .bind(&round.commitment_txid)
+        .bind(&round.commitment_tx)
+        .bind(&round.connector_address)
+        .bind(round.version as i32)
+        .bind(round.swept)
+        .bind(round.vtxo_tree_expiration)
+        .bind(&round.fail_reason)
+        .execute(&mut *tx)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        // Delete existing child data for upsert (idempotent)
+        for table in &["round_txs", "round_sweep_txs"] {
+            sqlx::query(&format!("DELETE FROM {} WHERE round_id = $1", table))
+                .bind(&round.id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        // Delete intents and their receivers/vtxo_intents
+        let intent_ids: Vec<String> =
+            sqlx::query_as::<_, (String,)>("SELECT id FROM intents WHERE round_id = $1")
+                .bind(&round.id)
+                .fetch_all(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?
+                .into_iter()
+                .map(|r| r.0)
+                .collect();
+
+        for iid in &intent_ids {
+            sqlx::query("DELETE FROM intent_receivers WHERE intent_id = $1")
+                .bind(iid)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+            sqlx::query("DELETE FROM vtxo_intents WHERE intent_id = $1")
+                .bind(iid)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+        sqlx::query("DELETE FROM intents WHERE round_id = $1")
+            .bind(&round.id)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        // Insert forfeit txs
+        for (pos, ftx) in round.forfeit_txs.iter().enumerate() {
+            sqlx::query(
+                "INSERT INTO round_txs (round_id, txid, tx, type, position) VALUES ($1, $2, $3, $4, $5)",
+            )
+            .bind(&round.id)
+            .bind(&ftx.txid)
+            .bind(&ftx.tx)
+            .bind("forfeit")
+            .bind(pos as i32)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        // Insert VTXO tree nodes
+        for (pos, node) in round.vtxo_tree.iter().enumerate() {
+            let children_json =
+                serde_json::to_string(&node.children).unwrap_or_else(|_| "{}".to_string());
+            sqlx::query(
+                "INSERT INTO round_txs (round_id, txid, tx, type, position, children) VALUES ($1, $2, $3, $4, $5, $6)",
+            )
+            .bind(&round.id)
+            .bind(&node.txid)
+            .bind(&node.tx)
+            .bind("vtxo_tree")
+            .bind(pos as i32)
+            .bind(&children_json)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        // Insert connector tree nodes
+        for (pos, node) in round.connectors.iter().enumerate() {
+            let children_json =
+                serde_json::to_string(&node.children).unwrap_or_else(|_| "{}".to_string());
+            sqlx::query(
+                "INSERT INTO round_txs (round_id, txid, tx, type, position, children) VALUES ($1, $2, $3, $4, $5, $6)",
+            )
+            .bind(&round.id)
+            .bind(&node.txid)
+            .bind(&node.tx)
+            .bind("connector")
+            .bind(pos as i32)
+            .bind(&children_json)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        // Insert sweep transactions
+        for (stxid, stx) in &round.sweep_txs {
+            sqlx::query("INSERT INTO round_sweep_txs (round_id, txid, tx) VALUES ($1, $2, $3)")
+                .bind(&round.id)
+                .bind(stxid)
+                .bind(stx)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        // Insert intents
+        for intent in round.intents.values() {
+            let conf_status = match round.confirmation_status.get(&intent.id) {
+                Some(ConfirmationStatus::Confirmed { confirmed_at }) => {
+                    format!("confirmed:{confirmed_at}")
+                }
+                Some(ConfirmationStatus::TimedOut) => "timed_out".to_string(),
+                _ => "pending".to_string(),
+            };
+
+            sqlx::query(
+                r#"
+                INSERT INTO intents (id, round_id, proof, message, txid, leaf_tx_asset_packet, confirmation_status)
+                VALUES ($1, $2, $3, $4, $5, $6, $7)
+                "#,
+            )
+            .bind(&intent.id)
+            .bind(&round.id)
+            .bind(&intent.proof)
+            .bind(&intent.message)
+            .bind(&intent.txid)
+            .bind(&intent.leaf_tx_asset_packet)
+            .bind(&conf_status)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+            // Insert receivers
+            for recv in &intent.receivers {
+                sqlx::query(
+                    r#"
+                    INSERT INTO intent_receivers (intent_id, amount, onchain_address, pubkey)
+                    VALUES ($1, $2, $3, $4)
+                    "#,
+                )
+                .bind(&intent.id)
+                .bind(recv.amount as i64)
+                .bind(&recv.onchain_address)
+                .bind(&recv.pubkey)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+            }
+
+            // Insert VTXO-intent associations
+            for input in &intent.inputs {
+                sqlx::query(
+                    "INSERT INTO vtxo_intents (vtxo_txid, vtxo_vout, intent_id) VALUES ($1, $2, $3)",
+                )
+                .bind(&input.outpoint.txid)
+                .bind(input.outpoint.vout as i32)
+                .bind(&intent.id)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_round_with_id(&self, id: &str) -> ArkResult<Option<Round>> {
+        debug!(round_id = %id, "Fetching round (PG)");
+
+        let row = sqlx::query_as::<_, PgRoundRow>(
+            r#"
+            SELECT id, starting_timestamp, ending_timestamp, stage_code,
+                   stage_ended, stage_failed, commitment_txid, commitment_tx,
+                   connector_address, version, swept, vtxo_tree_expiration, fail_reason
+            FROM rounds WHERE id = $1
+            "#,
+        )
+        .bind(id)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let row = match row {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        // Load round_txs
+        let tx_rows = sqlx::query_as::<_, PgRoundTxRow>(
+            "SELECT txid, tx, type, position, children FROM round_txs WHERE round_id = $1 ORDER BY position",
+        )
+        .bind(id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let mut forfeit_txs = Vec::new();
+        let mut vtxo_tree = Vec::new();
+        let mut connectors = Vec::new();
+
+        for tr in tx_rows {
+            match tr.tx_type.as_str() {
+                "forfeit" => {
+                    forfeit_txs.push(ForfeitTx {
+                        txid: tr.txid,
+                        tx: tr.tx,
+                    });
+                }
+                "vtxo_tree" => {
+                    let children: HashMap<u32, String> =
+                        serde_json::from_str(&tr.children).unwrap_or_default();
+                    vtxo_tree.push(TxTreeNode {
+                        txid: tr.txid,
+                        tx: tr.tx,
+                        children,
+                    });
+                }
+                "connector" => {
+                    let children: HashMap<u32, String> =
+                        serde_json::from_str(&tr.children).unwrap_or_default();
+                    connectors.push(TxTreeNode {
+                        txid: tr.txid,
+                        tx: tr.tx,
+                        children,
+                    });
+                }
+                _ => {}
+            }
+        }
+
+        // Load sweep txs
+        let sweep_rows = sqlx::query_as::<_, PgSweepTxRow>(
+            "SELECT txid, tx FROM round_sweep_txs WHERE round_id = $1",
+        )
+        .bind(id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let sweep_txs: HashMap<String, String> =
+            sweep_rows.into_iter().map(|r| (r.txid, r.tx)).collect();
+
+        // Load intents
+        let intent_rows = sqlx::query_as::<_, PgIntentRow>(
+            "SELECT id, proof, message, txid, leaf_tx_asset_packet, confirmation_status FROM intents WHERE round_id = $1",
+        )
+        .bind(id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let mut intents = HashMap::new();
+        let mut confirmation_status_map = HashMap::new();
+        for irow in intent_rows {
+            let receivers = sqlx::query_as::<_, PgReceiverRow>(
+                "SELECT amount, onchain_address, pubkey FROM intent_receivers WHERE intent_id = $1",
+            )
+            .bind(&irow.id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+            let input_rows = sqlx::query_as::<_, PgVtxoIntentRow>(
+                "SELECT vtxo_txid, vtxo_vout FROM vtxo_intents WHERE intent_id = $1",
+            )
+            .bind(&irow.id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+            let inputs: Vec<Vtxo> = input_rows
+                .into_iter()
+                .map(|r| {
+                    Vtxo::new(
+                        VtxoOutpoint::new(r.vtxo_txid, r.vtxo_vout as u32),
+                        0,
+                        String::new(),
+                    )
+                })
+                .collect();
+
+            let conf_status = parse_confirmation_status(&irow.confirmation_status);
+
+            let intent = Intent {
+                id: irow.id.clone(),
+                inputs,
+                receivers: receivers
+                    .into_iter()
+                    .map(|r| Receiver {
+                        amount: r.amount as u64,
+                        onchain_address: r.onchain_address,
+                        pubkey: r.pubkey,
+                    })
+                    .collect(),
+                proof: irow.proof,
+                message: irow.message,
+                txid: irow.txid,
+                leaf_tx_asset_packet: irow.leaf_tx_asset_packet,
+            };
+            confirmation_status_map.insert(intent.id.clone(), conf_status);
+            intents.insert(intent.id.clone(), intent);
+        }
+
+        let stage_code = match row.stage_code {
+            1 => RoundStage::Registration,
+            2 => RoundStage::Finalization,
+            _ => RoundStage::Undefined,
+        };
+
+        let round = Round {
+            id: row.id,
+            starting_timestamp: row.starting_timestamp,
+            ending_timestamp: row.ending_timestamp,
+            stage: Stage {
+                code: stage_code,
+                ended: row.stage_ended,
+                failed: row.stage_failed,
+            },
+            intents,
+            commitment_txid: row.commitment_txid,
+            commitment_tx: row.commitment_tx,
+            forfeit_txs,
+            vtxo_tree,
+            connectors,
+            connector_address: row.connector_address,
+            version: row.version as u32,
+            swept: row.swept,
+            vtxo_tree_expiration: row.vtxo_tree_expiration,
+            sweep_txs,
+            fail_reason: row.fail_reason,
+            confirmation_status: confirmation_status_map,
+        };
+
+        Ok(Some(round))
+    }
+
+    async fn get_round_stats(&self, commitment_txid: &str) -> ArkResult<Option<RoundStats>> {
+        debug!(commitment_txid = %commitment_txid, "Getting round stats (PG)");
+
+        let row = sqlx::query_as::<_, PgRoundRow>(
+            r#"
+            SELECT id, starting_timestamp, ending_timestamp, stage_code,
+                   stage_ended, stage_failed, commitment_txid, commitment_tx,
+                   connector_address, version, swept, vtxo_tree_expiration, fail_reason
+            FROM rounds WHERE commitment_txid = $1
+            "#,
+        )
+        .bind(commitment_txid)
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let row = match row {
+            Some(r) => r,
+            None => return Ok(None),
+        };
+
+        let intent_rows = sqlx::query_as::<_, PgIntentRow>(
+            "SELECT id, proof, message, txid, leaf_tx_asset_packet, confirmation_status FROM intents WHERE round_id = $1",
+        )
+        .bind(&row.id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let mut total_input_vtxos: i32 = 0;
+        let mut total_output_vtxos: i32 = 0;
+        let mut total_batch_amount: u64 = 0;
+
+        for irow in &intent_rows {
+            let input_count = sqlx::query_as::<_, (i64,)>(
+                "SELECT COUNT(*) FROM vtxo_intents WHERE intent_id = $1",
+            )
+            .bind(&irow.id)
+            .fetch_one(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+            total_input_vtxos += input_count.0 as i32;
+
+            let receivers = sqlx::query_as::<_, PgReceiverRow>(
+                "SELECT amount, onchain_address, pubkey FROM intent_receivers WHERE intent_id = $1",
+            )
+            .bind(&irow.id)
+            .fetch_all(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+            for r in &receivers {
+                total_batch_amount += r.amount as u64;
+                if r.onchain_address.is_empty() {
+                    total_output_vtxos += 1;
+                }
+            }
+        }
+
+        let forfeit_count = sqlx::query_as::<_, (i64,)>(
+            "SELECT COUNT(*) FROM round_txs WHERE round_id = $1 AND type = 'forfeit'",
+        )
+        .bind(&row.id)
+        .fetch_one(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        let total_forfeit_amount = forfeit_count.0 as u64;
+
+        Ok(Some(RoundStats {
+            swept: row.swept,
+            total_forfeit_amount,
+            total_input_vtxos,
+            total_batch_amount,
+            total_output_vtxos,
+            expires_at: row.vtxo_tree_expiration,
+            started: row.starting_timestamp,
+            ended: row.ending_timestamp,
+        }))
+    }
+
+    async fn confirm_intent(&self, round_id: &str, intent_id: &str) -> ArkResult<()> {
+        debug!(round_id = %round_id, intent_id = %intent_id, "Confirming intent (PG)");
+
+        let now = chrono::Utc::now().timestamp() as u64;
+        let status = format!("confirmed:{now}");
+
+        let result = sqlx::query(
+            "UPDATE intents SET confirmation_status = $1 WHERE round_id = $2 AND id = $3 AND confirmation_status = 'pending'",
+        )
+        .bind(&status)
+        .bind(round_id)
+        .bind(intent_id)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        if result.rows_affected() == 0 {
+            return Err(ArkError::Internal(format!(
+                "Intent {intent_id} not found or not pending in round {round_id}"
+            )));
+        }
+
+        Ok(())
+    }
+
+    async fn get_pending_confirmations(&self, round_id: &str) -> ArkResult<Vec<String>> {
+        debug!(round_id = %round_id, "Getting pending confirmations (PG)");
+
+        let rows = sqlx::query_as::<_, (String,)>(
+            "SELECT id FROM intents WHERE round_id = $1 AND confirmation_status = 'pending'",
+        )
+        .bind(round_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(rows.into_iter().map(|r| r.0).collect())
+    }
+}
+
+// ─── Row types (PG) ─────────────────────────────────────────────────────────
+
+#[derive(Debug, sqlx::FromRow)]
+struct PgRoundRow {
+    id: String,
+    starting_timestamp: i64,
+    ending_timestamp: i64,
+    stage_code: i32,
+    stage_ended: bool,
+    stage_failed: bool,
+    commitment_txid: String,
+    commitment_tx: String,
+    connector_address: String,
+    version: i32,
+    swept: bool,
+    vtxo_tree_expiration: i64,
+    fail_reason: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PgRoundTxRow {
+    txid: String,
+    tx: String,
+    #[sqlx(rename = "type")]
+    tx_type: String,
+    #[allow(dead_code)]
+    position: i32,
+    children: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PgSweepTxRow {
+    txid: String,
+    tx: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PgIntentRow {
+    id: String,
+    proof: String,
+    message: String,
+    txid: String,
+    leaf_tx_asset_packet: String,
+    confirmation_status: String,
+}
+
+/// Parse the confirmation_status string from the DB into a ConfirmationStatus enum
+fn parse_confirmation_status(s: &str) -> ConfirmationStatus {
+    if s.starts_with("confirmed:") {
+        let ts_str = s.strip_prefix("confirmed:").unwrap_or("0");
+        let ts = ts_str.parse::<u64>().unwrap_or(0);
+        ConfirmationStatus::Confirmed { confirmed_at: ts }
+    } else if s == "timed_out" {
+        ConfirmationStatus::TimedOut
+    } else {
+        ConfirmationStatus::Pending
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PgReceiverRow {
+    amount: i64,
+    onchain_address: String,
+    pubkey: String,
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PgVtxoIntentRow {
+    vtxo_txid: String,
+    vtxo_vout: i32,
+}

--- a/crates/arkd-db/src/repos/vtxo_repo_pg.rs
+++ b/crates/arkd-db/src/repos/vtxo_repo_pg.rs
@@ -1,0 +1,324 @@
+//! VTXO repository — PostgreSQL implementation of `arkd_core::ports::VtxoRepository`
+
+use arkd_core::domain::{Vtxo, VtxoOutpoint};
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::VtxoRepository;
+use async_trait::async_trait;
+use sqlx::PgPool;
+use tracing::debug;
+
+/// PostgreSQL-backed VTXO repository
+pub struct PgVtxoRepository {
+    pool: PgPool,
+}
+
+impl PgVtxoRepository {
+    /// Create a new repository backed by the given PostgreSQL pool
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl VtxoRepository for PgVtxoRepository {
+    async fn add_vtxos(&self, vtxos: &[Vtxo]) -> ArkResult<()> {
+        debug!(count = vtxos.len(), "Adding VTXOs (PG)");
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        for vtxo in vtxos {
+            let settled_by = if vtxo.settled_by.is_empty() {
+                None
+            } else {
+                Some(vtxo.settled_by.as_str())
+            };
+            let spent_by = if vtxo.spent_by.is_empty() {
+                None
+            } else {
+                Some(vtxo.spent_by.as_str())
+            };
+            let ark_txid = if vtxo.ark_txid.is_empty() {
+                None
+            } else {
+                Some(vtxo.ark_txid.as_str())
+            };
+
+            sqlx::query(
+                r#"
+                INSERT INTO vtxos (txid, vout, pubkey, amount, root_commitment_txid,
+                    settled_by, spent_by, ark_txid, spent, unrolled, swept,
+                    preconfirmed, expires_at, created_at)
+                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14)
+                ON CONFLICT(txid, vout) DO UPDATE SET
+                    pubkey = EXCLUDED.pubkey,
+                    amount = EXCLUDED.amount,
+                    root_commitment_txid = EXCLUDED.root_commitment_txid,
+                    settled_by = EXCLUDED.settled_by,
+                    spent_by = EXCLUDED.spent_by,
+                    ark_txid = EXCLUDED.ark_txid,
+                    spent = EXCLUDED.spent,
+                    unrolled = EXCLUDED.unrolled,
+                    swept = EXCLUDED.swept,
+                    preconfirmed = EXCLUDED.preconfirmed,
+                    expires_at = EXCLUDED.expires_at
+                "#,
+            )
+            .bind(&vtxo.outpoint.txid)
+            .bind(vtxo.outpoint.vout as i32)
+            .bind(&vtxo.pubkey)
+            .bind(vtxo.amount as i64)
+            .bind(&vtxo.root_commitment_txid)
+            .bind(settled_by)
+            .bind(spent_by)
+            .bind(ark_txid)
+            .bind(vtxo.spent)
+            .bind(vtxo.unrolled)
+            .bind(vtxo.swept)
+            .bind(vtxo.preconfirmed)
+            .bind(vtxo.expires_at)
+            .bind(vtxo.created_at)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+            // Insert commitment txids
+            sqlx::query(
+                "DELETE FROM vtxo_commitment_txids WHERE vtxo_txid = $1 AND vtxo_vout = $2",
+            )
+            .bind(&vtxo.outpoint.txid)
+            .bind(vtxo.outpoint.vout as i32)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+            for (pos, ctxid) in vtxo.commitment_txids.iter().enumerate() {
+                sqlx::query(
+                    r#"
+                    INSERT INTO vtxo_commitment_txids (vtxo_txid, vtxo_vout, commitment_txid, position)
+                    VALUES ($1, $2, $3, $4)
+                    "#,
+                )
+                .bind(&vtxo.outpoint.txid)
+                .bind(vtxo.outpoint.vout as i32)
+                .bind(ctxid)
+                .bind(pos as i32)
+                .execute(&mut *tx)
+                .await
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn get_vtxos(&self, outpoints: &[VtxoOutpoint]) -> ArkResult<Vec<Vtxo>> {
+        debug!(count = outpoints.len(), "Getting VTXOs by outpoints (PG)");
+
+        let mut result = Vec::with_capacity(outpoints.len());
+
+        for op in outpoints {
+            let row = sqlx::query_as::<_, PgVtxoRow>(
+                r#"
+                SELECT txid, vout, pubkey, amount, root_commitment_txid,
+                       settled_by, spent_by, ark_txid, spent, unrolled, swept,
+                       preconfirmed, expires_at, created_at
+                FROM vtxos
+                WHERE txid = $1 AND vout = $2
+                "#,
+            )
+            .bind(&op.txid)
+            .bind(op.vout as i32)
+            .fetch_optional(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+            if let Some(row) = row {
+                let commitment_txids = self.get_commitment_txids(&op.txid, op.vout).await?;
+                result.push(row.into_vtxo(commitment_txids));
+            }
+        }
+
+        Ok(result)
+    }
+
+    async fn get_all_vtxos_for_pubkey(&self, pubkey: &str) -> ArkResult<(Vec<Vtxo>, Vec<Vtxo>)> {
+        debug!(pubkey = %pubkey, "Getting all VTXOs for pubkey (PG)");
+
+        let rows = sqlx::query_as::<_, PgVtxoRow>(
+            r#"
+            SELECT txid, vout, pubkey, amount, root_commitment_txid,
+                   settled_by, spent_by, ark_txid, spent, unrolled, swept,
+                   preconfirmed, expires_at, created_at
+            FROM vtxos
+            WHERE pubkey = $1 AND unrolled = FALSE
+            "#,
+        )
+        .bind(pubkey)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let mut spendable = Vec::new();
+        let mut spent = Vec::new();
+
+        for row in rows {
+            let commitment_txids = self
+                .get_commitment_txids(&row.txid, row.vout as u32)
+                .await?;
+            let vtxo = row.into_vtxo(commitment_txids);
+            if vtxo.spent || vtxo.swept {
+                spent.push(vtxo);
+            } else {
+                spendable.push(vtxo);
+            }
+        }
+
+        Ok((spendable, spent))
+    }
+
+    async fn spend_vtxos(&self, spent: &[(VtxoOutpoint, String)], ark_txid: &str) -> ArkResult<()> {
+        debug!(count = spent.len(), ark_txid = %ark_txid, "Spending VTXOs (PG)");
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        for (outpoint, spent_by) in spent {
+            let rows_affected = sqlx::query(
+                r#"
+                UPDATE vtxos
+                SET spent = TRUE, spent_by = $1, ark_txid = $2
+                WHERE txid = $3 AND vout = $4
+                "#,
+            )
+            .bind(spent_by)
+            .bind(ark_txid)
+            .bind(&outpoint.txid)
+            .bind(outpoint.vout as i32)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?
+            .rows_affected();
+
+            if rows_affected == 0 {
+                return Err(ArkError::VtxoNotFound(outpoint.to_string()));
+            }
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn find_expired_vtxos(&self, before_timestamp: i64) -> ArkResult<Vec<Vtxo>> {
+        debug!(before_timestamp, "Finding expired VTXOs for sweep (PG)");
+
+        let rows = sqlx::query_as::<_, PgVtxoRow>(
+            r#"
+            SELECT txid, vout, pubkey, amount, root_commitment_txid,
+                   settled_by, spent_by, ark_txid, spent, unrolled, swept,
+                   preconfirmed, expires_at, created_at
+            FROM vtxos
+            WHERE expires_at > 0
+              AND expires_at < $1
+              AND spent = FALSE
+              AND swept = FALSE
+              AND unrolled = FALSE
+            "#,
+        )
+        .bind(before_timestamp)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let mut vtxos = Vec::with_capacity(rows.len());
+        for row in rows {
+            let commitment_txids = self
+                .get_commitment_txids(&row.txid, row.vout as u32)
+                .await?;
+            vtxos.push(row.into_vtxo(commitment_txids));
+        }
+
+        Ok(vtxos)
+    }
+}
+
+impl PgVtxoRepository {
+    /// Fetch the commitment txid chain for a VTXO
+    async fn get_commitment_txids(&self, txid: &str, vout: u32) -> ArkResult<Vec<String>> {
+        let rows = sqlx::query_as::<_, PgCommitmentTxidRow>(
+            r#"
+            SELECT commitment_txid, position
+            FROM vtxo_commitment_txids
+            WHERE vtxo_txid = $1 AND vtxo_vout = $2
+            ORDER BY position ASC
+            "#,
+        )
+        .bind(txid)
+        .bind(vout as i32)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(rows.into_iter().map(|r| r.commitment_txid).collect())
+    }
+}
+
+/// Row type for reading VTXOs from the database
+#[derive(Debug, sqlx::FromRow)]
+struct PgVtxoRow {
+    txid: String,
+    vout: i32,
+    pubkey: String,
+    amount: i64,
+    root_commitment_txid: String,
+    settled_by: Option<String>,
+    spent_by: Option<String>,
+    ark_txid: Option<String>,
+    spent: bool,
+    unrolled: bool,
+    swept: bool,
+    preconfirmed: bool,
+    expires_at: i64,
+    created_at: i64,
+}
+
+impl PgVtxoRow {
+    fn into_vtxo(self, commitment_txids: Vec<String>) -> Vtxo {
+        Vtxo {
+            outpoint: VtxoOutpoint::new(self.txid, self.vout as u32),
+            amount: self.amount as u64,
+            pubkey: self.pubkey,
+            commitment_txids,
+            root_commitment_txid: self.root_commitment_txid,
+            settled_by: self.settled_by.unwrap_or_default(),
+            spent_by: self.spent_by.unwrap_or_default(),
+            ark_txid: self.ark_txid.unwrap_or_default(),
+            spent: self.spent,
+            unrolled: self.unrolled,
+            swept: self.swept,
+            preconfirmed: self.preconfirmed,
+            expires_at: self.expires_at,
+            created_at: self.created_at,
+        }
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct PgCommitmentTxidRow {
+    commitment_txid: String,
+    #[allow(dead_code)]
+    position: i32,
+}


### PR DESCRIPTION
Implements Issue #47.

- `postgres` feature flag on `arkd-db`
- `PgPool` + connection pooling (max 10 connections)
- PostgreSQL migrations in `migrations/pg/`
- `round_repo_pg.rs`, `offchain_tx_repo_pg.rs`, `vtxo_repo_pg.rs`
- `database_url` config field (default: `sqlite://arkd.db`)

Closes #47