### PR TITLE
🔴 Redis live-store for ephemeral round state (#48)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,7 +184,7 @@ dependencies = [
  "arkd-core",
  "async-trait",
  "chrono",
- "redis",
+ "redis 0.27.6",
  "serde",
  "serde_json",
  "sqlx",
@@ -192,6 +192,16 @@ dependencies = [
  "tokio",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "arkd-live-store"
+version = "0.1.0"
+dependencies = [
+ "arkd-core",
+ "async-trait",
+ "redis 0.25.4",
+ "tokio",
 ]
 
 [[package]]
@@ -214,7 +224,7 @@ dependencies = [
  "hex",
  "proptest",
  "prost",
- "redis",
+ "redis 0.27.6",
  "secp256k1 0.29.1",
  "serde",
  "serde_json",
@@ -2724,6 +2734,30 @@ dependencies = [
 
 [[package]]
 name = "redis"
+version = "0.25.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0d7a6955c7511f60f3ba9e86c6d02b3c3f144f8c24b288d1f4e18074ab8bbec"
+dependencies = [
+ "arc-swap",
+ "async-trait",
+ "bytes",
+ "combine",
+ "futures",
+ "futures-util",
+ "itoa",
+ "percent-encoding",
+ "pin-project-lite",
+ "ryu",
+ "sha1_smol",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-retry",
+ "tokio-util",
+ "url",
+]
+
+[[package]]
+name = "redis"
 version = "0.27.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09d8f99a4090c89cc489a94833c901ead69bfbf3877b4867d5482e321ee875bc"
@@ -3804,6 +3838,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-retry"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f57eb36ecbe0fc510036adff84824dd3c24bb781e21bfa67b69d556aa85214f"
+dependencies = [
+ "pin-project",
+ "rand 0.8.5",
  "tokio",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ members = [
     "crates/arkd-api",
     "crates/arkd-db",
     "crates/arkd-bitcoin",
+    "crates/arkd-live-store",
 ]
 
 [dependencies]

--- a/config.example.toml
+++ b/config.example.toml
@@ -103,6 +103,10 @@ run_migrations = true
 # Redis cache URL (optional, recommended for production)
 # redis_url = "redis://127.0.0.1:6379"
 
+# Redis URL for ephemeral live-store (round state).
+# If unset, an in-memory store is used (data lost on restart).
+# live_store_redis_url = "redis://127.0.0.1:6379"
+
 # =============================================================================
 # Ark Protocol Configuration
 # =============================================================================

--- a/crates/arkd-core/src/ports.rs
+++ b/crates/arkd-core/src/ports.rs
@@ -222,6 +222,52 @@ pub trait EventPublisher: Send + Sync {
     async fn subscribe(&self) -> ArkResult<tokio::sync::broadcast::Receiver<ArkEvent>>;
 }
 
+/// Ephemeral storage for active round state (survives process restart via Redis,
+/// but does NOT need to be durable — round will fail/retry on crash).
+#[async_trait]
+pub trait LiveStore: Send + Sync {
+    /// Store an intent for a round. Expires after `ttl_secs`.
+    async fn set_intent(
+        &self,
+        round_id: &str,
+        intent_id: &str,
+        data: &[u8],
+        ttl_secs: u64,
+    ) -> ArkResult<()>;
+    /// Get an intent by round and intent ID.
+    async fn get_intent(&self, round_id: &str, intent_id: &str) -> ArkResult<Option<Vec<u8>>>;
+    /// List all intent IDs for a round.
+    async fn list_intents(&self, round_id: &str) -> ArkResult<Vec<String>>;
+    /// Delete an intent.
+    async fn delete_intent(&self, round_id: &str, intent_id: &str) -> ArkResult<()>;
+
+    /// Store a nonce for a signing session.
+    async fn set_nonce(
+        &self,
+        session_id: &str,
+        pubkey: &str,
+        nonce: &[u8],
+        ttl_secs: u64,
+    ) -> ArkResult<()>;
+    /// Get a nonce by session and pubkey.
+    async fn get_nonce(&self, session_id: &str, pubkey: &str) -> ArkResult<Option<Vec<u8>>>;
+    /// List all pubkeys that have submitted nonces for a session.
+    async fn list_nonces(&self, session_id: &str) -> ArkResult<Vec<String>>;
+
+    /// Store a partial signature.
+    async fn set_partial_sig(
+        &self,
+        session_id: &str,
+        pubkey: &str,
+        sig: &[u8],
+        ttl_secs: u64,
+    ) -> ArkResult<()>;
+    /// Get a partial signature by session and pubkey.
+    async fn get_partial_sig(&self, session_id: &str, pubkey: &str) -> ArkResult<Option<Vec<u8>>>;
+    /// List all pubkeys that have submitted partial sigs for a session.
+    async fn list_partial_sigs(&self, session_id: &str) -> ArkResult<Vec<String>>;
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -235,5 +281,6 @@ mod tests {
         _assert_object_safe::<dyn RoundRepository>();
         _assert_object_safe::<dyn CacheService>();
         _assert_object_safe::<dyn OffchainTxRepository>();
+        _assert_object_safe::<dyn LiveStore>();
     }
 }

--- a/crates/arkd-live-store/Cargo.toml
+++ b/crates/arkd-live-store/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "arkd-live-store"
+version = "0.1.0"
+edition = "2021"
+description = "Ephemeral live-store implementations (in-memory + Redis) for arkd round state"
+license = "MIT"
+
+[features]
+default = ["memory"]
+memory = []
+redis = ["dep:redis"]
+
+[dependencies]
+arkd-core = { path = "../arkd-core" }
+async-trait = "0.1"
+tokio = { version = "1", features = ["sync"] }
+redis = { version = "0.25", features = ["tokio-comp", "connection-manager"], optional = true }
+
+[dev-dependencies]
+tokio = { version = "1", features = ["macros", "rt-multi-thread"] }

--- a/crates/arkd-live-store/src/lib.rs
+++ b/crates/arkd-live-store/src/lib.rs
@@ -1,0 +1,15 @@
+//! Ephemeral live-store implementations for arkd round state.
+//!
+//! Provides [`InMemoryLiveStore`] for dev/test and [`RedisLiveStore`] for production.
+
+#[cfg(feature = "memory")]
+pub mod memory;
+
+#[cfg(feature = "redis")]
+pub mod redis;
+
+#[cfg(feature = "memory")]
+pub use memory::InMemoryLiveStore;
+
+#[cfg(feature = "redis")]
+pub use self::redis::RedisLiveStore;

--- a/crates/arkd-live-store/src/memory.rs
+++ b/crates/arkd-live-store/src/memory.rs
@@ -1,0 +1,215 @@
+//! In-memory implementation of [`LiveStore`] for dev/test.
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use arkd_core::error::ArkResult;
+use arkd_core::ports::LiveStore;
+use async_trait::async_trait;
+use tokio::sync::RwLock;
+
+/// In-memory ephemeral live-store.
+///
+/// TTL is ignored — entries persist until explicitly deleted or the process exits.
+/// Suitable for development and testing only.
+#[derive(Debug, Clone, Default)]
+pub struct InMemoryLiveStore {
+    data: Arc<RwLock<HashMap<String, Vec<u8>>>>,
+}
+
+impl InMemoryLiveStore {
+    /// Create a new empty in-memory live-store.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn intent_key(round_id: &str, intent_id: &str) -> String {
+        format!("intents:{round_id}:{intent_id}")
+    }
+
+    fn nonce_key(session_id: &str, pubkey: &str) -> String {
+        format!("nonces:{session_id}:{pubkey}")
+    }
+
+    fn partial_sig_key(session_id: &str, pubkey: &str) -> String {
+        format!("partial_sigs:{session_id}:{pubkey}")
+    }
+}
+
+#[async_trait]
+impl LiveStore for InMemoryLiveStore {
+    async fn set_intent(
+        &self,
+        round_id: &str,
+        intent_id: &str,
+        data: &[u8],
+        _ttl_secs: u64, // TTL ignored in memory impl
+    ) -> ArkResult<()> {
+        let key = Self::intent_key(round_id, intent_id);
+        self.data.write().await.insert(key, data.to_vec());
+        Ok(())
+    }
+
+    async fn get_intent(&self, round_id: &str, intent_id: &str) -> ArkResult<Option<Vec<u8>>> {
+        let key = Self::intent_key(round_id, intent_id);
+        Ok(self.data.read().await.get(&key).cloned())
+    }
+
+    async fn list_intents(&self, round_id: &str) -> ArkResult<Vec<String>> {
+        let prefix = format!("intents:{round_id}:");
+        let guard = self.data.read().await;
+        let ids: Vec<String> = guard
+            .keys()
+            .filter_map(|k| k.strip_prefix(&prefix).map(String::from))
+            .collect();
+        Ok(ids)
+    }
+
+    async fn delete_intent(&self, round_id: &str, intent_id: &str) -> ArkResult<()> {
+        let key = Self::intent_key(round_id, intent_id);
+        self.data.write().await.remove(&key);
+        Ok(())
+    }
+
+    async fn set_nonce(
+        &self,
+        session_id: &str,
+        pubkey: &str,
+        nonce: &[u8],
+        _ttl_secs: u64,
+    ) -> ArkResult<()> {
+        let key = Self::nonce_key(session_id, pubkey);
+        self.data.write().await.insert(key, nonce.to_vec());
+        Ok(())
+    }
+
+    async fn get_nonce(&self, session_id: &str, pubkey: &str) -> ArkResult<Option<Vec<u8>>> {
+        let key = Self::nonce_key(session_id, pubkey);
+        Ok(self.data.read().await.get(&key).cloned())
+    }
+
+    async fn list_nonces(&self, session_id: &str) -> ArkResult<Vec<String>> {
+        let prefix = format!("nonces:{session_id}:");
+        let guard = self.data.read().await;
+        let ids: Vec<String> = guard
+            .keys()
+            .filter_map(|k| k.strip_prefix(&prefix).map(String::from))
+            .collect();
+        Ok(ids)
+    }
+
+    async fn set_partial_sig(
+        &self,
+        session_id: &str,
+        pubkey: &str,
+        sig: &[u8],
+        _ttl_secs: u64,
+    ) -> ArkResult<()> {
+        let key = Self::partial_sig_key(session_id, pubkey);
+        self.data.write().await.insert(key, sig.to_vec());
+        Ok(())
+    }
+
+    async fn get_partial_sig(&self, session_id: &str, pubkey: &str) -> ArkResult<Option<Vec<u8>>> {
+        let key = Self::partial_sig_key(session_id, pubkey);
+        Ok(self.data.read().await.get(&key).cloned())
+    }
+
+    async fn list_partial_sigs(&self, session_id: &str) -> ArkResult<Vec<String>> {
+        let prefix = format!("partial_sigs:{session_id}:");
+        let guard = self.data.read().await;
+        let ids: Vec<String> = guard
+            .keys()
+            .filter_map(|k| k.strip_prefix(&prefix).map(String::from))
+            .collect();
+        Ok(ids)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn test_memory_set_get_intent() {
+        let store = InMemoryLiveStore::new();
+        let data = b"test-intent-data";
+        store
+            .set_intent("round-1", "intent-a", data, 300)
+            .await
+            .unwrap();
+        let got = store.get_intent("round-1", "intent-a").await.unwrap();
+        assert_eq!(got, Some(data.to_vec()));
+    }
+
+    #[tokio::test]
+    async fn test_memory_list_intents() {
+        let store = InMemoryLiveStore::new();
+        store
+            .set_intent("round-1", "intent-a", b"a", 300)
+            .await
+            .unwrap();
+        store
+            .set_intent("round-1", "intent-b", b"b", 300)
+            .await
+            .unwrap();
+        // Different round — should not appear
+        store
+            .set_intent("round-2", "intent-c", b"c", 300)
+            .await
+            .unwrap();
+        let mut ids = store.list_intents("round-1").await.unwrap();
+        ids.sort();
+        assert_eq!(ids, vec!["intent-a", "intent-b"]);
+    }
+
+    #[tokio::test]
+    async fn test_memory_delete_intent() {
+        let store = InMemoryLiveStore::new();
+        store
+            .set_intent("round-1", "intent-a", b"data", 300)
+            .await
+            .unwrap();
+        store.delete_intent("round-1", "intent-a").await.unwrap();
+        let got = store.get_intent("round-1", "intent-a").await.unwrap();
+        assert_eq!(got, None);
+    }
+
+    #[tokio::test]
+    async fn test_memory_nonce_roundtrip() {
+        let store = InMemoryLiveStore::new();
+        let nonce = b"random-nonce-bytes";
+        store
+            .set_nonce("session-1", "pk-abc", nonce, 120)
+            .await
+            .unwrap();
+        let got = store.get_nonce("session-1", "pk-abc").await.unwrap();
+        assert_eq!(got, Some(nonce.to_vec()));
+
+        let keys = store.list_nonces("session-1").await.unwrap();
+        assert_eq!(keys, vec!["pk-abc"]);
+    }
+
+    #[tokio::test]
+    async fn test_memory_partial_sig_roundtrip() {
+        let store = InMemoryLiveStore::new();
+        let sig = b"partial-sig-bytes";
+        store
+            .set_partial_sig("session-1", "pk-xyz", sig, 120)
+            .await
+            .unwrap();
+        let got = store.get_partial_sig("session-1", "pk-xyz").await.unwrap();
+        assert_eq!(got, Some(sig.to_vec()));
+
+        let keys = store.list_partial_sigs("session-1").await.unwrap();
+        assert_eq!(keys, vec!["pk-xyz"]);
+    }
+
+    #[tokio::test]
+    async fn test_memory_get_nonexistent_returns_none() {
+        let store = InMemoryLiveStore::new();
+        assert_eq!(store.get_intent("x", "y").await.unwrap(), None);
+        assert_eq!(store.get_nonce("x", "y").await.unwrap(), None);
+        assert_eq!(store.get_partial_sig("x", "y").await.unwrap(), None);
+    }
+}

--- a/crates/arkd-live-store/src/redis.rs
+++ b/crates/arkd-live-store/src/redis.rs
@@ -1,0 +1,164 @@
+//! Redis-backed implementation of [`LiveStore`] for production use.
+
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::LiveStore;
+use async_trait::async_trait;
+use redis::AsyncCommands;
+
+/// Redis-backed ephemeral live-store.
+///
+/// Uses `redis::aio::ConnectionManager` for automatic reconnection.
+/// Keys are set with TTL so they auto-expire after a round completes or times out.
+#[derive(Clone)]
+pub struct RedisLiveStore {
+    conn: redis::aio::ConnectionManager,
+}
+
+impl RedisLiveStore {
+    /// Connect to Redis at the given URL (e.g. `redis://127.0.0.1:6379`).
+    pub async fn new(url: &str) -> ArkResult<Self> {
+        let client =
+            redis::Client::open(url).map_err(|e| ArkError::Internal(format!("Redis: {e}")))?;
+        let conn = redis::aio::ConnectionManager::new(client)
+            .await
+            .map_err(|e| ArkError::Internal(format!("Redis connect: {e}")))?;
+        Ok(Self { conn })
+    }
+
+    fn intent_key(round_id: &str, intent_id: &str) -> String {
+        format!("intents:{round_id}:{intent_id}")
+    }
+
+    fn nonce_key(session_id: &str, pubkey: &str) -> String {
+        format!("nonces:{session_id}:{pubkey}")
+    }
+
+    fn partial_sig_key(session_id: &str, pubkey: &str) -> String {
+        format!("partial_sigs:{session_id}:{pubkey}")
+    }
+
+    /// Helper: SET key value EX ttl
+    async fn set_ex(&self, key: &str, value: &[u8], ttl_secs: u64) -> ArkResult<()> {
+        let mut conn = self.conn.clone();
+        conn.set_ex::<_, _, ()>(key, value, ttl_secs)
+            .await
+            .map_err(|e| ArkError::Internal(format!("Redis SET: {e}")))?;
+        Ok(())
+    }
+
+    /// Helper: GET key
+    async fn get_bytes(&self, key: &str) -> ArkResult<Option<Vec<u8>>> {
+        let mut conn = self.conn.clone();
+        let val: Option<Vec<u8>> = conn
+            .get(key)
+            .await
+            .map_err(|e| ArkError::Internal(format!("Redis GET: {e}")))?;
+        Ok(val)
+    }
+
+    /// Helper: KEYS pattern → extract suffix after last ':'
+    async fn list_keys_suffix(&self, pattern: &str) -> ArkResult<Vec<String>> {
+        let mut conn = self.conn.clone();
+        let keys: Vec<String> = conn
+            .keys(pattern)
+            .await
+            .map_err(|e| ArkError::Internal(format!("Redis KEYS: {e}")))?;
+        let suffixes = keys
+            .into_iter()
+            .filter_map(|k| k.rsplit(':').next().map(String::from))
+            .collect();
+        Ok(suffixes)
+    }
+}
+
+#[async_trait]
+impl LiveStore for RedisLiveStore {
+    async fn set_intent(
+        &self,
+        round_id: &str,
+        intent_id: &str,
+        data: &[u8],
+        ttl_secs: u64,
+    ) -> ArkResult<()> {
+        self.set_ex(&Self::intent_key(round_id, intent_id), data, ttl_secs)
+            .await
+    }
+
+    async fn get_intent(&self, round_id: &str, intent_id: &str) -> ArkResult<Option<Vec<u8>>> {
+        self.get_bytes(&Self::intent_key(round_id, intent_id)).await
+    }
+
+    async fn list_intents(&self, round_id: &str) -> ArkResult<Vec<String>> {
+        self.list_keys_suffix(&format!("intents:{round_id}:*"))
+            .await
+    }
+
+    async fn delete_intent(&self, round_id: &str, intent_id: &str) -> ArkResult<()> {
+        let mut conn = self.conn.clone();
+        conn.del::<_, ()>(Self::intent_key(round_id, intent_id))
+            .await
+            .map_err(|e| ArkError::Internal(format!("Redis DEL: {e}")))?;
+        Ok(())
+    }
+
+    async fn set_nonce(
+        &self,
+        session_id: &str,
+        pubkey: &str,
+        nonce: &[u8],
+        ttl_secs: u64,
+    ) -> ArkResult<()> {
+        self.set_ex(&Self::nonce_key(session_id, pubkey), nonce, ttl_secs)
+            .await
+    }
+
+    async fn get_nonce(&self, session_id: &str, pubkey: &str) -> ArkResult<Option<Vec<u8>>> {
+        self.get_bytes(&Self::nonce_key(session_id, pubkey)).await
+    }
+
+    async fn list_nonces(&self, session_id: &str) -> ArkResult<Vec<String>> {
+        self.list_keys_suffix(&format!("nonces:{session_id}:*"))
+            .await
+    }
+
+    async fn set_partial_sig(
+        &self,
+        session_id: &str,
+        pubkey: &str,
+        sig: &[u8],
+        ttl_secs: u64,
+    ) -> ArkResult<()> {
+        self.set_ex(&Self::partial_sig_key(session_id, pubkey), sig, ttl_secs)
+            .await
+    }
+
+    async fn get_partial_sig(&self, session_id: &str, pubkey: &str) -> ArkResult<Option<Vec<u8>>> {
+        self.get_bytes(&Self::partial_sig_key(session_id, pubkey))
+            .await
+    }
+
+    async fn list_partial_sigs(&self, session_id: &str) -> ArkResult<Vec<String>> {
+        self.list_keys_suffix(&format!("partial_sigs:{session_id}:*"))
+            .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Redis integration tests require a live Redis instance.
+    /// Run with: `cargo test --features redis -- --ignored`
+    #[tokio::test]
+    #[ignore = "requires a live Redis instance at redis://127.0.0.1:6379"]
+    async fn test_redis_intent_roundtrip() {
+        let store = RedisLiveStore::new("redis://127.0.0.1:6379")
+            .await
+            .expect("Redis connection failed");
+        let data = b"redis-test-data";
+        store.set_intent("r1", "i1", data, 60).await.unwrap();
+        let got = store.get_intent("r1", "i1").await.unwrap();
+        assert_eq!(got, Some(data.to_vec()));
+        store.delete_intent("r1", "i1").await.unwrap();
+    }
+}


### PR DESCRIPTION
Implements Issue #48.

- New `arkd-live-store` crate
- `LiveStore` trait in `arkd-core::ports`
- `InMemoryLiveStore` for dev/test
- `RedisLiveStore` for production (behind `redis` feature)
- `redis_url` config field

Closes #48