### PR TITLE
🔒 TLS support for gRPC endpoints (#49)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2819,7 +2819,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -2963,7 +2963,9 @@ version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
 dependencies = [
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki 0.103.9",
  "subtle",
@@ -2977,6 +2979,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -3926,8 +3937,10 @@ dependencies = [
  "percent-encoding",
  "pin-project",
  "prost",
+ "rustls-pemfile 2.2.0",
  "socket2 0.5.10",
  "tokio",
+ "tokio-rustls",
  "tokio-stream",
  "tower 0.4.13",
  "tower-layer",

--- a/crates/arkd-api/Cargo.toml
+++ b/crates/arkd-api/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT"
 
 [dependencies]
 # gRPC
-tonic = "0.12"
+tonic = { version = "0.12", features = ["tls"] }
 prost = "0.13"
 tonic-web = "0.12"  # For REST/gRPC gateway
 
@@ -17,7 +17,7 @@ tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 
 # Async runtime
-tokio = { version = "1.42", features = ["sync", "macros"] }
+tokio = { version = "1.42", features = ["sync", "macros", "fs"] }
 tokio-util = "0.7"
 async-stream = "0.3"
 tokio-stream = "0.1"

--- a/crates/arkd-api/src/server.rs
+++ b/crates/arkd-api/src/server.rs
@@ -83,13 +83,48 @@ impl Server {
         &self.authenticator
     }
 
+    /// Load TLS configuration if enabled.
+    ///
+    /// Returns `Some(ServerTlsConfig)` when `tls_enabled` is true and both
+    /// cert/key paths are provided. Returns `None` for plaintext mode.
+    async fn load_tls_config(&self) -> ApiResult<Option<tonic::transport::ServerTlsConfig>> {
+        if !self.config.tls_enabled {
+            return Ok(None);
+        }
+
+        let cert_path = self.config.tls_cert_path.as_deref().ok_or_else(|| {
+            crate::ApiError::StartupError(
+                "TLS enabled but tls_cert_path not configured".to_string(),
+            )
+        })?;
+        let key_path = self.config.tls_key_path.as_deref().ok_or_else(|| {
+            crate::ApiError::StartupError("TLS enabled but tls_key_path not configured".to_string())
+        })?;
+
+        let cert = tokio::fs::read(cert_path).await.map_err(|e| {
+            crate::ApiError::StartupError(format!("Failed to read TLS cert {cert_path}: {e}"))
+        })?;
+        let key = tokio::fs::read(key_path).await.map_err(|e| {
+            crate::ApiError::StartupError(format!("Failed to read TLS key {key_path}: {e}"))
+        })?;
+
+        let identity = tonic::transport::Identity::from_pem(cert, key);
+        let tls_config = tonic::transport::ServerTlsConfig::new().identity(identity);
+
+        info!("TLS configured with cert={cert_path} key={key_path}");
+        Ok(Some(tls_config))
+    }
+
     /// Run the server (blocking).
     ///
     /// Spawns both gRPC and admin servers and waits for them.
     /// If either server exits, the other is cancelled.
     pub async fn run(&self) -> ApiResult<()> {
-        let grpc_handle = self.spawn_grpc_server()?;
-        let admin_handle = self.spawn_admin_server()?;
+        // Load TLS config once (before spawning tasks)
+        let tls_config = self.load_tls_config().await?;
+
+        let grpc_handle = self.spawn_grpc_server(tls_config.clone())?;
+        let admin_handle = self.spawn_admin_server(tls_config)?;
 
         info!(
             grpc_addr = %self.config.grpc_addr,
@@ -115,7 +150,10 @@ impl Server {
     }
 
     /// Spawn the user-facing gRPC server.
-    fn spawn_grpc_server(&self) -> ApiResult<JoinHandle<Result<(), tonic::transport::Error>>> {
+    fn spawn_grpc_server(
+        &self,
+        tls_config: Option<tonic::transport::ServerTlsConfig>,
+    ) -> ApiResult<JoinHandle<Result<(), tonic::transport::Error>>> {
         let addr = self
             .config
             .grpc_addr
@@ -143,10 +181,15 @@ impl Server {
         let svc = tonic_web::enable(svc);
         let cancel = self.cancel.clone();
 
-        info!(%addr, require_auth = self.config.require_auth, "Spawning gRPC server (ArkService)");
+        let tls_enabled = tls_config.is_some();
+        info!(%addr, require_auth = self.config.require_auth, tls = tls_enabled, "Spawning gRPC server (ArkService)");
 
         Ok(tokio::spawn(async move {
-            TonicServer::builder()
+            let mut builder = TonicServer::builder();
+            if let Some(tls) = tls_config {
+                builder = builder.tls_config(tls).expect("invalid TLS configuration");
+            }
+            builder
                 .accept_http1(true) // Required for tonic-web
                 .add_service(svc)
                 .serve_with_shutdown(addr, cancel.cancelled())
@@ -155,7 +198,10 @@ impl Server {
     }
 
     /// Spawn the admin gRPC server on a separate port.
-    fn spawn_admin_server(&self) -> ApiResult<JoinHandle<Result<(), tonic::transport::Error>>> {
+    fn spawn_admin_server(
+        &self,
+        tls_config: Option<tonic::transport::ServerTlsConfig>,
+    ) -> ApiResult<JoinHandle<Result<(), tonic::transport::Error>>> {
         let addr_str = self.config.admin_addr();
         let addr = addr_str
             .parse()
@@ -165,10 +211,15 @@ impl Server {
         let svc = tonic_web::enable(AdminServiceServer::new(admin_service));
         let cancel = self.cancel.clone();
 
-        info!(%addr, "Spawning admin gRPC server (AdminService)");
+        let tls_enabled = tls_config.is_some();
+        info!(%addr, tls = tls_enabled, "Spawning admin gRPC server (AdminService)");
 
         Ok(tokio::spawn(async move {
-            TonicServer::builder()
+            let mut builder = TonicServer::builder();
+            if let Some(tls) = tls_config {
+                builder = builder.tls_config(tls).expect("invalid TLS configuration");
+            }
+            builder
                 .accept_http1(true)
                 .add_service(svc)
                 .serve_with_shutdown(addr, cancel.cancelled())
@@ -193,5 +244,13 @@ mod tests {
         let config = ServerConfig::default();
         // Admin addr should differ from grpc_addr
         assert_ne!(config.grpc_addr, config.admin_addr());
+    }
+
+    #[test]
+    fn test_server_config_tls_defaults_to_none() {
+        let cfg = ServerConfig::default();
+        assert!(!cfg.tls_enabled);
+        assert!(cfg.tls_cert_path.is_none());
+        assert!(cfg.tls_key_path.is_none());
     }
 }

--- a/crates/arkd-api/tests/grpc_integration.rs
+++ b/crates/arkd-api/tests/grpc_integration.rs
@@ -821,3 +821,27 @@ async fn test_offchain_tx_submit_and_get() {
     assert_eq!(get.tx_id, tx_id);
     assert!(!get.stage.is_empty());
 }
+
+// ─── TLS Configuration Tests ────────────────────────────────────────
+
+#[test]
+fn test_tls_config_fields_default_none() {
+    let config = arkd_api::ServerConfig::default();
+    assert!(!config.tls_enabled);
+    assert!(config.tls_cert_path.is_none());
+    assert!(config.tls_key_path.is_none());
+}
+
+#[test]
+fn test_tls_config_none_uses_plaintext() {
+    // ServerConfig with TLS disabled should work fine (plaintext)
+    let config = arkd_api::ServerConfig {
+        tls_enabled: false,
+        tls_cert_path: None,
+        tls_key_path: None,
+        ..Default::default()
+    };
+    assert!(!config.tls_enabled);
+    // Server creation should succeed with plaintext config
+    // (actual server start tested via start_ark_server above)
+}

--- a/scripts/gen-tls-certs.sh
+++ b/scripts/gen-tls-certs.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+# Generate self-signed TLS certificate for development
+# Usage: ./scripts/gen-tls-certs.sh [output_dir]
+set -euo pipefail
+
+OUTPUT="${1:-./certs}"
+mkdir -p "$OUTPUT"
+
+openssl req -x509 -newkey rsa:4096 -keyout "$OUTPUT/key.pem" \
+  -out "$OUTPUT/cert.pem" -days 365 -nodes \
+  -subj "/CN=arkd-dev/O=arkd/C=US"
+
+echo "Generated: $OUTPUT/cert.pem and $OUTPUT/key.pem"


### PR DESCRIPTION
Implements Issue #49.

- `tls_cert_path` + `tls_key_path` on `ServerConfig`
- Cert loaded at startup; plaintext fallback when unconfigured
- `scripts/gen-tls-certs.sh` for self-signed dev certs
- Tests for default None config

Closes #49