### PR TITLE
🔑 Separate signer process: SignerService proto + RemoteSignerClient (#50)

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -29,6 +29,11 @@ enable_logging = true
 # Admin API token (generate a secure random token for production)
 # admin_token = "your-secure-admin-token"
 
+# Remote signer gRPC endpoint for key isolation.
+# When set, signing operations are delegated to a separate signer process.
+# When unset (default), local signing is used.
+# remote_signer_url = "http://127.0.0.1:7072"
+
 # =============================================================================
 # Bitcoin Configuration
 # =============================================================================

--- a/crates/arkd-api/build.rs
+++ b/crates/arkd-api/build.rs
@@ -5,7 +5,11 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
         .build_server(true)
         .build_client(true)
         .compile_protos(
-            &["ark/v1/ark_service.proto", "ark/v1/admin_service.proto"],
+            &[
+                "ark/v1/ark_service.proto",
+                "ark/v1/admin_service.proto",
+                "ark/v1/signer_service.proto",
+            ],
             &[proto_root],
         )?;
 

--- a/crates/arkd-api/src/config.rs
+++ b/crates/arkd-api/src/config.rs
@@ -44,6 +44,11 @@ pub struct ServerConfig {
     /// When true, authentication is strictly enforced (production).
     #[serde(default)]
     pub require_auth: bool,
+
+    /// gRPC endpoint for remote signer process (key isolation).
+    /// If `None`, local signing is used. Example: `"http://127.0.0.1:7072"`
+    #[serde(default)]
+    pub remote_signer_url: Option<String>,
 }
 
 fn default_max_connections() -> usize {
@@ -93,6 +98,7 @@ impl Default for ServerConfig {
             enable_logging: true,
             admin_token: None,
             require_auth: false, // Dev mode by default
+            remote_signer_url: None,
         }
     }
 }

--- a/crates/arkd-api/src/grpc/mod.rs
+++ b/crates/arkd-api/src/grpc/mod.rs
@@ -5,3 +5,4 @@ pub mod ark_service;
 pub mod broker;
 pub mod convert;
 pub mod middleware;
+pub mod signer_client;

--- a/crates/arkd-api/src/grpc/signer_client.rs
+++ b/crates/arkd-api/src/grpc/signer_client.rs
@@ -1,0 +1,113 @@
+//! Remote signer gRPC client for key isolation.
+//!
+//! When `remote_signer_url` is configured, the main arkd process delegates
+//! all signing operations to a separate signer process via this client.
+
+use tonic::transport::Channel;
+
+use crate::proto::ark_v1::signer_service_client::SignerServiceClient;
+use crate::proto::ark_v1::{
+    AggregateKeysRequest, GetPublicKeyRequest, SignMessageRequest, SignTransactionRequest,
+};
+
+/// Remote signer client wrapping the generated gRPC `SignerServiceClient`.
+pub struct RemoteSignerClient {
+    inner: SignerServiceClient<Channel>,
+}
+
+impl RemoteSignerClient {
+    /// Connect to a remote signer at the given gRPC URL.
+    pub async fn connect(url: &str) -> Result<Self, tonic::transport::Error> {
+        let channel = Channel::from_shared(url.to_string())
+            .expect("valid URI")
+            .connect()
+            .await?;
+        Ok(Self {
+            inner: SignerServiceClient::new(channel),
+        })
+    }
+
+    /// Retrieve the signer's public key.
+    pub async fn get_public_key(&mut self) -> Result<Vec<u8>, tonic::Status> {
+        let resp = self.inner.get_public_key(GetPublicKeyRequest {}).await?;
+        Ok(resp.into_inner().pubkey)
+    }
+
+    /// Sign a PSBT, optionally restricting to specific input indexes.
+    pub async fn sign_transaction(
+        &mut self,
+        psbt: Vec<u8>,
+        input_indexes: Vec<u32>,
+    ) -> Result<Vec<u8>, tonic::Status> {
+        let resp = self
+            .inner
+            .sign_transaction(SignTransactionRequest {
+                psbt,
+                input_indexes,
+            })
+            .await?;
+        Ok(resp.into_inner().signed_psbt)
+    }
+
+    /// Sign an arbitrary message (Schnorr).
+    pub async fn sign_message(&mut self, message: Vec<u8>) -> Result<Vec<u8>, tonic::Status> {
+        let resp = self
+            .inner
+            .sign_message(SignMessageRequest { message })
+            .await?;
+        Ok(resp.into_inner().signature)
+    }
+
+    /// Aggregate public keys (MuSig2).
+    pub async fn aggregate_keys(
+        &mut self,
+        pubkeys: Vec<Vec<u8>>,
+    ) -> Result<Vec<u8>, tonic::Status> {
+        let resp = self
+            .inner
+            .aggregate_keys(AggregateKeysRequest { pubkeys })
+            .await?;
+        Ok(resp.into_inner().aggregated_pubkey)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::proto::ark_v1;
+
+    #[test]
+    fn test_signer_proto_compiles() {
+        // Verify all generated signer types are accessible
+        let _req = ark_v1::GetPublicKeyRequest {};
+        let _resp = ark_v1::GetPublicKeyResponse {
+            pubkey: vec![0u8; 33],
+        };
+        let _sign_req = ark_v1::SignTransactionRequest {
+            psbt: vec![],
+            input_indexes: vec![0, 1],
+        };
+        let _sign_resp = ark_v1::SignTransactionResponse {
+            signed_psbt: vec![],
+        };
+        let _msg_req = ark_v1::SignMessageRequest {
+            message: vec![0u8; 32],
+        };
+        let _msg_resp = ark_v1::SignMessageResponse {
+            signature: vec![0u8; 64],
+        };
+        let _agg_req = ark_v1::AggregateKeysRequest { pubkeys: vec![] };
+        let _agg_resp = ark_v1::AggregateKeysResponse {
+            aggregated_pubkey: vec![],
+        };
+    }
+
+    #[test]
+    fn test_remote_signer_url_config_default_none() {
+        let config = crate::ServerConfig::default();
+        assert!(
+            config.remote_signer_url.is_none(),
+            "remote_signer_url should default to None (local signing)"
+        );
+    }
+}

--- a/crates/arkd-api/src/lib.rs
+++ b/crates/arkd-api/src/lib.rs
@@ -35,6 +35,7 @@ pub mod proto {
 
 pub use config::ServerConfig;
 pub use grpc::broker::{EventBroker, SharedEventBroker};
+pub use grpc::signer_client::RemoteSignerClient;
 pub use monitoring::{spawn_monitoring_server, MonitoringConfig};
 pub use server::Server;
 

--- a/proto/ark/v1/signer_service.proto
+++ b/proto/ark/v1/signer_service.proto
@@ -1,0 +1,40 @@
+syntax = "proto3";
+package ark.v1;
+
+option go_package = "github.com/arkade-os/arkd/api/gen/ark/v1";
+
+// SignerService provides remote signing operations for ASP key isolation.
+// The signer process holds the private key; the main arkd process calls it.
+service SignerService {
+  rpc SignTransaction(SignTransactionRequest) returns (SignTransactionResponse);
+  rpc SignMessage(SignMessageRequest) returns (SignMessageResponse);
+  rpc GetPublicKey(GetPublicKeyRequest) returns (GetPublicKeyResponse);
+  rpc AggregateKeys(AggregateKeysRequest) returns (AggregateKeysResponse);
+}
+
+message SignTransactionRequest {
+  bytes psbt = 1;                      // PSBT bytes to sign
+  repeated uint32 input_indexes = 2;   // Which inputs to sign
+}
+message SignTransactionResponse {
+  bytes signed_psbt = 1;
+}
+
+message SignMessageRequest {
+  bytes message = 1;                   // Raw message bytes (32-byte hash recommended)
+}
+message SignMessageResponse {
+  bytes signature = 1;                 // 64-byte Schnorr signature
+}
+
+message GetPublicKeyRequest {}
+message GetPublicKeyResponse {
+  bytes pubkey = 1;                    // 33-byte compressed public key
+}
+
+message AggregateKeysRequest {
+  repeated bytes pubkeys = 1;          // Public keys to aggregate (MuSig2)
+}
+message AggregateKeysResponse {
+  bytes aggregated_pubkey = 1;
+}


### PR DESCRIPTION
Implements Issue #50.

- `proto/ark/v1/signer_service.proto` — SignerService gRPC definition
- `RemoteSignerClient` wrapping the generated gRPC client
- `remote_signer_url` config field (None = local signing)
- Tests for config defaults

Closes #50