### PR TITLE
🔄 Round loop: auto-trigger rounds from time scheduler (#82)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,6 +228,7 @@ dependencies = [
  "arkd-bitcoin",
  "arkd-core",
  "arkd-db",
+ "arkd-scheduler",
  "arkd-wallet",
  "async-trait",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -61,6 +61,7 @@ clap = { version = "4.5", features = ["derive"] }
 arkd-api = { path = "crates/arkd-api" }
 arkd-core = { path = "crates/arkd-core" }
 arkd-db = { path = "crates/arkd-db" }
+arkd-scheduler = { path = "crates/arkd-scheduler" }
 arkd-wallet = { path = "crates/arkd-wallet" }
 async-trait = "0.1"
 

--- a/crates/arkd-api/src/config.rs
+++ b/crates/arkd-api/src/config.rs
@@ -66,6 +66,10 @@ pub struct ServerConfig {
     #[serde(default)]
     pub allow_csv_block_type: bool,
 
+    /// Seconds between automatic round triggers (time-based scheduling). Default: 30.
+    #[serde(default = "default_round_duration_secs")]
+    pub round_duration_secs: u64,
+
     /// Number of blocks between round triggers when block-based scheduling is enabled.
     #[serde(default = "default_round_interval_blocks")]
     pub round_interval_blocks: u32,
@@ -107,6 +111,9 @@ impl ServerConfig {
 fn default_round_interval_blocks() -> u32 {
     6
 }
+fn default_round_duration_secs() -> u64 {
+    30
+}
 
 impl Default for ServerConfig {
     fn default() -> Self {
@@ -127,6 +134,7 @@ impl Default for ServerConfig {
             asp_key_hex: None,
             allow_csv_block_type: false,
             round_interval_blocks: 6,
+            round_duration_secs: 30,
         }
     }
 }

--- a/crates/arkd-core/src/lib.rs
+++ b/crates/arkd-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod domain;
 pub mod error;
 pub mod metrics;
 pub mod ports;
+pub mod round_loop;
 pub mod round_scheduler;
 pub mod signer;
 pub mod sweep;
@@ -44,6 +45,7 @@ pub use ports::{
     ArkEvent, CacheService, EventPublisher, RoundRepository, SignerService, TxBuilder,
     VtxoRepository, WalletService,
 };
+pub use round_loop::spawn_round_loop;
 pub use round_scheduler::{RoundScheduler, SchedulerCommand, SchedulerConfig, SchedulerState};
 pub use signer::LocalSigner;
 pub use sweep::{SweepBatch, SweepConfig, SweepService, SweepStats};

--- a/crates/arkd-core/src/round_loop.rs
+++ b/crates/arkd-core/src/round_loop.rs
@@ -1,0 +1,257 @@
+//! Round loop — consumes scheduler ticks and triggers new rounds.
+//!
+//! This is the glue between the `TimeScheduler` port and `ArkService::start_round`.
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+use tokio::task::JoinHandle;
+use tracing::{error, info};
+
+use crate::application::ArkService;
+
+/// Spawn a background task that calls `core.start_round()` on every tick.
+///
+/// Returns a `JoinHandle` so the caller can await or abort the loop.
+/// The loop exits cleanly when `tick_rx` is closed (sender dropped).
+pub fn spawn_round_loop(core: Arc<ArkService>, mut tick_rx: mpsc::Receiver<()>) -> JoinHandle<()> {
+    tokio::spawn(async move {
+        info!("Round loop started — waiting for scheduler ticks");
+
+        while let Some(()) = tick_rx.recv().await {
+            match core.start_round().await {
+                Ok(round) => {
+                    info!(round_id = %round.id, "Round triggered by scheduler");
+                }
+                Err(e) => {
+                    // Log but keep looping — transient errors (e.g. "round already
+                    // active") should not kill the loop.
+                    error!("Failed to start round: {e}");
+                }
+            }
+        }
+
+        info!("Round loop exiting — tick channel closed");
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::atomic::{AtomicU32, Ordering};
+
+    use async_trait::async_trait;
+    use bitcoin::XOnlyPublicKey;
+    use tokio::sync::broadcast;
+
+    use crate::application::ArkConfig;
+    use crate::domain::VtxoOutpoint;
+    use crate::error::ArkResult;
+    use crate::ports::*;
+
+    // ── Minimal mock implementations ────────────────────────────────
+
+    struct StubWallet;
+    #[async_trait]
+    impl WalletService for StubWallet {
+        async fn status(&self) -> ArkResult<WalletStatus> {
+            Ok(WalletStatus {
+                initialized: true,
+                unlocked: true,
+                synced: true,
+            })
+        }
+        async fn get_forfeit_pubkey(&self) -> ArkResult<XOnlyPublicKey> {
+            Ok(XOnlyPublicKey::from_slice(&[1u8; 32]).unwrap())
+        }
+        async fn derive_connector_address(&self) -> ArkResult<String> {
+            Ok(String::new())
+        }
+        async fn sign_transaction(&self, p: &str, _: bool) -> ArkResult<String> {
+            Ok(p.into())
+        }
+        async fn select_utxos(&self, _: u64, _: bool) -> ArkResult<(Vec<TxInput>, u64)> {
+            Ok((vec![], 0))
+        }
+        async fn broadcast_transaction(&self, _: Vec<String>) -> ArkResult<String> {
+            Ok(String::new())
+        }
+        async fn fee_rate(&self) -> ArkResult<u64> {
+            Ok(1)
+        }
+        async fn get_current_block_time(&self) -> ArkResult<BlockTimestamp> {
+            Ok(BlockTimestamp {
+                height: 1,
+                timestamp: 0,
+            })
+        }
+        async fn get_dust_amount(&self) -> ArkResult<u64> {
+            Ok(546)
+        }
+        async fn get_outpoint_status(&self, _: &VtxoOutpoint) -> ArkResult<bool> {
+            Ok(false)
+        }
+    }
+
+    struct StubSigner;
+    #[async_trait]
+    impl SignerService for StubSigner {
+        async fn get_pubkey(&self) -> ArkResult<XOnlyPublicKey> {
+            Ok(XOnlyPublicKey::from_slice(&[1u8; 32]).unwrap())
+        }
+        async fn sign_transaction(&self, p: &str, _: bool) -> ArkResult<String> {
+            Ok(p.into())
+        }
+    }
+
+    struct StubVtxoRepo;
+    #[async_trait]
+    impl VtxoRepository for StubVtxoRepo {
+        async fn add_vtxos(&self, _: &[crate::domain::Vtxo]) -> ArkResult<()> {
+            Ok(())
+        }
+        async fn get_vtxos(&self, _: &[VtxoOutpoint]) -> ArkResult<Vec<crate::domain::Vtxo>> {
+            Ok(vec![])
+        }
+        async fn get_all_vtxos_for_pubkey(
+            &self,
+            _: &str,
+        ) -> ArkResult<(Vec<crate::domain::Vtxo>, Vec<crate::domain::Vtxo>)> {
+            Ok((vec![], vec![]))
+        }
+        async fn spend_vtxos(&self, _: &[(VtxoOutpoint, String)], _: &str) -> ArkResult<()> {
+            Ok(())
+        }
+    }
+
+    struct StubTxBuilder;
+    #[async_trait]
+    impl TxBuilder for StubTxBuilder {
+        async fn build_commitment_tx(
+            &self,
+            _: &XOnlyPublicKey,
+            _: &[crate::domain::Intent],
+            _: &[BoardingInput],
+        ) -> ArkResult<CommitmentTxResult> {
+            unimplemented!()
+        }
+        async fn verify_forfeit_txs(
+            &self,
+            _: &[crate::domain::Vtxo],
+            _: &crate::domain::FlatTxTree,
+            _: &[String],
+        ) -> ArkResult<Vec<ValidForfeitTx>> {
+            unimplemented!()
+        }
+    }
+
+    struct StubCache;
+    #[async_trait]
+    impl CacheService for StubCache {
+        async fn set(&self, _: &str, _: &[u8], _: Option<u64>) -> ArkResult<()> {
+            Ok(())
+        }
+        async fn get(&self, _: &str) -> ArkResult<Option<Vec<u8>>> {
+            Ok(None)
+        }
+        async fn delete(&self, _: &str) -> ArkResult<bool> {
+            Ok(false)
+        }
+    }
+
+    struct CountingEvents {
+        count: AtomicU32,
+    }
+    impl CountingEvents {
+        fn new() -> Self {
+            Self {
+                count: AtomicU32::new(0),
+            }
+        }
+        fn round_started_count(&self) -> u32 {
+            self.count.load(Ordering::SeqCst)
+        }
+    }
+    #[async_trait]
+    impl EventPublisher for CountingEvents {
+        async fn publish_event(&self, event: ArkEvent) -> ArkResult<()> {
+            if matches!(event, ArkEvent::RoundStarted { .. }) {
+                self.count.fetch_add(1, Ordering::SeqCst);
+            }
+            Ok(())
+        }
+        async fn subscribe(&self) -> ArkResult<broadcast::Receiver<ArkEvent>> {
+            let (_tx, rx) = broadcast::channel(1);
+            Ok(rx)
+        }
+    }
+
+    fn make_core(events: Arc<CountingEvents>) -> Arc<ArkService> {
+        Arc::new(ArkService::new(
+            Arc::new(StubWallet),
+            Arc::new(StubSigner),
+            Arc::new(StubVtxoRepo),
+            Arc::new(StubTxBuilder),
+            Arc::new(StubCache),
+            events,
+            ArkConfig::default(),
+        ))
+    }
+
+    // ── Tests ───────────────────────────────────────────────────────
+
+    #[tokio::test]
+    async fn tick_triggers_round() {
+        let events = Arc::new(CountingEvents::new());
+        let core = make_core(events.clone());
+        let (tx, rx) = mpsc::channel(1);
+
+        let handle = spawn_round_loop(core, rx);
+
+        tx.send(()).await.unwrap();
+        // Give the loop a moment to process
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+        assert_eq!(events.round_started_count(), 1);
+
+        drop(tx);
+        handle.await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn error_does_not_kill_loop() {
+        let events = Arc::new(CountingEvents::new());
+        let core = make_core(events.clone());
+        let (tx, rx) = mpsc::channel(2);
+
+        let handle = spawn_round_loop(core, rx);
+
+        // First tick starts a round (succeeds)
+        tx.send(()).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Second tick: round already active → error, but loop should survive
+        tx.send(()).await.unwrap();
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        // Loop is still alive — count is still 1 (second call errored)
+        assert_eq!(events.round_started_count(), 1);
+
+        drop(tx);
+        handle.await.unwrap(); // exits cleanly
+    }
+
+    #[tokio::test]
+    async fn handle_is_returned_and_joinable() {
+        let events = Arc::new(CountingEvents::new());
+        let core = make_core(events);
+        let (tx, rx) = mpsc::channel(1);
+
+        let handle = spawn_round_loop(core, rx);
+        assert!(!handle.is_finished());
+
+        drop(tx);
+        let result = handle.await;
+        assert!(result.is_ok());
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,9 @@ use std::sync::Arc;
 use anyhow::Result;
 use tracing::info;
 
+use arkd_core::ports::TimeScheduler;
+use arkd_scheduler::SimpleTimeScheduler;
+
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt()
@@ -45,7 +48,23 @@ async fn main() -> Result<()> {
 
     // --- API server ---
     let config = arkd_api::ServerConfig::default();
-    info!(grpc = %config.grpc_addr, "Starting gRPC server");
+    info!(
+        grpc = %config.grpc_addr,
+        round_duration_secs = config.round_duration_secs,
+        "Starting gRPC server"
+    );
+
+    // --- Round loop (auto-trigger rounds from scheduler) ---
+    let scheduler = SimpleTimeScheduler;
+    let tick_rx = scheduler
+        .schedule(std::time::Duration::from_secs(config.round_duration_secs))
+        .await
+        .map_err(|e| anyhow::anyhow!("Scheduler error: {e}"))?;
+    let _round_loop = arkd_core::spawn_round_loop(Arc::clone(&core), tick_rx);
+    info!(
+        interval_secs = config.round_duration_secs,
+        "Round loop started"
+    );
 
     let server = arkd_api::Server::new(
         config,


### PR DESCRIPTION
## Summary

Wires the round loop so rounds are automatically triggered by the time scheduler at a configurable interval.

Closes #82

## Changes

- **`arkd-core::ports`** — Add `TimeScheduler` trait (async, returns `mpsc::Receiver<()>`)
- **`arkd-scheduler`** (new crate) — `SimpleTimeScheduler` implementation using `tokio::time::interval`
- **`arkd-core::round_loop`** (new module) — `spawn_round_loop(core, tick_rx)` consumes ticks and calls `core.start_round()`; errors are logged but don't kill the loop
- **`arkd-api::ServerConfig`** — Add `round_duration_secs: u64` (default 30)
- **`config.example.toml`** — Document `round_duration_secs`
- **`src/main.rs`** — Wire scheduler + round loop before `server.run()`

## Tests

- `tick_triggers_round` — sending a tick results in `RoundStarted` event
- `error_does_not_kill_loop` — second tick errors (round already active) but loop survives
- `handle_is_returned_and_joinable` — JoinHandle is valid and completes when channel closes
- `test_scheduler_emits_ticks` — SimpleTimeScheduler emits at least one tick
- `test_scheduler_stops_when_receiver_dropped` — background task exits gracefully