### PR TITLE
🧪 Nigiri E2E test script + testing docs (#83)

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,17 @@ cargo bench
 - Property-based tests: VTXO invariants, serialization roundtrips, amount conservation
 - Performance benchmarks: tree construction, round lifecycle, DB operations
 
+### End-to-End Tests (Nigiri)
+
+Run the full E2E test against a local Bitcoin regtest using [Nigiri](https://nigiri.vulpem.com/):
+
+```bash
+nigiri start
+./scripts/e2e-test.sh
+```
+
+See [docs/testing.md](docs/testing.md) for details and manual gRPC testing instructions.
+
 ### Code style
 
 ```bash

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -1,0 +1,33 @@
+# Testing arkd-rs
+
+## Unit Tests
+
+```bash
+cargo test --workspace
+```
+
+## Integration Tests (Nigiri)
+
+### Prerequisites
+
+- [Nigiri](https://nigiri.vulpem.com/) installed
+- grpcurl installed (optional but recommended)
+
+### Setup
+
+```bash
+nigiri start
+./scripts/e2e-test.sh
+```
+
+### Manual gRPC testing
+
+```bash
+# Start arkd
+cargo run
+
+# In another terminal:
+grpcurl -plaintext localhost:50051 list
+grpcurl -plaintext localhost:50051 ark.v1.ArkService/GetInfo
+grpcurl -plaintext localhost:50051 ark.v1.ArkService/ListRounds
+```

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# End-to-end integration test using Nigiri (Bitcoin regtest + Esplora)
+# Usage: ./scripts/e2e-test.sh
+set -euo pipefail
+
+GRPC="localhost:50051"
+CONFIG="tests/nigiri-config.toml"
+
+echo "=== arkd-rs E2E Test ==="
+
+# 1. Check Nigiri is running
+if ! curl -sf http://localhost:3000/blocks/tip/height > /dev/null 2>&1; then
+  echo "ERROR: Nigiri not running. Start with: nigiri start"
+  exit 1
+fi
+echo "✅ Nigiri running"
+
+# 2. Build arkd
+cargo build --release 2>&1 | tail -3
+echo "✅ Binary built"
+
+# 3. Start arkd
+./target/release/arkd &
+ARKD_PID=$!
+trap "kill $ARKD_PID 2>/dev/null || true" EXIT
+sleep 2
+
+# 4. Check GetInfo
+echo "--- GetInfo ---"
+if command -v grpcurl > /dev/null 2>&1; then
+  grpcurl -plaintext $GRPC ark.v1.ArkService/GetInfo
+  echo "✅ GetInfo works"
+else
+  echo "grpcurl not installed — skipping gRPC check"
+  # Fallback: check process is running
+  kill -0 $ARKD_PID && echo "✅ arkd process running"
+fi
+
+echo ""
+echo "=== All checks passed ==="

--- a/tests/nigiri-config.toml
+++ b/tests/nigiri-config.toml
@@ -1,0 +1,22 @@
+# arkd-rs Nigiri (regtest) configuration
+# For use with: https://nigiri.vulpem.com/
+
+[server]
+grpc_addr = "[::1]:50051"
+rest_addr = "127.0.0.1:8080"
+require_auth = false
+
+[bitcoin]
+network = "regtest"
+rpc_host = "127.0.0.1"
+rpc_port = 18443
+rpc_user = "admin1"
+rpc_password = "123"
+
+[wallet]
+esplora_url = "http://localhost:3000"
+network = "regtest"
+
+[ark]
+round_duration_secs = 5
+network = "regtest"


### PR DESCRIPTION
## Summary

Adds end-to-end integration test infrastructure using [Nigiri](https://nigiri.vulpem.com/) (Bitcoin regtest + Esplora).

Closes #83

## Changes

- **`tests/nigiri-config.toml`** — Regtest config matching Nigiri defaults (admin1/123, Esplora on :3000)
- **`scripts/e2e-test.sh`** — Automated E2E script: checks Nigiri, builds arkd, starts it, verifies gRPC GetInfo
- **`docs/testing.md`** — Testing documentation (unit tests, Nigiri setup, manual gRPC commands)
- **`README.md`** — Added E2E testing section pointing to docs and script

## How to test

```bash
nigiri start
./scripts/e2e-test.sh
```