### PR TITLE
🛠️ Missing admin RPCs (#57)

### DIFF
--- a/crates/arkd-api/src/grpc/admin_service.rs
+++ b/crates/arkd-api/src/grpc/admin_service.rs
@@ -144,12 +144,14 @@ impl AdminServiceTrait for AdminGrpcService {
         let req = request.into_inner();
         info!("AdminService::UpdateIntentFees called");
 
-        let fees = req
+        let _fees = req
             .fees
             .ok_or_else(|| Status::invalid_argument("fees config is required"))?;
 
-        // Stub: echo back the requested config
-        Ok(Response::new(UpdateIntentFeesResponse { fees: Some(fees) }))
+        // Stub: requires fee persistence — returning UNIMPLEMENTED for consistency
+        Err(Status::unimplemented(
+            "UpdateIntentFees not yet implemented — requires fee persistence",
+        ))
     }
 
     async fn clear_intent_fees(
@@ -251,14 +253,14 @@ impl AdminServiceTrait for AdminGrpcService {
         let req = request.into_inner();
         info!("AdminService::UpdateScheduledSessionConfig called");
 
-        let config = req
+        let _config = req
             .config
             .ok_or_else(|| Status::invalid_argument("config is required"))?;
 
-        // Stub: echo back the requested config
-        Ok(Response::new(UpdateScheduledSessionConfigResponse {
-            config: Some(config),
-        }))
+        // Stub: requires config persistence — returning UNIMPLEMENTED for consistency
+        Err(Status::unimplemented(
+            "UpdateScheduledSessionConfig not yet implemented — requires config persistence",
+        ))
     }
 
     async fn clear_scheduled_session_config(

--- a/proto/ark/v1/admin_service.proto
+++ b/proto/ark/v1/admin_service.proto
@@ -119,7 +119,7 @@ message DeleteIntentsResponse {
 
 message IntentFeeConfig {
   uint64 base_fee_sats = 1;
-  uint64 fee_rate_ppm = 2;  // parts per million
+  uint64 fee_rate_ppm = 2;  // fee rate in parts per million (e.g. 1000 = 0.1%)
 }
 
 message GetIntentFeesRequest {}


### PR DESCRIPTION
## Summary

Adds 13 missing admin RPCs to `AdminService` as specified in #57.

### New RPCs
- **Intent management:** `ListIntents`, `DeleteIntents`, `GetIntentFees`, `UpdateIntentFees`, `ClearIntentFees`
- **Sweep:** `GetScheduledSweep`, `Sweep`
- **Liquidity:** `GetExpiringLiquidity`, `GetRecoverableLiquidity`
- **Auth:** `RevokeAuth`
- **Session config:** `GetScheduledSessionConfig`, `UpdateScheduledSessionConfig`, `ClearScheduledSessionConfig`
- **Convictions:** `ListConvictions`, `DeleteConviction`

### Implementation
- Proto definitions added to `admin_service.proto` with proper message types
- Stub handlers in `AdminGrpcService` — read-only RPCs return empty/default responses, mutating RPCs return `UNIMPLEMENTED` until backing repositories are wired
- Input validation on required fields
- All handlers log via `tracing`
- `cargo check` + `cargo clippy` + `cargo fmt` pass clean

Closes #57