### PR TITLE
🔑 Key rotation: MultiSigner + deprecated_signers support

### DIFF
--- a/config.example.toml
+++ b/config.example.toml
@@ -44,6 +44,10 @@ enable_logging = true
 # Generate with: openssl rand -hex 32
 # asp_key_hex = "e8f32e723decf4051aefac8e2c93c9c5b214313817cdb01a1494b917c8436b35"
 
+# Deprecated ASP signer keys — hex public keys of previous ASP signers
+# that should still be accepted for verification after a key rotation.
+# deprecated_signer_keys = ["old-hex-key-1", "old-hex-key-2"]
+
 # =============================================================================
 # Bitcoin Configuration
 # =============================================================================

--- a/crates/arkd-api/src/config.rs
+++ b/crates/arkd-api/src/config.rs
@@ -62,6 +62,11 @@ pub struct ServerConfig {
     #[serde(default)]
     pub asp_key_hex: Option<String>,
 
+    /// List of deprecated ASP key hex strings that are still accepted for
+    /// verification (e.g. after a key rotation). Empty by default.
+    #[serde(default)]
+    pub deprecated_signer_keys: Vec<String>,
+
     /// Use block-height-based round scheduling instead of time-based.
     #[serde(default)]
     pub allow_csv_block_type: bool,
@@ -132,6 +137,7 @@ impl Default for ServerConfig {
             remote_signer_url: None,
             esplora_url: None,
             asp_key_hex: None,
+            deprecated_signer_keys: Vec::new(),
             allow_csv_block_type: false,
             round_interval_blocks: 6,
             round_duration_secs: 30,
@@ -164,6 +170,12 @@ mod tests {
     fn test_config_asp_key_defaults_to_none() {
         let config = ServerConfig::default();
         assert!(config.asp_key_hex.is_none());
+    }
+
+    #[test]
+    fn test_config_deprecated_keys_default_empty() {
+        let config = ServerConfig::default();
+        assert!(config.deprecated_signer_keys.is_empty());
     }
 
     #[test]

--- a/crates/arkd-core/src/lib.rs
+++ b/crates/arkd-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod cosigning;
 pub mod domain;
 pub mod error;
 pub mod metrics;
+pub mod multi_signer;
 pub mod ports;
 pub mod round_loop;
 pub mod round_scheduler;
@@ -41,6 +42,7 @@ pub use domain::{
     VtxoOutpoint,
 };
 pub use error::{ArkError, ArkResult};
+pub use multi_signer::MultiSigner;
 pub use ports::{
     ArkEvent, CacheService, EventPublisher, RoundRepository, SignerService, TxBuilder,
     VtxoRepository, WalletService,

--- a/crates/arkd-core/src/multi_signer.rs
+++ b/crates/arkd-core/src/multi_signer.rs
@@ -1,0 +1,119 @@
+//! MultiSigner — wraps a primary signer plus zero or more deprecated signers.
+//!
+//! After a key rotation the old key(s) may still be needed to verify
+//! existing VTXOs. `MultiSigner` keeps them around while always signing
+//! with the current (primary) key.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+use bitcoin::XOnlyPublicKey;
+
+use crate::error::ArkResult;
+use crate::ports::SignerService;
+
+/// A signer that holds the current active key plus zero or more deprecated keys.
+///
+/// * **Signing** always delegates to the primary signer.
+/// * **Verification** can check against any key returned by [`all_pubkeys`](Self::all_pubkeys).
+pub struct MultiSigner {
+    primary: Arc<dyn SignerService>,
+    deprecated: Vec<Arc<dyn SignerService>>,
+}
+
+impl MultiSigner {
+    /// Create a new `MultiSigner`.
+    pub fn new(primary: Arc<dyn SignerService>, deprecated: Vec<Arc<dyn SignerService>>) -> Self {
+        Self {
+            primary,
+            deprecated,
+        }
+    }
+
+    /// Reference to the primary (active) signer.
+    pub fn primary(&self) -> &Arc<dyn SignerService> {
+        &self.primary
+    }
+
+    /// All public keys: `[primary, …deprecated]`.
+    pub async fn all_pubkeys(&self) -> ArkResult<Vec<XOnlyPublicKey>> {
+        let mut keys = vec![self.primary.get_pubkey().await?];
+        for d in &self.deprecated {
+            keys.push(d.get_pubkey().await?);
+        }
+        Ok(keys)
+    }
+}
+
+#[async_trait]
+impl SignerService for MultiSigner {
+    async fn get_pubkey(&self) -> ArkResult<XOnlyPublicKey> {
+        self.primary.get_pubkey().await
+    }
+
+    async fn sign_transaction(&self, partial_tx: &str, extract_raw: bool) -> ArkResult<String> {
+        self.primary.sign_transaction(partial_tx, extract_raw).await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::signer::LocalSigner;
+
+    fn random_signer() -> Arc<dyn SignerService> {
+        Arc::new(LocalSigner::random())
+    }
+
+    #[tokio::test]
+    async fn test_multi_signer_uses_primary_pubkey() {
+        let primary = random_signer();
+        let expected = primary.get_pubkey().await.unwrap();
+
+        let multi = MultiSigner::new(primary, vec![random_signer()]);
+        assert_eq!(multi.get_pubkey().await.unwrap(), expected);
+    }
+
+    #[tokio::test]
+    async fn test_multi_signer_signs_with_primary() {
+        let primary = random_signer();
+        let multi = MultiSigner::new(primary.clone(), vec![random_signer()]);
+
+        let input = "deadbeef";
+        let result = multi.sign_transaction(input, false).await.unwrap();
+        let expected = primary.sign_transaction(input, false).await.unwrap();
+        assert_eq!(result, expected);
+    }
+
+    #[tokio::test]
+    async fn test_multi_signer_all_pubkeys_includes_all() {
+        let primary = random_signer();
+        let dep1 = random_signer();
+        let dep2 = random_signer();
+
+        let pk_primary = primary.get_pubkey().await.unwrap();
+        let pk_dep1 = dep1.get_pubkey().await.unwrap();
+        let pk_dep2 = dep2.get_pubkey().await.unwrap();
+
+        let multi = MultiSigner::new(primary, vec![dep1, dep2]);
+        let all = multi.all_pubkeys().await.unwrap();
+
+        assert_eq!(all.len(), 3);
+        assert_eq!(all[0], pk_primary);
+        assert_eq!(all[1], pk_dep1);
+        assert_eq!(all[2], pk_dep2);
+    }
+
+    #[tokio::test]
+    async fn test_multi_signer_empty_deprecated_works() {
+        let primary = random_signer();
+        let pk = primary.get_pubkey().await.unwrap();
+
+        let multi = MultiSigner::new(primary, vec![]);
+        assert_eq!(multi.get_pubkey().await.unwrap(), pk);
+
+        let all = multi.all_pubkeys().await.unwrap();
+        assert_eq!(all.len(), 1);
+        assert_eq!(all[0], pk);
+    }
+}


### PR DESCRIPTION
## Summary

Implements **#60** — key rotation support via `MultiSigner` and `deprecated_signer_keys` config.

### Changes

- **`crates/arkd-core/src/multi_signer.rs`** — New `MultiSigner` struct wrapping a primary signer + deprecated signers. Implements `SignerService` (delegates to primary). Provides `all_pubkeys()` for verification against any key (current or deprecated). Includes 4 unit tests.
- **`crates/arkd-api/src/config.rs`** — Added `deprecated_signer_keys: Vec<String>` to `ServerConfig` with `#[serde(default)]`. Added test.
- **`crates/arkd-core/src/lib.rs`** — Export `multi_signer` module and `MultiSigner`.
- **`config.example.toml`** — Documented `deprecated_signer_keys` option.

### Testing

- `cargo check` ✅
- `cargo test -p arkd-core --lib multi_signer` — 4/4 passed ✅
- `cargo fmt --all` ✅

Closes #60