### PR TITLE
⌨️ ark-cli: command-line client skeleton (#96)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -110,6 +110,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "ark-cli"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "arkd-api"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,7 @@ members = [
     "crates/arkd-scanner",
     "crates/arkd-scheduler",
     "crates/arkd-fee-manager",
+    "crates/ark-cli",
 ]
 
 [dependencies]

--- a/crates/ark-cli/Cargo.toml
+++ b/crates/ark-cli/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ark-cli"
+version = "0.1.0"
+edition = "2021"
+description = "Command-line client for testing arkd-rs interactively"
+
+[[bin]]
+name = "ark-cli"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive"] }
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"
+serde_json = "1"
+tracing = "0.1"
+tracing-subscriber = "0.3"

--- a/crates/ark-cli/src/main.rs
+++ b/crates/ark-cli/src/main.rs
@@ -1,0 +1,163 @@
+use anyhow::Result;
+use clap::{Parser, Subcommand};
+
+/// Command-line client for testing arkd-rs interactively
+#[derive(Parser, Debug)]
+#[command(name = "ark-cli", version, about)]
+pub struct Cli {
+    /// Server URL to connect to
+    #[arg(long, default_value = "http://localhost:50051", global = true)]
+    pub server: String,
+
+    /// Output results as JSON
+    #[arg(long, global = true)]
+    pub json: bool,
+
+    #[command(subcommand)]
+    pub command: Commands,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum Commands {
+    /// Show server info
+    Info,
+    /// Round management commands
+    Round {
+        #[command(subcommand)]
+        action: RoundAction,
+    },
+    /// VTXO management commands
+    Vtxo {
+        #[command(subcommand)]
+        action: VtxoAction,
+    },
+    /// Show server status
+    Status,
+}
+
+#[derive(Subcommand, Debug)]
+pub enum RoundAction {
+    /// List all rounds
+    List,
+    /// Get details for a specific round
+    Get {
+        /// Round identifier
+        id: String,
+    },
+}
+
+#[derive(Subcommand, Debug)]
+pub enum VtxoAction {
+    /// List VTXOs for a public key
+    List {
+        /// Public key to query
+        pubkey: String,
+    },
+}
+
+fn handle_command(cli: &Cli) -> Result<()> {
+    match &cli.command {
+        Commands::Info => {
+            if cli.json {
+                let info = serde_json::json!({
+                    "server": cli.server,
+                    "grpc_client": "TODO — gRPC client not yet implemented",
+                });
+                println!("{}", serde_json::to_string_pretty(&info)?);
+            } else {
+                println!("Server: {}", cli.server);
+                println!("gRPC client: TODO — not yet implemented");
+            }
+        }
+        Commands::Round { action } => match action {
+            RoundAction::List => {
+                if cli.json {
+                    let out =
+                        serde_json::json!({ "rounds": [], "note": "stub — gRPC client TODO" });
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                } else {
+                    println!("[stub] Would list rounds from {}", cli.server);
+                }
+            }
+            RoundAction::Get { id } => {
+                if cli.json {
+                    let out =
+                        serde_json::json!({ "round_id": id, "note": "stub — gRPC client TODO" });
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                } else {
+                    println!("[stub] Would get round {} from {}", id, cli.server);
+                }
+            }
+        },
+        Commands::Vtxo { action } => match action {
+            VtxoAction::List { pubkey } => {
+                if cli.json {
+                    let out = serde_json::json!({ "pubkey": pubkey, "vtxos": [], "note": "stub — gRPC client TODO" });
+                    println!("{}", serde_json::to_string_pretty(&out)?);
+                } else {
+                    println!("[stub] Would list VTXOs for {} from {}", pubkey, cli.server);
+                }
+            }
+        },
+        Commands::Status => {
+            if cli.json {
+                let out = serde_json::json!({ "server": cli.server, "status": "unknown", "note": "stub — gRPC client TODO" });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else {
+                println!("[stub] Would check status of {}", cli.server);
+            }
+        }
+    }
+    Ok(())
+}
+
+#[tokio::main]
+async fn main() -> Result<()> {
+    tracing_subscriber::fmt::init();
+    let cli = Cli::parse();
+    handle_command(&cli)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn test_cli_info_command_exists() {
+        let cli = Cli::parse_from(["ark-cli", "info"]);
+        assert!(matches!(cli.command, Commands::Info));
+    }
+
+    #[test]
+    fn test_cli_round_list_command_exists() {
+        let cli = Cli::parse_from(["ark-cli", "round", "list"]);
+        assert!(matches!(
+            cli.command,
+            Commands::Round {
+                action: RoundAction::List
+            }
+        ));
+    }
+
+    #[test]
+    fn test_cli_default_server() {
+        let cli = Cli::parse_from(["ark-cli", "info"]);
+        assert_eq!(cli.server, "http://localhost:50051");
+    }
+
+    #[test]
+    fn test_cli_json_flag() {
+        let cli = Cli::parse_from(["ark-cli", "--json", "info"]);
+        assert!(cli.json);
+    }
+
+    #[test]
+    fn test_cli_help_does_not_panic() {
+        // Verify the CLI can be built without panicking
+        let result = Cli::try_parse_from(["ark-cli", "--help"]);
+        // --help causes an early exit / error, but should not panic
+        assert!(result.is_err());
+    }
+}


### PR DESCRIPTION
## Summary
Adds `crates/ark-cli/` — a command-line client for testing arkd-rs interactively.

## What
- `ark-cli info` — print server URL (gRPC client TODO)
- `ark-cli round list` / `round get <id>` — stubs
- `ark-cli vtxo list <pubkey>` — stub
- `ark-cli status` — stub
- `--server` flag (default `http://localhost:50051`)
- `--json` flag for JSON output
- 5 unit tests

No actual gRPC calls yet — those come after proto client generation.

Closes #96