### PR TITLE
🔄 Round execution: real start_round + finalize logic (#94)

### DIFF
--- a/crates/arkd-core/src/application.rs
+++ b/crates/arkd-core/src/application.rs
@@ -248,6 +248,7 @@ impl ArkService {
                 round_id: round.id.clone(),
                 commitment_tx: round.commitment_tx.clone(),
                 timestamp: round.ending_timestamp,
+                vtxo_count: round.vtxo_tree.len() as u32,
             })
             .await?;
 


### PR DESCRIPTION
## Summary

Implements **Issue #94**: adds real `finalize_round()` logic to `ArkService`.

### Changes
- Added `ArkService::finalize_round()` method that:
  1. Collects pending intents from the active round
  2. Skips (fails) the round if no intents are registered
  3. Transitions to finalization stage
  4. Calls `tx_builder.build_commitment_tx()` to build the commitment transaction
  5. Stores commitment tx, VTXO tree, connectors on the round
  6. Emits `ArkEvent::RoundFinalized`
  7. Marks the round as successfully ended

### Tests (3 new)
- `test_finalize_round_with_intents` — happy path: register intent → finalize → commitment tx stored, RoundFinalized emitted
- `test_finalize_round_no_intents_skips` — empty round is failed with reason, no RoundFinalized event
- `test_finalize_round_without_active_round_errors` — calling finalize with no active round returns error

Closes #94