### PR TITLE
🚀 Release pipeline: cross-platform binaries + Docker image (#35)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,109 @@
+name: Release
+
+on:
+  release:
+    types: [released]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build-binaries:
+    name: Build ${{ matrix.target }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        include:
+          - target: x86_64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: arkd
+            asset_name: arkd-linux-amd64
+          - target: aarch64-unknown-linux-gnu
+            os: ubuntu-latest
+            binary: arkd
+            asset_name: arkd-linux-arm64
+          - target: x86_64-apple-darwin
+            os: macos-latest
+            binary: arkd
+            asset_name: arkd-macos-amd64
+          - target: aarch64-apple-darwin
+            os: macos-latest
+            binary: arkd
+            asset_name: arkd-macos-arm64
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: |
+          if [ "${{ matrix.os }}" = "ubuntu-latest" ]; then
+            sudo apt-get update && sudo apt-get install -y protobuf-compiler
+          else
+            brew install protobuf
+          fi
+
+      - name: Install Rust
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: ${{ matrix.target }}
+
+      - name: Install cross (for Linux cross-compilation)
+        if: matrix.os == 'ubuntu-latest'
+        run: cargo install cross --git https://github.com/cross-rs/cross
+
+      - name: Build (Linux via cross)
+        if: matrix.os == 'ubuntu-latest'
+        run: cross build --release --target ${{ matrix.target }} --bin arkd
+
+      - name: Build (macOS native)
+        if: matrix.os == 'macos-latest'
+        run: cargo build --release --target ${{ matrix.target }} --bin arkd
+
+      - name: Upload binary
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ github.event.release.upload_url }}
+          asset_path: target/${{ matrix.target }}/release/${{ matrix.binary }}
+          asset_name: ${{ matrix.asset_name }}
+          asset_content_type: application/octet-stream
+
+  docker:
+    name: Build and push Docker image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max


### PR DESCRIPTION
## Summary

Implements **Issue #35**: Release pipeline triggered on GitHub Release (`released` event).

### What this adds

- **`.github/workflows/release.yml`** — new workflow that:
  - Builds cross-platform binaries (linux-amd64, linux-arm64, macos-amd64, macos-arm64) using `cross` for Linux targets and native `cargo` for macOS
  - Uploads binaries as release assets
  - Builds and pushes multi-arch Docker image to GHCR with semver tags
  - Uses GHA cache for Docker layer caching

### Notes

- Dockerfile already existed — no changes needed there
- No Rust code changes; CI should pass without compilation
- `protoc` installation step added for both Linux and macOS build environments

Closes #35