### PR TITLE
🔒 Trivy container security scan in CI (#36)

### DIFF
--- a/.github/workflows/trivy.yml
+++ b/.github/workflows/trivy.yml
@@ -1,0 +1,38 @@
+name: Trivy Security Scan
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  trivy:
+    name: Trivy container scan
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Build Docker image
+        run: docker build -t arkd-rs:trivy-scan .
+
+      - name: Run Trivy vulnerability scanner
+        uses: aquasecurity/trivy-action@master
+        with:
+          image-ref: arkd-rs:trivy-scan
+          format: sarif
+          output: trivy-results.sarif
+          severity: CRITICAL,HIGH
+          exit-code: '1'
+          ignore-unfixed: true
+
+      - name: Upload SARIF to GitHub Security tab
+        uses: github/codeql-action/upload-sarif@v3
+        if: always()
+        with:
+          sarif_file: trivy-results.sarif


### PR DESCRIPTION
## Summary

Adds a Trivy container vulnerability scanner as a new CI workflow.

Closes #36

### What it does
- Builds the Docker image from the existing `Dockerfile`
- Runs Trivy to scan for CRITICAL and HIGH CVEs
- Fails the check (`exit-code: 1`) on any unfixed CRITICAL/HIGH vulnerability
- Uploads SARIF results to the GitHub Security tab
- Ignores unfixed vulnerabilities (no noise from upstream issues)

### Design decisions
- **Separate workflow file** (`trivy.yml`) — does not affect the existing CI checks
- **Runs on push to main + PRs** — catches issues before merge
- **SARIF upload** — integrates with GitHub Advanced Security for browsable results
- Uses the existing multi-stage `Dockerfile` (no new Dockerfile needed)