### PR TITLE
🏗️ Client SDK: arkd-client crate (#63)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -129,12 +129,12 @@ dependencies = [
  "arkd-core",
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bitcoin",
  "hex",
  "macaroon",
- "prost",
+ "prost 0.13.5",
  "reqwest 0.12.28",
  "serde",
  "serde_json",
@@ -143,7 +143,7 @@ dependencies = [
  "tokio-stream",
  "tokio-test",
  "tokio-util",
- "tonic",
+ "tonic 0.12.3",
  "tonic-build",
  "tonic-web",
  "tower 0.5.3",
@@ -166,6 +166,20 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-test",
+]
+
+[[package]]
+name = "arkd-client"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "prost 0.12.6",
+ "serde",
+ "serde_json",
+ "thiserror 1.0.69",
+ "tokio",
+ "tonic 0.11.0",
+ "tracing",
 ]
 
 [[package]]
@@ -269,7 +283,7 @@ dependencies = [
  "criterion",
  "hex",
  "proptest",
- "prost",
+ "prost 0.13.5",
  "redis 0.27.6",
  "secp256k1 0.29.1",
  "serde",
@@ -280,7 +294,7 @@ dependencies = [
  "tokio",
  "tokio-test",
  "toml",
- "tonic",
+ "tonic 0.12.3",
  "tonic-build",
  "tracing",
  "tracing-subscriber",
@@ -406,12 +420,40 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.6.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b829e4e32b91e643de6eafe82b1d90675f5874230191a4ffbc1b336dec4d6bf"
+dependencies = [
+ "async-trait",
+ "axum-core 0.3.4",
+ "bitflags 1.3.2",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "itoa",
+ "matchit",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "sync_wrapper 0.1.2",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
 dependencies = [
  "async-trait",
- "axum-core",
+ "axum-core 0.4.5",
  "bytes",
  "futures-util",
  "http 1.4.0",
@@ -436,6 +478,23 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "759fa577a247914fd3f7f76d62972792636412fbfd634cd452f6a385a74d2d2c"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "mime",
+ "rustversion",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]
@@ -1687,6 +1746,18 @@ dependencies = [
 
 [[package]]
 name = "hyper-timeout"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb958482e8c7be4bc3cf272a766a2b0bf1a6755e7a6ae777f017a31d11b13b1"
+dependencies = [
+ "hyper 0.14.32",
+ "pin-project-lite",
+ "tokio",
+ "tokio-io-timeout",
+]
+
+[[package]]
+name = "hyper-timeout"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
@@ -2640,12 +2711,22 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "deb1435c188b76130da55f17a466d252ff7b1418b2ad3e037d127b94e3411f29"
+dependencies = [
+ "bytes",
+ "prost-derive 0.12.6",
+]
+
+[[package]]
+name = "prost"
 version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.13.5",
 ]
 
 [[package]]
@@ -2661,11 +2742,24 @@ dependencies = [
  "once_cell",
  "petgraph",
  "prettyplease",
- "prost",
+ "prost 0.13.5",
  "prost-types",
  "regex",
  "syn",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.12.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81bddcdb20abf9501610992b6759a4c888aef7d1a7247ef75e2404275ac24af1"
+dependencies = [
+ "anyhow",
+ "itertools 0.10.5",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2687,7 +2781,7 @@ version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
 dependencies = [
- "prost",
+ "prost 0.13.5",
 ]
 
 [[package]]
@@ -3911,6 +4005,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-io-timeout"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0bd86198d9ee903fedd2f9a2e72014287c0d9167e4ae43b5853007205dda1b76"
+dependencies = [
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
 name = "tokio-macros"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4042,13 +4146,40 @@ checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
 
 [[package]]
 name = "tonic"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76c4eb7a4e9ef9d4763600161f12f5070b92a578e1b634db88a6887844c91a13"
+dependencies = [
+ "async-stream",
+ "async-trait",
+ "axum 0.6.20",
+ "base64 0.21.7",
+ "bytes",
+ "h2 0.3.27",
+ "http 0.2.12",
+ "http-body 0.4.6",
+ "hyper 0.14.32",
+ "hyper-timeout 0.4.1",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.12.6",
+ "tokio",
+ "tokio-stream",
+ "tower 0.4.13",
+ "tower-layer",
+ "tower-service",
+ "tracing",
+]
+
+[[package]]
+name = "tonic"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "877c5b330756d856ffcc4553ab34a5684481ade925ecc54bcd1bf02b1d0d4d52"
 dependencies = [
  "async-stream",
  "async-trait",
- "axum",
+ "axum 0.7.9",
  "base64 0.22.1",
  "bytes",
  "h2 0.4.13",
@@ -4056,11 +4187,11 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.8.1",
- "hyper-timeout",
+ "hyper-timeout 0.5.2",
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "prost",
+ "prost 0.13.5",
  "rustls-pemfile 2.2.0",
  "socket2 0.5.10",
  "tokio",
@@ -4099,7 +4230,7 @@ dependencies = [
  "http-body-util",
  "pin-project",
  "tokio-stream",
- "tonic",
+ "tonic 0.12.3",
  "tower-http 0.5.2",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "crates/arkd-scheduler",
     "crates/arkd-fee-manager",
     "crates/ark-cli",
+    "crates/arkd-client",
     "crates/arkd-nostr",
 ]
 

--- a/crates/arkd-client/Cargo.toml
+++ b/crates/arkd-client/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "arkd-client"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+tonic = { version = "0.11", features = ["transport"] }
+tokio = { version = "1", features = ["full"] }
+anyhow = "1"
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+tracing = "0.1"
+prost = "0.12"
+thiserror = "1"

--- a/crates/arkd-client/src/client.rs
+++ b/crates/arkd-client/src/client.rs
@@ -1,0 +1,99 @@
+use crate::error::{ClientError, ClientResult};
+use crate::types::{Intent, ServerInfo, TxResult, Vtxo};
+
+/// Client for communicating with an arkd-rs server.
+pub struct ArkClient {
+    server_url: String,
+}
+
+impl ArkClient {
+    /// Create a new client connected to `server_url` (e.g. `http://localhost:50051`).
+    pub fn new(server_url: impl Into<String>) -> Self {
+        Self {
+            server_url: server_url.into(),
+        }
+    }
+
+    pub fn server_url(&self) -> &str {
+        &self.server_url
+    }
+
+    /// Get server info. (stub — real gRPC call once proto client is generated)
+    pub async fn get_info(&self) -> ClientResult<ServerInfo> {
+        // TODO: real tonic client call
+        // For now return a stub to show the API shape
+        Err(ClientError::Connection(format!(
+            "gRPC client not yet wired to {}: use grpcurl for now",
+            self.server_url
+        )))
+    }
+
+    /// List VTXOs owned by `pubkey`.
+    pub async fn list_vtxos(&self, _pubkey: &str) -> ClientResult<Vec<Vtxo>> {
+        Err(ClientError::Connection("gRPC client not yet wired".into()))
+    }
+
+    /// Register an intent to receive VTXOs in the next round.
+    pub async fn register_intent(&self, _intent: Intent) -> ClientResult<String> {
+        Err(ClientError::Connection("gRPC client not yet wired".into()))
+    }
+
+    /// Submit an offchain transaction.
+    pub async fn submit_tx(&self, _tx_hex: &str) -> ClientResult<TxResult> {
+        Err(ClientError::Connection("gRPC client not yet wired".into()))
+    }
+
+    /// Board: register a new VTXO from an on-chain output.
+    pub async fn board(
+        &self,
+        _txid: &str,
+        _vout: u32,
+        _amount: u64,
+        _pubkey: &str,
+    ) -> ClientResult<String> {
+        Err(ClientError::Connection("gRPC client not yet wired".into()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_client_new() {
+        let c = ArkClient::new("http://localhost:50051");
+        assert_eq!(c.server_url(), "http://localhost:50051");
+    }
+
+    #[test]
+    fn test_client_url_stored() {
+        let c = ArkClient::new("http://192.168.1.1:50051");
+        assert!(c.server_url().contains("192.168.1.1"));
+    }
+
+    #[tokio::test]
+    async fn test_get_info_returns_error_when_not_connected() {
+        let c = ArkClient::new("http://localhost:50051");
+        assert!(c.get_info().await.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_list_vtxos_returns_error_when_not_connected() {
+        let c = ArkClient::new("http://localhost:50051");
+        assert!(c.list_vtxos("pubkey123").await.is_err());
+    }
+
+    #[test]
+    fn test_server_info_serde() {
+        let info = crate::types::ServerInfo {
+            pubkey: "abc".into(),
+            network: "regtest".into(),
+            round_lifetime: 512,
+            unilateral_exit_delay: 1024,
+            version: "0.1.0".into(),
+        };
+        let j = serde_json::to_string(&info).unwrap();
+        let info2: crate::types::ServerInfo = serde_json::from_str(&j).unwrap();
+        assert_eq!(info2.network, "regtest");
+    }
+}

--- a/crates/arkd-client/src/error.rs
+++ b/crates/arkd-client/src/error.rs
@@ -1,0 +1,15 @@
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+pub enum ClientError {
+    #[error("Connection failed: {0}")]
+    Connection(String),
+    #[error("RPC error: {0}")]
+    Rpc(String),
+    #[error("Invalid response: {0}")]
+    InvalidResponse(String),
+    #[error("Serialization error: {0}")]
+    Serialization(String),
+}
+
+pub type ClientResult<T> = Result<T, ClientError>;

--- a/crates/arkd-client/src/lib.rs
+++ b/crates/arkd-client/src/lib.rs
@@ -1,0 +1,7 @@
+//! arkd-client — gRPC client library for arkd-rs.
+//!
+//! Provides a typed Rust client for the Ark protocol server.
+
+pub mod client;
+pub mod error;
+pub mod types;

--- a/crates/arkd-client/src/types.rs
+++ b/crates/arkd-client/src/types.rs
@@ -1,0 +1,37 @@
+use serde::{Deserialize, Serialize};
+
+/// Server information returned by GetInfo.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ServerInfo {
+    pub pubkey: String,
+    pub network: String,
+    pub round_lifetime: u32,
+    pub unilateral_exit_delay: u32,
+    pub version: String,
+}
+
+/// A VTXO owned by a pubkey.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Vtxo {
+    pub id: String,
+    pub txid: String,
+    pub vout: u32,
+    pub amount: u64,
+    pub pubkey: String,
+    pub expiry_at: u64,
+    pub is_note: bool,
+}
+
+/// A round registration intent.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Intent {
+    pub amount: u64,
+    pub receiver_pubkey: String,
+}
+
+/// Result of submitting an offchain transaction.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxResult {
+    pub tx_id: String,
+    pub status: String,
+}


### PR DESCRIPTION
Implements #63 — adds the arkd-client crate.

- ArkClient with async stubs: get_info, list_vtxos, register_intent, submit_tx, board
- Types: ServerInfo, Vtxo, Intent, TxResult (serde)
- ClientError enum with thiserror
- 5 unit tests

Closes #63