### PR TITLE
⌨️ ark-cli: board, send, receive, list-vtxos, exit commands (#64)

### DIFF
--- a/crates/ark-cli/src/main.rs
+++ b/crates/ark-cli/src/main.rs
@@ -33,6 +33,37 @@ pub enum Commands {
     },
     /// Show server status
     Status,
+    /// Register an on-chain UTXO as a VTXO (boarding)
+    Board {
+        /// Transaction ID of the on-chain UTXO
+        txid: String,
+        /// Output index
+        vout: u32,
+        /// Amount in satoshis
+        amount: u64,
+        /// Receiver pubkey (hex)
+        pubkey: String,
+    },
+    /// Send VTXOs to a recipient
+    Send {
+        /// Recipient pubkey (hex)
+        to: String,
+        /// Amount in satoshis
+        amount: u64,
+    },
+    /// Show receive pubkey/address
+    Receive,
+    /// List all VTXOs for this wallet
+    ListVtxos {
+        /// Filter by pubkey (optional)
+        #[arg(long)]
+        pubkey: Option<String>,
+    },
+    /// Unilateral exit to on-chain
+    Exit {
+        /// VTXO ID to exit
+        vtxo_id: String,
+    },
 }
 
 #[derive(Subcommand, Debug)]
@@ -99,6 +130,96 @@ fn handle_command(cli: &Cli) -> Result<()> {
                 }
             }
         },
+        Commands::Board {
+            txid,
+            vout,
+            amount,
+            pubkey,
+        } => {
+            if cli.json {
+                let out = serde_json::json!({
+                    "command": "board",
+                    "txid": txid,
+                    "vout": vout,
+                    "amount": amount,
+                    "pubkey": pubkey,
+                    "server": cli.server,
+                    "note": "stub — gRPC client TODO"
+                });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else {
+                println!(
+                    "Board: would register UTXO {}:{} ({} sats) for pubkey {} via {}",
+                    txid, vout, amount, pubkey, cli.server
+                );
+            }
+        }
+        Commands::Send { to, amount } => {
+            if cli.json {
+                let out = serde_json::json!({
+                    "command": "send",
+                    "to": to,
+                    "amount": amount,
+                    "server": cli.server,
+                    "note": "stub — gRPC client TODO"
+                });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else {
+                println!(
+                    "Send: would transfer {} sats to {} via {}",
+                    amount, to, cli.server
+                );
+            }
+        }
+        Commands::Receive => {
+            if cli.json {
+                let out = serde_json::json!({
+                    "command": "receive",
+                    "server": cli.server,
+                    "note": "stub — gRPC client TODO"
+                });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else {
+                println!(
+                    "Receive: would return pubkey/address for {} — gRPC not yet wired",
+                    cli.server
+                );
+            }
+        }
+        Commands::ListVtxos { pubkey } => {
+            let filter = pubkey.as_deref().unwrap_or("(all)");
+            if cli.json {
+                let out = serde_json::json!({
+                    "command": "list-vtxos",
+                    "pubkey_filter": filter,
+                    "vtxos": [],
+                    "server": cli.server,
+                    "note": "stub — gRPC client TODO"
+                });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else {
+                println!(
+                    "ListVtxos: would list VTXOs for pubkey={} via {}",
+                    filter, cli.server
+                );
+            }
+        }
+        Commands::Exit { vtxo_id } => {
+            if cli.json {
+                let out = serde_json::json!({
+                    "command": "exit",
+                    "vtxo_id": vtxo_id,
+                    "server": cli.server,
+                    "note": "stub — gRPC client TODO"
+                });
+                println!("{}", serde_json::to_string_pretty(&out)?);
+            } else {
+                println!(
+                    "Exit: would initiate unilateral exit for VTXO {} via {}",
+                    vtxo_id, cli.server
+                );
+            }
+        }
         Commands::Status => {
             if cli.json {
                 let out = serde_json::json!({ "server": cli.server, "status": "unknown", "note": "stub — gRPC client TODO" });
@@ -151,6 +272,46 @@ mod tests {
     fn test_cli_json_flag() {
         let cli = Cli::parse_from(["ark-cli", "--json", "info"]);
         assert!(cli.json);
+    }
+
+    #[test]
+    fn test_cli_board_command_exists() {
+        let cli = Cli::parse_from(["ark-cli", "board", "abc123", "0", "100000", "02deadbeef"]);
+        assert!(matches!(cli.command, Commands::Board { .. }));
+    }
+
+    #[test]
+    fn test_cli_send_command_exists() {
+        let cli = Cli::parse_from(["ark-cli", "send", "02deadbeef", "50000"]);
+        assert!(matches!(cli.command, Commands::Send { .. }));
+    }
+
+    #[test]
+    fn test_cli_receive_command_exists() {
+        let cli = Cli::parse_from(["ark-cli", "receive"]);
+        assert!(matches!(cli.command, Commands::Receive));
+    }
+
+    #[test]
+    fn test_cli_list_vtxos_command_exists() {
+        let cli = Cli::parse_from(["ark-cli", "list-vtxos"]);
+        assert!(matches!(cli.command, Commands::ListVtxos { .. }));
+    }
+
+    #[test]
+    fn test_cli_list_vtxos_with_pubkey_filter() {
+        let cli = Cli::parse_from(["ark-cli", "list-vtxos", "--pubkey", "02abc"]);
+        if let Commands::ListVtxos { pubkey } = &cli.command {
+            assert_eq!(pubkey.as_deref(), Some("02abc"));
+        } else {
+            panic!("Expected ListVtxos command");
+        }
+    }
+
+    #[test]
+    fn test_cli_exit_command_exists() {
+        let cli = Cli::parse_from(["ark-cli", "exit", "vtxo-id-123"]);
+        assert!(matches!(cli.command, Commands::Exit { .. }));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Expands ark-cli with the full command set per Issue #64:

- `board` — register on-chain UTXO as VTXO (boarding)
- `send` — send VTXOs to a recipient pubkey
- `receive` — show receive pubkey/address
- `list-vtxos` — list all VTXOs for wallet (with optional `--pubkey` filter)
- `exit` — unilateral exit to on-chain

All commands are stubs (print what they would do) with `--json` output support, matching the existing pattern from PR #102.

## Tests

6 new tests added (11 total, all passing):
- `test_cli_board_command_exists`
- `test_cli_send_command_exists`
- `test_cli_receive_command_exists`
- `test_cli_list_vtxos_command_exists`
- `test_cli_list_vtxos_with_pubkey_filter`
- `test_cli_exit_command_exists`

Closes #64