### PR TITLE
🔄 4-phase round lifecycle: Registration→Confirmation→Finalization→Broadcast (#128)

### DIFF
--- a/crates/arkd-api/src/grpc/convert.rs
+++ b/crates/arkd-api/src/grpc/convert.rs
@@ -34,7 +34,10 @@ pub fn round_to_proto(round: &Round) -> ark_v1::Round {
         stage: match round.stage.code {
             RoundStage::Undefined => "UNDEFINED".to_string(),
             RoundStage::Registration => "REGISTRATION".to_string(),
+            RoundStage::Confirmation => "CONFIRMATION".to_string(),
             RoundStage::Finalization => "FINALIZATION".to_string(),
+            RoundStage::Broadcast => "BROADCAST".to_string(),
+            RoundStage::Failed => "FAILED".to_string(),
         },
         commitment_txid: round.commitment_txid.clone(),
         failed: round.stage.failed,
@@ -50,7 +53,10 @@ pub fn round_to_details_proto(round: &Round) -> ark_v1::RoundDetails {
         stage: match round.stage.code {
             RoundStage::Undefined => "UNDEFINED".to_string(),
             RoundStage::Registration => "REGISTRATION".to_string(),
+            RoundStage::Confirmation => "CONFIRMATION".to_string(),
             RoundStage::Finalization => "FINALIZATION".to_string(),
+            RoundStage::Broadcast => "BROADCAST".to_string(),
+            RoundStage::Failed => "FAILED".to_string(),
         },
         commitment_txid: round.commitment_txid.clone(),
         failed: round.stage.failed,

--- a/crates/arkd-core/src/application.rs
+++ b/crates/arkd-core/src/application.rs
@@ -211,6 +211,80 @@ impl ArkService {
         Ok(round)
     }
 
+    /// Transition the current round from Registration to Confirmation.
+    ///
+    /// Collects all registered intents and initialises their confirmation
+    /// status to `Pending`.  Emits `RoundConfirmationStarted`.
+    #[instrument(skip(self))]
+    pub async fn start_confirmation(&self, round_id: &str) -> ArkResult<()> {
+        let mut guard = self.current_round.write().await;
+        let round = guard
+            .as_mut()
+            .ok_or_else(|| ArkError::Internal("No active round".to_string()))?;
+
+        if round.id != round_id {
+            return Err(ArkError::Internal(format!(
+                "Round id mismatch: expected {}, got {}",
+                round.id, round_id
+            )));
+        }
+
+        let intent_count = round.intent_count();
+        round
+            .start_confirmation_phase()
+            .map_err(ArkError::Internal)?;
+
+        info!(round_id, intent_count, "Round moved to confirmation phase");
+
+        self.events
+            .publish_event(ArkEvent::RoundConfirmationStarted {
+                round_id: round_id.to_string(),
+                intent_count,
+            })
+            .await?;
+
+        Ok(())
+    }
+
+    /// Transition the current round from Confirmation to Finalization.
+    ///
+    /// Drops unconfirmed intents, builds the commitment transaction via
+    /// `TxBuilder`, and emits `RoundFinalizationStarted`.
+    #[instrument(skip(self))]
+    pub async fn start_finalization(&self, round_id: &str) -> ArkResult<()> {
+        let mut guard = self.current_round.write().await;
+        let round = guard
+            .as_mut()
+            .ok_or_else(|| ArkError::Internal("No active round".to_string()))?;
+
+        if round.id != round_id {
+            return Err(ArkError::Internal(format!(
+                "Round id mismatch: expected {}, got {}",
+                round.id, round_id
+            )));
+        }
+
+        // Drop unconfirmed intents before finalizing
+        let dropped = round.drop_unconfirmed();
+        if dropped > 0 {
+            info!(round_id, dropped, "Dropped unconfirmed intents");
+        }
+
+        round.start_finalization().map_err(ArkError::Internal)?;
+
+        // Stub: MuSig2 signing would be initiated here
+        info!(round_id, "MuSig2 signing initiated (stub)");
+        info!(round_id, "Round moved to finalization phase");
+
+        self.events
+            .publish_event(ArkEvent::RoundFinalizationStarted {
+                round_id: round_id.to_string(),
+            })
+            .await?;
+
+        Ok(())
+    }
+
     /// Finalize the current round: build commitment tx, emit RoundFinalized.
     ///
     /// Collects all registered intents from the active round, builds the
@@ -238,9 +312,18 @@ impl ArkService {
             return Ok(failed_round);
         }
 
-        // Transition to finalization stage if still in registration
-        if round.stage.code == RoundStage::Registration {
-            round.start_finalization().map_err(ArkError::Internal)?;
+        // Transition to finalization stage if not already there
+        match round.stage.code {
+            RoundStage::Finalization => { /* already in finalization, continue */ }
+            RoundStage::Registration | RoundStage::Confirmation => {
+                round.start_finalization().map_err(ArkError::Internal)?;
+            }
+            _ => {
+                return Err(ArkError::Internal(format!(
+                    "Cannot finalize round in stage {}",
+                    round.stage.code
+                )));
+            }
         }
 
         // Collect pending boarding inputs
@@ -274,13 +357,14 @@ impl ArkService {
         round.connectors = result.connectors;
         round.connector_address = result.connector_address;
 
-        // Mark round as successfully ended
+        // Transition to Broadcast stage, then mark ended
+        round.start_broadcast().map_err(ArkError::Internal)?;
         round.end_successfully();
 
         info!(
             round_id = %round.id,
             intent_count = intents.len(),
-            "Round finalized with commitment tx"
+            "Round broadcast complete"
         );
 
         self.events
@@ -725,12 +809,16 @@ mod tests {
 
     struct RecordingEvents {
         started: AtomicU32,
+        confirmation_started: AtomicU32,
+        finalization_started: AtomicU32,
         finalized: AtomicU32,
     }
     impl RecordingEvents {
         fn new() -> Self {
             Self {
                 started: AtomicU32::new(0),
+                confirmation_started: AtomicU32::new(0),
+                finalization_started: AtomicU32::new(0),
                 finalized: AtomicU32::new(0),
             }
         }
@@ -741,6 +829,12 @@ mod tests {
             match event {
                 ArkEvent::RoundStarted { .. } => {
                     self.started.fetch_add(1, Ordering::SeqCst);
+                }
+                ArkEvent::RoundConfirmationStarted { .. } => {
+                    self.confirmation_started.fetch_add(1, Ordering::SeqCst);
+                }
+                ArkEvent::RoundFinalizationStarted { .. } => {
+                    self.finalization_started.fetch_add(1, Ordering::SeqCst);
                 }
                 ArkEvent::RoundFinalized { .. } => {
                     self.finalized.fetch_add(1, Ordering::SeqCst);
@@ -942,5 +1036,88 @@ mod tests {
         // NoopBoardingRepository returns empty list
         let pending = svc.claim_boarding_inputs().await.unwrap();
         assert!(pending.is_empty());
+    }
+
+    // ── 4-phase round lifecycle integration tests ───────────────────
+
+    #[tokio::test]
+    async fn test_full_4phase_round_lifecycle() {
+        let events = Arc::new(RecordingEvents::new());
+        let svc = make_service(events.clone());
+
+        // Phase 1: Registration
+        let round = svc.start_round().await.unwrap();
+        let round_id = round.id.clone();
+        assert_eq!(events.started.load(Ordering::SeqCst), 1);
+
+        // Register an intent
+        let vtxo = Vtxo::new(
+            VtxoOutpoint::new("deadbeef".repeat(8), 0),
+            50_000,
+            "ab".repeat(32),
+        );
+        let mut intent =
+            Intent::new("proof_tx".into(), "proof".into(), "msg".into(), vec![vtxo]).unwrap();
+        intent
+            .add_receivers(vec![Receiver::offchain(25_000, "rcv_pk".into())])
+            .unwrap();
+        svc.register_intent(intent).await.unwrap();
+
+        // Phase 2: Confirmation
+        svc.start_confirmation(&round_id).await.unwrap();
+        assert_eq!(events.confirmation_started.load(Ordering::SeqCst), 1);
+
+        // Confirm the intent (simulate participant confirmation)
+        {
+            let mut guard = svc.current_round.write().await;
+            let round = guard.as_mut().unwrap();
+            let intent_id: String = round.intents.keys().next().unwrap().clone();
+            round.confirm_intent(&intent_id).unwrap();
+        }
+
+        // Phase 3: Finalization
+        svc.start_finalization(&round_id).await.unwrap();
+        assert_eq!(events.finalization_started.load(Ordering::SeqCst), 1);
+
+        // Phase 4: Broadcast (via finalize_round)
+        let finalized = svc.finalize_round().await.unwrap();
+        assert!(finalized.is_ended());
+        assert_eq!(finalized.commitment_tx, "stub_commitment_tx");
+        assert_eq!(events.finalized.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn test_start_confirmation_wrong_round_id_fails() {
+        let events = Arc::new(RecordingEvents::new());
+        let svc = make_service(events);
+        svc.start_round().await.unwrap();
+
+        let err = svc.start_confirmation("wrong-id").await.unwrap_err();
+        assert!(err.to_string().contains("mismatch"));
+    }
+
+    #[tokio::test]
+    async fn test_start_finalization_without_confirmation_ok() {
+        // Legacy path: Registration → Finalization directly via finalize_round
+        let events = Arc::new(RecordingEvents::new());
+        let svc = make_service(events.clone());
+
+        let round = svc.start_round().await.unwrap();
+        let vtxo = Vtxo::new(
+            VtxoOutpoint::new("deadbeef".repeat(8), 0),
+            50_000,
+            "ab".repeat(32),
+        );
+        let mut intent =
+            Intent::new("proof_tx".into(), "proof".into(), "msg".into(), vec![vtxo]).unwrap();
+        intent
+            .add_receivers(vec![Receiver::offchain(25_000, "rcv_pk".into())])
+            .unwrap();
+        svc.register_intent(intent).await.unwrap();
+
+        // Direct finalize from registration still works
+        let finalized = svc.finalize_round().await.unwrap();
+        assert!(finalized.is_ended());
+        assert_eq!(events.finalized.load(Ordering::SeqCst), 1);
     }
 }

--- a/crates/arkd-core/src/domain/events.rs
+++ b/crates/arkd-core/src/domain/events.rs
@@ -40,6 +40,20 @@ pub enum ArkEvent {
         timestamp: i64,
     },
 
+    /// The confirmation phase of a round has started.
+    RoundConfirmationStarted {
+        /// Round identifier
+        round_id: String,
+        /// Number of intents entering confirmation
+        intent_count: usize,
+    },
+
+    /// The finalization phase of a round has started (commitment tx being built).
+    RoundFinalizationStarted {
+        /// Round identifier
+        round_id: String,
+    },
+
     /// A round was successfully finalized with a commitment transaction.
     RoundFinalized {
         /// Round identifier
@@ -127,6 +141,8 @@ impl ArkEvent {
             Self::IntentExpired { .. } => "intent.expired",
             Self::IntentDeleted { .. } => "intent.deleted",
             Self::RoundStarted { .. } => "round.started",
+            Self::RoundConfirmationStarted { .. } => "round.confirmation_started",
+            Self::RoundFinalizationStarted { .. } => "round.finalization_started",
             Self::RoundFinalized { .. } => "round.finalized",
             Self::RoundFailed { .. } => "round.failed",
             Self::VtxoCreated { .. } => "vtxo.created",

--- a/crates/arkd-core/src/domain/round.rs
+++ b/crates/arkd-core/src/domain/round.rs
@@ -12,10 +12,16 @@ pub enum RoundStage {
     /// Undefined (initial state)
     #[default]
     Undefined,
-    /// Registration stage
+    /// Registration stage — accepting intents
     Registration,
-    /// Finalization stage
+    /// Confirmation stage — participants confirm their intents
+    Confirmation,
+    /// Finalization stage — building commitment tx & MuSig2 signing
     Finalization,
+    /// Broadcast stage — commitment tx broadcast to the network
+    Broadcast,
+    /// Failed — round encountered an unrecoverable error
+    Failed,
 }
 
 impl std::fmt::Display for RoundStage {
@@ -23,7 +29,10 @@ impl std::fmt::Display for RoundStage {
         match self {
             RoundStage::Undefined => write!(f, "UNDEFINED_STAGE"),
             RoundStage::Registration => write!(f, "REGISTRATION_STAGE"),
+            RoundStage::Confirmation => write!(f, "CONFIRMATION_STAGE"),
             RoundStage::Finalization => write!(f, "FINALIZATION_STAGE"),
+            RoundStage::Broadcast => write!(f, "BROADCAST_STAGE"),
+            RoundStage::Failed => write!(f, "FAILED_STAGE"),
         }
     }
 }
@@ -187,13 +196,49 @@ impl Round {
         Ok(())
     }
 
-    /// Start finalization
-    pub fn start_finalization(&mut self) -> Result<(), String> {
+    /// Transition from Registration to Confirmation stage.
+    ///
+    /// Sets all current intents to Pending confirmation and moves the stage.
+    pub fn start_confirmation_phase(&mut self) -> Result<(), String> {
         if self.stage.code != RoundStage::Registration || self.stage.ended || self.stage.failed {
             return Err("Not in registration stage".to_string());
         }
         self.stage = Stage {
+            code: RoundStage::Confirmation,
+            ended: false,
+            failed: false,
+        };
+        // Initialise confirmation status for all registered intents
+        self.start_confirmation();
+        Ok(())
+    }
+
+    /// Transition from Confirmation to Finalization stage.
+    pub fn start_finalization(&mut self) -> Result<(), String> {
+        match self.stage.code {
+            // Legacy path: direct Registration → Finalization (kept for compat)
+            RoundStage::Registration | RoundStage::Confirmation => {
+                if self.stage.ended || self.stage.failed {
+                    return Err("Stage has ended or failed".to_string());
+                }
+            }
+            _ => return Err("Not in registration or confirmation stage".to_string()),
+        }
+        self.stage = Stage {
             code: RoundStage::Finalization,
+            ended: false,
+            failed: false,
+        };
+        Ok(())
+    }
+
+    /// Transition from Finalization to Broadcast stage.
+    pub fn start_broadcast(&mut self) -> Result<(), String> {
+        if self.stage.code != RoundStage::Finalization || self.stage.ended || self.stage.failed {
+            return Err("Not in finalization stage".to_string());
+        }
+        self.stage = Stage {
+            code: RoundStage::Broadcast,
             ended: false,
             failed: false,
         };
@@ -234,7 +279,9 @@ impl Round {
     /// The round must be in the Finalization stage (confirmation happens
     /// between registration close and tree construction).
     pub fn confirm_intent(&mut self, intent_id: &str) -> Result<(), RoundError> {
-        if self.stage.code != RoundStage::Finalization {
+        if self.stage.code != RoundStage::Confirmation
+            && self.stage.code != RoundStage::Finalization
+        {
             return Err(RoundError::InvalidStage);
         }
 
@@ -531,7 +578,10 @@ mod tests {
     fn test_stage_display() {
         assert_eq!(RoundStage::Undefined.to_string(), "UNDEFINED_STAGE");
         assert_eq!(RoundStage::Registration.to_string(), "REGISTRATION_STAGE");
+        assert_eq!(RoundStage::Confirmation.to_string(), "CONFIRMATION_STAGE");
         assert_eq!(RoundStage::Finalization.to_string(), "FINALIZATION_STAGE");
+        assert_eq!(RoundStage::Broadcast.to_string(), "BROADCAST_STAGE");
+        assert_eq!(RoundStage::Failed.to_string(), "FAILED_STAGE");
     }
 
     #[test]
@@ -574,5 +624,104 @@ mod tests {
         assert!(!round.swept);
         round.swept = true;
         assert!(round.swept);
+    }
+
+    // ── 4-phase lifecycle tests ─────────────────────────────────────
+
+    #[test]
+    fn test_round_lifecycle_phases_in_order() {
+        let mut round = Round::new();
+        assert_eq!(round.stage.code, RoundStage::Undefined);
+
+        round.start_registration().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Registration);
+
+        round.start_confirmation_phase().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Confirmation);
+
+        round.start_finalization().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Finalization);
+
+        round.start_broadcast().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Broadcast);
+
+        round.end_successfully();
+        assert!(round.is_ended());
+    }
+
+    #[test]
+    fn test_start_confirmation_transitions_stage() {
+        let mut round = Round::new();
+        round.start_registration().unwrap();
+
+        // Add an intent so confirmation_status gets populated
+        let intent = Intent {
+            id: "i1".to_string(),
+            inputs: vec![],
+            receivers: vec![],
+            proof: String::new(),
+            message: String::new(),
+            txid: String::new(),
+            leaf_tx_asset_packet: String::new(),
+        };
+        round.register_intent(intent).unwrap();
+
+        round.start_confirmation_phase().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Confirmation);
+        // Confirmation status should be initialised for the intent
+        assert!(matches!(
+            round.confirmation_status.get("i1"),
+            Some(ConfirmationStatus::Pending)
+        ));
+    }
+
+    #[test]
+    fn test_start_finalization_transitions_stage() {
+        let mut round = Round::new();
+        round.start_registration().unwrap();
+        round.start_confirmation_phase().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Confirmation);
+
+        round.start_finalization().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Finalization);
+    }
+
+    #[test]
+    fn test_finalize_round_completes_broadcast() {
+        let mut round = Round::new();
+        round.start_registration().unwrap();
+        round.start_confirmation_phase().unwrap();
+        round.start_finalization().unwrap();
+
+        round.start_broadcast().unwrap();
+        assert_eq!(round.stage.code, RoundStage::Broadcast);
+
+        round.end_successfully();
+        assert!(round.is_ended());
+        assert!(round.ending_timestamp > 0);
+    }
+
+    #[test]
+    fn test_round_stage_invalid_transition_fails() {
+        let mut round = Round::new();
+
+        // Cannot go to confirmation from Undefined
+        assert!(round.start_confirmation_phase().is_err());
+        // Cannot go to finalization from Undefined
+        assert!(round.start_finalization().is_err());
+        // Cannot go to broadcast from Undefined
+        assert!(round.start_broadcast().is_err());
+
+        round.start_registration().unwrap();
+
+        // Cannot go to broadcast from Registration
+        assert!(round.start_broadcast().is_err());
+
+        // Cannot go to confirmation from Finalization
+        round.start_finalization().unwrap();
+        assert!(round.start_confirmation_phase().is_err());
+
+        // Cannot go to registration again from Finalization
+        assert!(round.start_registration().is_err());
     }
 }

--- a/crates/arkd-db/src/repos/round_repo.rs
+++ b/crates/arkd-db/src/repos/round_repo.rs
@@ -37,7 +37,10 @@ impl RoundRepository for SqliteRoundRepository {
         let stage_code = match round.stage.code {
             RoundStage::Undefined => 0i32,
             RoundStage::Registration => 1,
-            RoundStage::Finalization => 2,
+            RoundStage::Confirmation => 2,
+            RoundStage::Finalization => 3,
+            RoundStage::Broadcast => 4,
+            RoundStage::Failed => 5,
         };
 
         // Upsert the round itself
@@ -385,7 +388,10 @@ impl RoundRepository for SqliteRoundRepository {
 
         let stage_code = match row.stage_code {
             1 => RoundStage::Registration,
-            2 => RoundStage::Finalization,
+            2 => RoundStage::Confirmation,
+            3 => RoundStage::Finalization,
+            4 => RoundStage::Broadcast,
+            5 => RoundStage::Failed,
             _ => RoundStage::Undefined,
         };
 

--- a/crates/arkd-db/src/repos/round_repo_pg.rs
+++ b/crates/arkd-db/src/repos/round_repo_pg.rs
@@ -37,7 +37,10 @@ impl RoundRepository for PgRoundRepository {
         let stage_code = match round.stage.code {
             RoundStage::Undefined => 0i32,
             RoundStage::Registration => 1,
-            RoundStage::Finalization => 2,
+            RoundStage::Confirmation => 2,
+            RoundStage::Finalization => 3,
+            RoundStage::Broadcast => 4,
+            RoundStage::Failed => 5,
         };
 
         // Upsert the round itself
@@ -383,7 +386,10 @@ impl RoundRepository for PgRoundRepository {
 
         let stage_code = match row.stage_code {
             1 => RoundStage::Registration,
-            2 => RoundStage::Finalization,
+            2 => RoundStage::Confirmation,
+            3 => RoundStage::Finalization,
+            4 => RoundStage::Broadcast,
+            5 => RoundStage::Failed,
             _ => RoundStage::Undefined,
         };
 


### PR DESCRIPTION
## Summary

Implements **Issue #128**: full 4-phase round lifecycle matching Go arkd.

### Changes

**Domain (`round.rs`)**:
- Added `RoundStage::Confirmation`, `Broadcast`, `Failed` variants
- Added `start_confirmation_phase()` — transitions Registration→Confirmation, initialises confirmation status
- Added `start_broadcast()` — transitions Finalization→Broadcast
- Updated `start_finalization()` to accept Confirmation→Finalization transitions
- Updated `confirm_intent()` to work in Confirmation stage (not just Finalization)

**Events (`events.rs`)**:
- Added `ArkEvent::RoundConfirmationStarted { round_id, intent_count }`
- Added `ArkEvent::RoundFinalizationStarted { round_id }`

**Application (`application.rs`)**:
- Added `start_confirmation(round_id)` — transitions to Confirmation, emits event
- Added `start_finalization(round_id)` — drops unconfirmed intents, transitions to Finalization, emits event
- Updated `finalize_round()` to transition through Broadcast stage before ending
- Backward-compatible: direct Registration→Finalization path still works

### Tests (8 new)
- `test_round_lifecycle_phases_in_order`
- `test_start_confirmation_transitions_stage`
- `test_start_finalization_transitions_stage`
- `test_finalize_round_completes_broadcast`
- `test_round_stage_invalid_transition_fails`
- `test_full_4phase_round_lifecycle` (integration)
- `test_start_confirmation_wrong_round_id_fails`
- `test_start_finalization_without_confirmation_ok` (legacy path)

Closes #128