### PR TITLE
🧹 Production sweeper service (#132)

### DIFF
--- a/crates/arkd-core/src/application.rs
+++ b/crates/arkd-core/src/application.rs
@@ -19,8 +19,8 @@ use crate::ports::{
     ArkEvent, BoardingRepository, CacheService, CheckpointRepository, ConfirmationStore,
     EventPublisher, ForfeitRepository, FraudDetector, NoopBoardingRepository,
     NoopCheckpointRepository, NoopConfirmationStore, NoopForfeitRepository, NoopFraudDetector,
-    NoopOffchainTxRepository, OffchainTxRepository, SignerService, TxBuilder, VtxoRepository,
-    WalletService,
+    NoopOffchainTxRepository, NoopSweepService, OffchainTxRepository, SignerService, SweepService,
+    TxBuilder, VtxoRepository, WalletService,
 };
 
 /// Round timing configuration (matches Go arkd's `roundTiming`)
@@ -167,6 +167,7 @@ pub struct ArkService {
     fraud_detector: Arc<dyn FraudDetector>,
     confirmation_store: Arc<dyn ConfirmationStore>,
     offchain_tx_repo: Arc<dyn OffchainTxRepository>,
+    sweep_service: Arc<dyn SweepService>,
     config: ArkConfig,
     current_round: RwLock<Option<Round>>,
     /// Active exits indexed by ID
@@ -198,6 +199,7 @@ impl ArkService {
             fraud_detector: Arc::new(NoopFraudDetector),
             confirmation_store: Arc::new(NoopConfirmationStore),
             offchain_tx_repo: Arc::new(NoopOffchainTxRepository),
+            sweep_service: Arc::new(NoopSweepService),
             config,
             current_round: RwLock::new(None),
             exits: RwLock::new(std::collections::HashMap::new()),
@@ -807,6 +809,30 @@ impl ArkService {
         }
         info!(swept_count = swept, "Checkpoint sweep complete");
         Ok(swept)
+    }
+
+    /// Run a scheduled sweep via the pluggable [`SweepService`] port.
+    ///
+    /// If any VTXOs were swept, publishes an [`ArkEvent::SweepCompleted`].
+    pub async fn run_scheduled_sweep(&self, current_height: u32) -> ArkResult<()> {
+        let result = self
+            .sweep_service
+            .sweep_expired_vtxos(current_height)
+            .await?;
+        if result.vtxos_swept > 0 {
+            tracing::info!(
+                vtxos_swept = result.vtxos_swept,
+                sats_recovered = result.sats_recovered,
+                "Sweep complete"
+            );
+            self.events
+                .publish_event(ArkEvent::SweepCompleted {
+                    vtxos_swept: result.vtxos_swept,
+                    sats_recovered: result.sats_recovered,
+                })
+                .await?;
+        }
+        Ok(())
     }
 
     /// Submit a forfeit transaction for persistence.
@@ -1858,6 +1884,51 @@ mod tests {
             let result = svc.submit_offchain_tx(test_inputs(), outputs).await;
             assert!(result.is_err());
             assert!(result.unwrap_err().to_string().contains("dust"));
+        }
+    }
+
+    // ── Sweep service tests ─────────────────────────────────────────
+
+    mod sweep_tests {
+        use super::*;
+        use crate::ports::{NoopSweepService, SweepResult, SweepService};
+
+        #[tokio::test]
+        async fn test_noop_sweep_returns_empty_result() {
+            let svc = NoopSweepService;
+            let result = svc.sweep_expired_vtxos(100).await.unwrap();
+            assert_eq!(result.vtxos_swept, 0);
+            assert_eq!(result.sats_recovered, 0);
+            assert!(result.tx_ids.is_empty());
+
+            let result = svc.sweep_connectors("round-1").await.unwrap();
+            assert_eq!(result.vtxos_swept, 0);
+            assert_eq!(result.sats_recovered, 0);
+            assert!(result.tx_ids.is_empty());
+        }
+
+        #[test]
+        fn test_sweep_result_default() {
+            let r = SweepResult::default();
+            assert_eq!(r.vtxos_swept, 0);
+            assert_eq!(r.sats_recovered, 0);
+            assert!(r.tx_ids.is_empty());
+        }
+
+        #[tokio::test]
+        async fn test_run_scheduled_sweep_no_vtxos() {
+            let events = Arc::new(RecordingEvents::new());
+            let svc = make_service(events.clone());
+            // NoopSweepService returns 0 vtxos → no event published, no error.
+            svc.run_scheduled_sweep(500).await.unwrap();
+            // started/finalized counters unchanged (no SweepCompleted counted there).
+            assert_eq!(events.started.load(Ordering::SeqCst), 0);
+        }
+
+        #[test]
+        fn test_sweep_service_trait_object_safe() {
+            // Proves SweepService can be used as a trait object.
+            let _: Arc<dyn SweepService> = Arc::new(NoopSweepService);
         }
     }
 }

--- a/crates/arkd-core/src/domain/events.rs
+++ b/crates/arkd-core/src/domain/events.rs
@@ -161,6 +161,15 @@ pub enum ArkEvent {
 
     /// The Ark server is shutting down.
     ServerStopping,
+
+    // ── Sweep ─────────────────────────────────────────────────────
+    /// A scheduled sweep completed successfully.
+    SweepCompleted {
+        /// Number of VTXOs swept
+        vtxos_swept: usize,
+        /// Total satoshis recovered
+        sats_recovered: u64,
+    },
 }
 
 impl ArkEvent {
@@ -184,6 +193,7 @@ impl ArkEvent {
             Self::FraudDetected { .. } => "fraud.detected",
             Self::ServerStarted { .. } => "server.started",
             Self::ServerStopping => "server.stopping",
+            Self::SweepCompleted { .. } => "sweep.completed",
         }
     }
 }

--- a/crates/arkd-core/src/lib.rs
+++ b/crates/arkd-core/src/lib.rs
@@ -49,13 +49,13 @@ pub use multi_signer::MultiSigner;
 pub use ports::{
     ArkEvent, CacheService, CheckpointRepository, EventPublisher, ForfeitRepository, FraudDetector,
     LoggingEventPublisher, NoopCheckpointRepository, NoopForfeitRepository, NoopFraudDetector,
-    NoopOffchainTxRepository, OffchainTxRepository, RoundRepository, SignerService, TxBuilder,
-    VtxoRepository, WalletService,
+    NoopOffchainTxRepository, NoopSweepService, OffchainTxRepository, RoundRepository,
+    SignerService, SweepResult, SweepService, TxBuilder, VtxoRepository, WalletService,
 };
 pub use round_loop::spawn_round_loop;
 pub use round_scheduler::{RoundScheduler, SchedulerCommand, SchedulerConfig, SchedulerState};
 pub use signer::LocalSigner;
-pub use sweep::{SweepBatch, SweepConfig, SweepService, SweepStats};
+pub use sweep::{SweepBatch, SweepConfig, SweepRunner, SweepStats};
 pub use sweeper::Sweeper;
 
 /// Crate version

--- a/crates/arkd-core/src/ports.rs
+++ b/crates/arkd-core/src/ports.rs
@@ -735,3 +735,44 @@ pub trait CurrentRoundStore: Send + Sync {
     /// Clear the current round ID.
     async fn clear(&self) -> ArkResult<()>;
 }
+
+// ── Sweep service ─────────────────────────────────────────────────
+
+/// Result of a sweep operation.
+#[derive(Debug, Default, Clone)]
+pub struct SweepResult {
+    /// Number of VTXOs swept
+    pub vtxos_swept: usize,
+    /// Total satoshis recovered
+    pub sats_recovered: u64,
+    /// Transaction IDs produced
+    pub tx_ids: Vec<String>,
+}
+
+/// Port for sweeping expired VTXOs and round connectors back to the ASP.
+#[async_trait]
+pub trait SweepService: Send + Sync {
+    /// Sweep VTXOs that have expired by `current_height`.
+    async fn sweep_expired_vtxos(&self, current_height: u32) -> ArkResult<SweepResult>;
+    /// Sweep connector outputs for a given round.
+    async fn sweep_connectors(&self, round_id: &str) -> ArkResult<SweepResult>;
+}
+
+/// No-op implementation of [`SweepService`] for tests and early bootstrapping.
+pub struct NoopSweepService;
+
+#[async_trait]
+impl SweepService for NoopSweepService {
+    async fn sweep_expired_vtxos(&self, current_height: u32) -> ArkResult<SweepResult> {
+        tracing::debug!(
+            current_height,
+            "NoopSweepService: skipping expired VTXO sweep"
+        );
+        Ok(SweepResult::default())
+    }
+
+    async fn sweep_connectors(&self, round_id: &str) -> ArkResult<SweepResult> {
+        tracing::debug!(round_id, "NoopSweepService: skipping connector sweep");
+        Ok(SweepResult::default())
+    }
+}

--- a/crates/arkd-core/src/sweep.rs
+++ b/crates/arkd-core/src/sweep.rs
@@ -74,7 +74,7 @@ impl SweepBatch {
 }
 
 /// Sweep service for recovering expired VTXOs
-pub struct SweepService {
+pub struct SweepRunner {
     config: SweepConfig,
     #[allow(dead_code)] // Will be used when find_sweepable_vtxos is fully implemented
     vtxo_repo: Arc<dyn VtxoRepository>,
@@ -86,7 +86,7 @@ pub struct SweepService {
     shutdown: broadcast::Sender<()>,
 }
 
-impl SweepService {
+impl SweepRunner {
     /// Create a new sweep service
     pub fn new(
         config: SweepConfig,
@@ -459,7 +459,7 @@ mod tests {
         let round_repo = Arc::new(MockRoundRepo);
         let wallet = Arc::new(MockWallet);
 
-        let service = SweepService::new(config, vtxo_repo, round_repo, wallet);
+        let service = SweepRunner::new(config, vtxo_repo, round_repo, wallet);
 
         // Create 5 VTXOs
         let vtxos: Vec<Vtxo> = (0..5)

--- a/crates/arkd-core/src/sweeper.rs
+++ b/crates/arkd-core/src/sweeper.rs
@@ -1,6 +1,6 @@
 //! Lightweight VTXO sweeper — finds expired VTXOs and reclaims them for the ASP.
 //!
-//! Unlike [`crate::sweep::SweepService`] which handles batching & broadcasting,
+//! Unlike [`crate::sweep::SweepRunner`] which handles batching & broadcasting,
 //! this module provides a small, testable core that:
 //! 1. Queries for expired VTXOs via [`VtxoRepository::find_expired_vtxos`].
 //! 2. Publishes a [`ArkEvent::VtxoForfeited`] for each one.


### PR DESCRIPTION
Closes #132

## Changes
- Added `SweepService` trait to `ports.rs` with `sweep_expired_vtxos` and `sweep_connectors` methods
- Added `SweepResult` struct and `NoopSweepService` implementation
- Added `SweepCompleted` variant to `ArkEvent` enum
- Added `sweep_service` field to `ArkService` (defaults to `NoopSweepService`)
- Added `run_scheduled_sweep` method to `ArkService`
- Renamed existing concrete `SweepService` struct to `SweepRunner` to avoid naming conflict
- Exported `SweepService`, `SweepResult`, `NoopSweepService` from `lib.rs`
- 4 new tests: noop returns empty, default result, scheduled sweep no vtxos, trait object safety