### PR TITLE
🔍 Wire Esplora scanner into round flow (#142)

### DIFF
--- a/crates/arkd-core/src/application.rs
+++ b/crates/arkd-core/src/application.rs
@@ -16,11 +16,12 @@ use crate::domain::{
 use crate::domain::{OffchainTx, VtxoInput, VtxoOutput};
 use crate::error::{ArkError, ArkResult};
 use crate::ports::{
-    ArkEvent, BoardingRepository, CacheService, CheckpointRepository, ConfirmationStore,
-    EventPublisher, ForfeitRepository, FraudDetector, IndexerService, IndexerStats,
-    NoopBoardingRepository, NoopCheckpointRepository, NoopConfirmationStore, NoopForfeitRepository,
-    NoopFraudDetector, NoopIndexerService, NoopOffchainTxRepository, NoopSweepService,
-    OffchainTxRepository, SignerService, SweepService, TxBuilder, VtxoRepository, WalletService,
+    ArkEvent, BlockchainScanner, BoardingRepository, CacheService, CheckpointRepository,
+    ConfirmationStore, EventPublisher, ForfeitRepository, FraudDetector, IndexerService,
+    IndexerStats, NoopBlockchainScanner, NoopBoardingRepository, NoopCheckpointRepository,
+    NoopConfirmationStore, NoopForfeitRepository, NoopFraudDetector, NoopIndexerService,
+    NoopOffchainTxRepository, NoopSweepService, OffchainTxRepository, SignerService, SweepService,
+    TxBuilder, VtxoRepository, WalletService,
 };
 
 /// Round timing configuration (matches Go arkd's `roundTiming`)
@@ -168,6 +169,7 @@ pub struct ArkService {
     confirmation_store: Arc<dyn ConfirmationStore>,
     offchain_tx_repo: Arc<dyn OffchainTxRepository>,
     sweep_service: Arc<dyn SweepService>,
+    scanner: Arc<dyn BlockchainScanner>,
     indexer: Arc<dyn IndexerService>,
     config: ArkConfig,
     current_round: RwLock<Option<Round>>,
@@ -201,6 +203,7 @@ impl ArkService {
             confirmation_store: Arc::new(NoopConfirmationStore),
             offchain_tx_repo: Arc::new(NoopOffchainTxRepository),
             sweep_service: Arc::new(NoopSweepService),
+            scanner: Arc::new(NoopBlockchainScanner::new()),
             indexer: Arc::new(NoopIndexerService),
             config,
             current_round: RwLock::new(None),
@@ -212,6 +215,17 @@ impl ArkService {
     pub fn with_confirmation_store(mut self, store: Arc<dyn ConfirmationStore>) -> Self {
         self.confirmation_store = store;
         self
+    }
+
+    /// Set a custom blockchain scanner (for production Esplora/Electrum use).
+    pub fn with_scanner(mut self, scanner: Arc<dyn BlockchainScanner>) -> Self {
+        self.scanner = scanner;
+        self
+    }
+
+    /// Get a reference to the blockchain scanner.
+    pub fn scanner(&self) -> &dyn BlockchainScanner {
+        self.scanner.as_ref()
     }
 
     /// Set a custom indexer service.

--- a/crates/arkd-core/src/lib.rs
+++ b/crates/arkd-core/src/lib.rs
@@ -48,11 +48,12 @@ pub use domain::{
 pub use error::{ArkError, ArkResult};
 pub use multi_signer::MultiSigner;
 pub use ports::{
-    ArkEvent, CacheService, CheckpointRepository, EventPublisher, ForfeitRepository, FraudDetector,
-    IndexerService, IndexerStats, LoggingEventPublisher, NoopCheckpointRepository,
-    NoopForfeitRepository, NoopFraudDetector, NoopIndexerService, NoopOffchainTxRepository,
-    NoopSweepService, OffchainTxRepository, RoundRepository, SignerService, SweepResult,
-    SweepService, TxBuilder, VtxoRepository, WalletService,
+    ArkEvent, BlockchainScanner, CacheService, CheckpointRepository, EventPublisher,
+    ForfeitRepository, FraudDetector, IndexerService, IndexerStats, LoggingEventPublisher,
+    NoopBlockchainScanner, NoopCheckpointRepository, NoopForfeitRepository, NoopFraudDetector,
+    NoopIndexerService, NoopOffchainTxRepository, NoopSweepService, OffchainTxRepository,
+    RoundRepository, ScriptSpentEvent, SignerService, SweepResult, SweepService, TxBuilder,
+    VtxoRepository, WalletService,
 };
 pub use round_loop::spawn_round_loop;
 pub use round_scheduler::{RoundScheduler, SchedulerCommand, SchedulerConfig, SchedulerState};

--- a/crates/arkd-core/src/ports.rs
+++ b/crates/arkd-core/src/ports.rs
@@ -418,6 +418,46 @@ pub trait BlockchainScanner: Send + Sync {
     async fn tip_height(&self) -> ArkResult<u32>;
 }
 
+/// No-op blockchain scanner for dev/test environments within arkd-core.
+///
+/// Returns `Ok(())` for watch/unwatch, height 0, and an idle notification channel.
+pub struct NoopBlockchainScanner {
+    sender: tokio::sync::broadcast::Sender<ScriptSpentEvent>,
+}
+
+impl NoopBlockchainScanner {
+    /// Create a new no-op blockchain scanner.
+    pub fn new() -> Self {
+        let (sender, _) = tokio::sync::broadcast::channel(16);
+        Self { sender }
+    }
+}
+
+impl Default for NoopBlockchainScanner {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl BlockchainScanner for NoopBlockchainScanner {
+    async fn watch_script(&self, _script_pubkey: Vec<u8>) -> ArkResult<()> {
+        Ok(())
+    }
+
+    async fn unwatch_script(&self, _script_pubkey: &[u8]) -> ArkResult<()> {
+        Ok(())
+    }
+
+    fn notification_channel(&self) -> tokio::sync::broadcast::Receiver<ScriptSpentEvent> {
+        self.sender.subscribe()
+    }
+
+    async fn tip_height(&self) -> ArkResult<u32> {
+        Ok(0)
+    }
+}
+
 /// Asset repository — manages registered tokens and NFTs on this ASP.
 #[async_trait]
 pub trait AssetRepository: Send + Sync {
@@ -534,6 +574,7 @@ impl OffchainTxRepository for NoopOffchainTxRepository {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Arc;
     fn _assert_object_safe<T: ?Sized>() {}
 
     #[test]
@@ -598,6 +639,44 @@ mod tests {
         let assets = repo.list_assets().await.unwrap();
         assert!(assets.is_empty());
         assert!(repo.get_asset("nonexistent").await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn test_noop_blockchain_scanner_watch_unwatch() {
+        let scanner = NoopBlockchainScanner::new();
+        assert!(scanner.watch_script(vec![0xab, 0xcd]).await.is_ok());
+        assert!(scanner.unwatch_script(&[0xab, 0xcd]).await.is_ok());
+    }
+
+    #[tokio::test]
+    async fn test_noop_blockchain_scanner_tip_height() {
+        let scanner = NoopBlockchainScanner::new();
+        assert_eq!(scanner.tip_height().await.unwrap(), 0);
+    }
+
+    #[tokio::test]
+    async fn test_noop_blockchain_scanner_notification_channel() {
+        let scanner = NoopBlockchainScanner::new();
+        let _rx = scanner.notification_channel();
+        // Channel created — no messages expected from noop
+    }
+
+    #[tokio::test]
+    async fn test_noop_blockchain_scanner_as_trait_object() {
+        let scanner: Arc<dyn BlockchainScanner> = Arc::new(NoopBlockchainScanner::new());
+        let watch_result: ArkResult<()> = scanner.watch_script(vec![0x01, 0x02]).await;
+        assert!(watch_result.is_ok());
+        let unwatch_result: ArkResult<()> = scanner.unwatch_script(&[0x01, 0x02]).await;
+        assert!(unwatch_result.is_ok());
+        let height: u32 = scanner.tip_height().await.unwrap();
+        assert_eq!(height, 0);
+    }
+
+    #[test]
+    fn test_noop_blockchain_scanner_default() {
+        let scanner = NoopBlockchainScanner::default();
+        let _rx = scanner.notification_channel();
+        // Default impl works
     }
 }
 


### PR DESCRIPTION
## Summary

Wires the `BlockchainScanner` trait into `ArkService` with a `NoopBlockchainScanner` default, enabling production scanners (Esplora, Electrum) to be injected via `with_scanner()`.

### Changes
- **`arkd-core/src/ports.rs`**: Added `NoopBlockchainScanner` struct implementing `BlockchainScanner` trait (watch/unwatch/tip_height/notification_channel) + 5 tests
- **`arkd-core/src/application.rs`**: Added `scanner: Arc<dyn BlockchainScanner>` field to `ArkService`, defaults to `NoopBlockchainScanner` in `new()`, added `with_scanner()` builder and `scanner()` getter
- **`arkd-core/src/lib.rs`**: Exported `BlockchainScanner`, `NoopBlockchainScanner`, `ScriptSpentEvent`

Closes #142