### PR TITLE
✨ arkd-client: Add CollaborativeExit and Unroll APIs

### DIFF
--- a/crates/arkd-client/src/client.rs
+++ b/crates/arkd-client/src/client.rs
@@ -688,7 +688,7 @@ impl ArkClient {
 /// Low-level unilateral exit helper.
 ///
 /// Computes the redeem branch (path from the VTXO tree root to the VTXO leaf)
-/// and yields the next transaction to broadcast at each call to [`next_redeem_tx`].
+/// and yields the next transaction to broadcast at each call to `next_redeem_tx`.
 ///
 /// # Usage
 /// ```ignore


### PR DESCRIPTION
## Summary

Adds `collaborative_exit` and `unroll` to `ArkClient`, plus the `RedeemBranch` struct.

## Changes

### `collaborative_exit` (#206)
- New method `collaborative_exit(onchain_address, amount, vtxo_ids)`
- Calls `RequestExit` gRPC with the caller-supplied VTXO outpoints and destination address
- Input validation: non-empty address, `amount > 0`, non-empty `vtxo_ids`
- Boarding inputs are not included (server enforces: `"include onchain inputs and outputs"`)
- Returns `pending:<exit_id>` placeholder until round settlement completes and real commitment txid is available

### `unroll` + `RedeemBranch` (#205)
- Add `unroll()` stub method — returns a `not yet implemented` error with clear documentation of prerequisites (VTXO tree indexer + Bitcoin wallet signing)
- Add `RedeemBranch` struct with `new(vtxo)` and `next_redeem_tx()` stub methods
- Full implementation requires `GetVtxoChain` (IndexerService) and Bitcoin transaction construction

### Tests
- `collaborative_exit`: empty address, zero amount, empty vtxo_ids validation rejected before RPC
- `collaborative_exit`: not-connected error path
- `unroll`: stub returns descriptive error
- `RedeemBranch::next_redeem_tx`: returns `None` when no pending txs

Closes #205
Closes #206