### PR TITLE
✨ feat(arkd-api): wire server-side script filter in GetTransactionsStream

### DIFF
--- a/crates/arkd-api/src/grpc/ark_service.rs
+++ b/crates/arkd-api/src/grpc/ark_service.rs
@@ -61,8 +61,9 @@ use crate::proto::ark_v1::{
     UpdateStreamTopicsRequest,
     UpdateStreamTopicsResponse,
 };
+use std::collections::HashSet;
 
-use super::broker::SharedEventBroker;
+use super::broker::{SharedEventBroker, SharedTransactionEventBroker};
 use super::convert;
 use super::middleware::{get_authenticated_user, require_authenticated_user};
 
@@ -71,6 +72,7 @@ pub struct ArkGrpcService {
     core: Arc<arkd_core::ArkService>,
     round_repo: Arc<dyn RoundRepository>,
     broker: SharedEventBroker,
+    tx_broker: SharedTransactionEventBroker,
     /// Retained for API compatibility; offchain tx operations now go through `core`.
     #[allow(dead_code)]
     offchain_tx_repo: Arc<dyn OffchainTxRepository>,
@@ -82,12 +84,14 @@ impl ArkGrpcService {
         core: Arc<arkd_core::ArkService>,
         round_repo: Arc<dyn RoundRepository>,
         broker: SharedEventBroker,
+        tx_broker: SharedTransactionEventBroker,
         offchain_tx_repo: Arc<dyn OffchainTxRepository>,
     ) -> Self {
         Self {
             core,
             round_repo,
             broker,
+            tx_broker,
             offchain_tx_repo,
         }
     }
@@ -870,11 +874,25 @@ impl ArkServiceTrait for ArkGrpcService {
     }
 
     /// GetTransactionsStream opens a server-streaming connection for transaction events.
+    ///
+    /// The client can optionally provide a list of scripts to filter events.
+    /// Only `ArkTxEvent`s where `from_script` or `to_script` matches one of the
+    /// provided scripts will be forwarded. If no scripts are provided, all
+    /// events are forwarded.
     async fn get_transactions_stream(
         &self,
-        _request: Request<GetTransactionsStreamRequest>,
+        request: Request<GetTransactionsStreamRequest>,
     ) -> Result<Response<Self::GetTransactionsStreamStream>, Status> {
-        info!("GetTransactionsStream called");
+        let req = request.into_inner();
+        let script_filter: HashSet<String> = req.scripts.into_iter().collect();
+        let has_filter = !script_filter.is_empty();
+
+        info!(
+            filter_count = script_filter.len(),
+            "GetTransactionsStream called"
+        );
+
+        let mut rx = self.tx_broker.subscribe();
 
         let output = stream! {
             // Yield an initial heartbeat so the client knows the stream is alive
@@ -888,19 +906,40 @@ impl ArkServiceTrait for ArkGrpcService {
                 )),
             });
 
-            // TODO(#159): Forward actual transaction events from the broker
-            // For now, keep the stream alive with periodic heartbeats
+            // Forward filtered events from the broker
             loop {
-                tokio::time::sleep(std::time::Duration::from_secs(30)).await;
-                let now = std::time::SystemTime::now()
-                    .duration_since(std::time::UNIX_EPOCH)
-                    .unwrap_or_default()
-                    .as_secs() as i64;
-                yield Ok(TransactionEvent {
-                    event: Some(crate::proto::ark_v1::transaction_event::Event::Heartbeat(
-                        TransactionHeartbeatEvent { timestamp: now },
-                    )),
-                });
+                match rx.recv().await {
+                    Ok(event) => {
+                        // Apply script filter if present
+                        if has_filter {
+                            if let Some(ref inner) = event.event {
+                                match inner {
+                                    crate::proto::ark_v1::transaction_event::Event::ArkTx(ark_tx) => {
+                                        // Check if from_script or to_script matches any filter
+                                        let matches = script_filter.contains(&ark_tx.from_script)
+                                            || script_filter.contains(&ark_tx.to_script);
+                                        if matches {
+                                            yield Ok(event);
+                                        }
+                                        // Skip events that don't match the filter
+                                    }
+                                    // Always forward non-ArkTx events (heartbeats, commitment_tx)
+                                    _ => yield Ok(event),
+                                }
+                            }
+                        } else {
+                            // No filter — forward all events
+                            yield Ok(event);
+                        }
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Lagged(n)) => {
+                        warn!(skipped = n, "Transaction stream client lagged, skipped events");
+                        // Continue receiving — don't break
+                    }
+                    Err(tokio::sync::broadcast::error::RecvError::Closed) => {
+                        break;
+                    }
+                }
             }
         };
 
@@ -913,7 +952,8 @@ impl ArkServiceTrait for ArkGrpcService {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::proto::ark_v1::Outpoint;
+    use crate::proto::ark_v1::transaction_event::Event as TxEventType;
+    use crate::proto::ark_v1::{ArkTxEvent, Outpoint};
 
     #[test]
     fn test_request_validation() {
@@ -937,5 +977,88 @@ mod tests {
         };
         assert!(!req.vtxo_ids.is_empty());
         assert!(!req.destination.is_empty());
+    }
+
+    #[test]
+    fn test_script_filter_matches_from_script() {
+        let filter: HashSet<String> = ["script_a", "script_b"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let event = ArkTxEvent {
+            txid: "tx1".to_string(),
+            from_script: "script_a".to_string(),
+            to_script: "script_c".to_string(),
+            amount: 1000,
+            timestamp: 12345,
+        };
+
+        let matches = filter.contains(&event.from_script) || filter.contains(&event.to_script);
+        assert!(matches, "Filter should match from_script");
+    }
+
+    #[test]
+    fn test_script_filter_matches_to_script() {
+        let filter: HashSet<String> = ["script_x", "script_y"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let event = ArkTxEvent {
+            txid: "tx2".to_string(),
+            from_script: "script_z".to_string(),
+            to_script: "script_y".to_string(),
+            amount: 2000,
+            timestamp: 12345,
+        };
+
+        let matches = filter.contains(&event.from_script) || filter.contains(&event.to_script);
+        assert!(matches, "Filter should match to_script");
+    }
+
+    #[test]
+    fn test_script_filter_no_match() {
+        let filter: HashSet<String> = ["script_a", "script_b"]
+            .iter()
+            .map(|s| s.to_string())
+            .collect();
+
+        let event = ArkTxEvent {
+            txid: "tx3".to_string(),
+            from_script: "script_x".to_string(),
+            to_script: "script_y".to_string(),
+            amount: 3000,
+            timestamp: 12345,
+        };
+
+        let matches = filter.contains(&event.from_script) || filter.contains(&event.to_script);
+        assert!(!matches, "Filter should not match unrelated scripts");
+    }
+
+    #[test]
+    fn test_empty_filter_matches_all() {
+        let filter: HashSet<String> = HashSet::new();
+        let has_filter = !filter.is_empty();
+
+        assert!(!has_filter, "Empty filter should not be considered active");
+    }
+
+    #[test]
+    fn test_heartbeat_always_forwarded() {
+        // Heartbeats should always be forwarded regardless of filter
+        let event = TransactionEvent {
+            event: Some(TxEventType::Heartbeat(TransactionHeartbeatEvent {
+                timestamp: 12345,
+            })),
+        };
+
+        // This tests the match arm logic — non-ArkTx events should pass through
+        if let Some(TxEventType::Heartbeat(_)) = event.event {
+            // Heartbeat — would be forwarded
+            assert!(true);
+        } else {
+            panic!("Expected heartbeat event");
+        }
     }
 }

--- a/crates/arkd-api/src/grpc/broker.rs
+++ b/crates/arkd-api/src/grpc/broker.rs
@@ -1,4 +1,4 @@
-//! Event broker for streaming round lifecycle events to clients.
+//! Event brokers for streaming events to clients.
 
 use std::sync::Arc;
 use tokio::sync::broadcast;
@@ -29,3 +29,30 @@ impl EventBroker {
 
 /// Shared reference to an EventBroker.
 pub type SharedEventBroker = Arc<EventBroker>;
+
+/// Broadcasts transaction events to connected stream clients.
+#[derive(Clone)]
+pub struct TransactionEventBroker {
+    sender: broadcast::Sender<crate::proto::ark_v1::TransactionEvent>,
+}
+
+impl TransactionEventBroker {
+    /// Create a new TransactionEventBroker with the given channel capacity.
+    pub fn new(capacity: usize) -> Self {
+        let (sender, _) = broadcast::channel(capacity);
+        Self { sender }
+    }
+
+    /// Publish a transaction event to all connected subscribers.
+    pub fn publish(&self, event: crate::proto::ark_v1::TransactionEvent) {
+        let _ = self.sender.send(event);
+    }
+
+    /// Subscribe to the transaction event stream.
+    pub fn subscribe(&self) -> broadcast::Receiver<crate::proto::ark_v1::TransactionEvent> {
+        self.sender.subscribe()
+    }
+}
+
+/// Shared reference to a TransactionEventBroker.
+pub type SharedTransactionEventBroker = Arc<TransactionEventBroker>;

--- a/crates/arkd-api/src/lib.rs
+++ b/crates/arkd-api/src/lib.rs
@@ -34,7 +34,9 @@ pub mod proto {
 }
 
 pub use config::ServerConfig;
-pub use grpc::broker::{EventBroker, SharedEventBroker};
+pub use grpc::broker::{
+    EventBroker, SharedEventBroker, SharedTransactionEventBroker, TransactionEventBroker,
+};
 pub use grpc::signer_client::RemoteSignerClient;
 pub use grpc::wallet_service::WalletGrpcService;
 pub use monitoring::{spawn_monitoring_server, MonitoringConfig};

--- a/crates/arkd-api/src/server.rs
+++ b/crates/arkd-api/src/server.rs
@@ -12,7 +12,9 @@ use arkd_core::ports::{OffchainTxRepository, RoundRepository};
 use crate::auth::Authenticator;
 use crate::grpc::admin_service::AdminGrpcService;
 use crate::grpc::ark_service::ArkGrpcService;
-use crate::grpc::broker::SharedEventBroker;
+use crate::grpc::broker::{
+    SharedEventBroker, SharedTransactionEventBroker, TransactionEventBroker,
+};
 use crate::grpc::indexer_service::IndexerGrpcService;
 use crate::grpc::middleware::AuthInterceptor;
 use crate::grpc::wallet_service::WalletGrpcService;
@@ -35,6 +37,7 @@ pub struct Server {
     core: Arc<arkd_core::ArkService>,
     round_repo: Arc<dyn RoundRepository>,
     broker: SharedEventBroker,
+    tx_broker: SharedTransactionEventBroker,
     offchain_tx_repo: Arc<dyn OffchainTxRepository>,
     authenticator: Arc<Authenticator>,
     cancel: CancellationToken,
@@ -65,12 +68,14 @@ impl Server {
         });
 
         let broker = Arc::new(crate::grpc::broker::EventBroker::new(256));
+        let tx_broker = Arc::new(TransactionEventBroker::new(256));
 
         Ok(Self {
             config,
             core,
             round_repo,
             broker,
+            tx_broker,
             offchain_tx_repo,
             authenticator,
             cancel: CancellationToken::new(),
@@ -85,6 +90,20 @@ impl Server {
     /// Get the authenticator for creating tokens.
     pub fn authenticator(&self) -> &Arc<Authenticator> {
         &self.authenticator
+    }
+
+    /// Get the round event broker for publishing round lifecycle events.
+    pub fn event_broker(&self) -> &SharedEventBroker {
+        &self.broker
+    }
+
+    /// Get the transaction event broker for publishing transaction events.
+    ///
+    /// Use this to publish `TransactionEvent`s that will be streamed to clients
+    /// via `GetTransactionsStream`. Events are filtered server-side based on
+    /// the client's script filter.
+    pub fn tx_event_broker(&self) -> &SharedTransactionEventBroker {
+        &self.tx_broker
     }
 
     /// Load TLS configuration if enabled.
@@ -168,6 +187,7 @@ impl Server {
             Arc::clone(&self.core),
             Arc::clone(&self.round_repo),
             Arc::clone(&self.broker),
+            Arc::clone(&self.tx_broker),
             Arc::clone(&self.offchain_tx_repo),
         );
 

--- a/crates/arkd-api/tests/grpc_integration.rs
+++ b/crates/arkd-api/tests/grpc_integration.rs
@@ -14,9 +14,10 @@ use arkd_api::proto::ark_v1::ark_service_client::ArkServiceClient;
 use arkd_api::proto::ark_v1::ark_service_server::ArkServiceServer;
 use arkd_api::proto::ark_v1::{
     DeleteIntentRequest, EstimateIntentFeeRequest, FinalizeTxRequest, GetEventStreamRequest,
-    GetInfoRequest, GetPendingTxRequest, GetRoundRequest, GetStatusRequest, GetVtxosRequest,
-    ListRoundsRequest, Outpoint, Output, RegisterForRoundRequest, RequestExitRequest,
-    SignedVtxoInput, SubmitTxRequest, UpdateStreamTopicsRequest,
+    GetInfoRequest, GetPendingTxRequest, GetRoundRequest, GetStatusRequest,
+    GetTransactionsStreamRequest, GetVtxosRequest, ListRoundsRequest, Outpoint, Output,
+    RegisterForRoundRequest, RequestExitRequest, SignedVtxoInput, SubmitTxRequest,
+    UpdateStreamTopicsRequest,
 };
 
 use arkd_api::grpc::admin_service::AdminGrpcService;
@@ -272,12 +273,14 @@ async fn start_ark_server() -> ArkServiceClient<Channel> {
     let core = build_test_core();
     let round_repo: Arc<dyn arkd_core::ports::RoundRepository> = Arc::new(MockRoundRepo);
     let broker = Arc::new(arkd_api::EventBroker::new(64));
+    let tx_broker = Arc::new(arkd_api::TransactionEventBroker::new(64));
     let offchain_tx_repo: Arc<dyn arkd_core::ports::OffchainTxRepository> =
         Arc::new(MockOffchainTxRepo::new());
     let svc = ArkServiceServer::new(ArkGrpcService::new(
         core,
         round_repo,
         broker,
+        tx_broker,
         offchain_tx_repo,
     ));
 
@@ -919,6 +922,58 @@ async fn test_offchain_tx_submit_and_get() {
         .into_inner();
     assert_eq!(get.tx_id, tx_id);
     assert!(!get.stage.is_empty());
+}
+
+// ─── GetTransactionsStream Tests ────────────────────────────────────
+
+#[tokio::test]
+async fn test_transactions_stream_initial_heartbeat() {
+    use tokio_stream::StreamExt;
+
+    let mut client = start_ark_server().await;
+
+    let response = client
+        .get_transactions_stream(GetTransactionsStreamRequest { scripts: vec![] })
+        .await
+        .expect("get_transactions_stream should succeed");
+
+    let mut stream = response.into_inner();
+    let first = stream.next().await.expect("stream should yield an item");
+    let event = first.expect("first item should be Ok");
+
+    match event.event {
+        Some(arkd_api::proto::ark_v1::transaction_event::Event::Heartbeat(hb)) => {
+            assert!(hb.timestamp > 0, "heartbeat timestamp should be positive");
+        }
+        other => panic!("Expected heartbeat event, got: {:?}", other),
+    }
+}
+
+#[tokio::test]
+async fn test_transactions_stream_with_script_filter() {
+    use tokio_stream::StreamExt;
+
+    let mut client = start_ark_server().await;
+
+    // Request stream with a script filter
+    let response = client
+        .get_transactions_stream(GetTransactionsStreamRequest {
+            scripts: vec!["script_alice".to_string(), "script_bob".to_string()],
+        })
+        .await
+        .expect("get_transactions_stream should succeed");
+
+    let mut stream = response.into_inner();
+    // Should still get initial heartbeat
+    let first = stream.next().await.expect("stream should yield an item");
+    let event = first.expect("first item should be Ok");
+
+    match event.event {
+        Some(arkd_api::proto::ark_v1::transaction_event::Event::Heartbeat(hb)) => {
+            assert!(hb.timestamp > 0, "heartbeat timestamp should be positive");
+        }
+        other => panic!("Expected heartbeat event, got: {:?}", other),
+    }
 }
 
 // ─── TLS Configuration Tests ────────────────────────────────────────


### PR DESCRIPTION
## Summary

Implements server-side filtering for `GetTransactionsStream` RPC based on the `scripts` field in `GetTransactionsStreamRequest`.

## Changes

### New: TransactionEventBroker
- Added `TransactionEventBroker` for broadcasting `TransactionEvent`s (parallel to the existing `EventBroker` for `RoundEvent`s)
- Exported `SharedTransactionEventBroker` and `TransactionEventBroker` from the crate

### ArkGrpcService Updates
- Added `tx_broker: SharedTransactionEventBroker` field
- Updated constructor to accept the new broker
- Implemented filtering logic in `get_transactions_stream`:
  - Extract `scripts` from request into a `HashSet` for O(1) lookups
  - For `ArkTxEvent`, check if `from_script` or `to_script` matches any filter
  - Always forward non-ArkTx events (heartbeats, commitment_tx)
  - No filter = forward all events

### Server Updates
- Creates `TransactionEventBroker` alongside `EventBroker`
- Exposes `tx_event_broker()` getter for applications to publish events

### Tests
- Unit tests for script filter matching logic
- Integration tests for `GetTransactionsStream` with and without filters

## API Behavior

```protobuf
message GetTransactionsStreamRequest {
  repeated string scripts = 1;  // Filter by scripts (optional)
}
```

- **Empty scripts**: All events forwarded
- **Non-empty scripts**: Only `ArkTxEvent` where `from_script ∈ scripts` OR `to_script ∈ scripts` is forwarded
- Heartbeats and other event types are always forwarded regardless of filter

Closes #222