### PR TITLE
feat(db): ScheduledSessionRepo with SQLite + PostgreSQL (#271)

### DIFF
--- a/crates/arkd-api/src/grpc/admin_service.rs
+++ b/crates/arkd-api/src/grpc/admin_service.rs
@@ -388,12 +388,31 @@ impl AdminServiceTrait for AdminGrpcService {
         _request: Request<GetScheduledSessionConfigRequest>,
     ) -> Result<Response<GetScheduledSessionConfigResponse>, Status> {
         info!("AdminService::GetScheduledSessionConfig called");
+
+        let repo = self.core.scheduled_session_repo();
+        let persisted = repo
+            .get()
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        let config = match persisted {
+            Some(cfg) => crate::proto::ark_v1::SessionConfig {
+                round_interval_secs: cfg.round_interval_secs,
+                round_lifetime_secs: cfg.round_lifetime_secs,
+                max_intents_per_round: cfg.max_intents_per_round,
+            },
+            None => {
+                // Fall back to static config defaults
+                crate::proto::ark_v1::SessionConfig {
+                    round_interval_secs: 10,
+                    round_lifetime_secs: 30,
+                    max_intents_per_round: 128,
+                }
+            }
+        };
+
         Ok(Response::new(GetScheduledSessionConfigResponse {
-            config: Some(crate::proto::ark_v1::SessionConfig {
-                round_interval_secs: 10,
-                round_lifetime_secs: 30,
-                max_intents_per_round: 128,
-            }),
+            config: Some(config),
         }))
     }
 
@@ -404,14 +423,25 @@ impl AdminServiceTrait for AdminGrpcService {
         let req = request.into_inner();
         info!("AdminService::UpdateScheduledSessionConfig called");
 
-        let _config = req
+        let proto_config = req
             .config
             .ok_or_else(|| Status::invalid_argument("config is required"))?;
 
-        // TODO: needs mutable ConfigService (#165)
-        Err(Status::unimplemented(
-            "UpdateScheduledSessionConfig not yet implemented — requires config persistence",
-        ))
+        let domain_config = arkd_core::ScheduledSessionConfig::new(
+            proto_config.round_interval_secs,
+            proto_config.round_lifetime_secs,
+            proto_config.max_intents_per_round,
+        );
+
+        self.core
+            .scheduled_session_repo()
+            .upsert(domain_config)
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
+        Ok(Response::new(UpdateScheduledSessionConfigResponse {
+            config: Some(proto_config),
+        }))
     }
 
     async fn clear_scheduled_session_config(
@@ -419,6 +449,13 @@ impl AdminServiceTrait for AdminGrpcService {
         _request: Request<ClearScheduledSessionConfigRequest>,
     ) -> Result<Response<ClearScheduledSessionConfigResponse>, Status> {
         info!("AdminService::ClearScheduledSessionConfig called");
+
+        self.core
+            .scheduled_session_repo()
+            .clear()
+            .await
+            .map_err(|e| Status::internal(e.to_string()))?;
+
         Ok(Response::new(ClearScheduledSessionConfigResponse {}))
     }
 

--- a/crates/arkd-core/src/application.rs
+++ b/crates/arkd-core/src/application.rs
@@ -190,6 +190,7 @@ pub struct ArkService {
     /// MuSig2 signing session store for tree nonces/signatures (#159)
     signing_session_store: Arc<dyn crate::ports::SigningSessionStore>,
     asset_repo: Arc<dyn AssetRepository>,
+    scheduled_session_repo: Arc<dyn crate::ports::ScheduledSessionRepository>,
     notifier: Arc<dyn crate::ports::Notifier>,
     config: ArkConfig,
     config_service: Arc<dyn ConfigService>,
@@ -233,6 +234,7 @@ impl ArkService {
             conviction_repo: Arc::new(NoopConvictionRepository),
             signing_session_store: Arc::new(crate::ports::NoopSigningSessionStore),
             asset_repo: Arc::new(NoopAssetRepository),
+            scheduled_session_repo: Arc::new(crate::ports::NoopScheduledSessionRepository),
             notifier: Arc::new(crate::ports::NoopNotifier),
             config,
             config_service,
@@ -294,6 +296,15 @@ impl ArkService {
         self
     }
 
+    /// Set a custom scheduled-session repository for config persistence (#271).
+    pub fn with_scheduled_session_repo(
+        mut self,
+        repo: Arc<dyn crate::ports::ScheduledSessionRepository>,
+    ) -> Self {
+        self.scheduled_session_repo = repo;
+        self
+    }
+
     /// Set a custom notifier for VTXO expiry notifications (Issue #247).
     pub fn with_notifier(mut self, notifier: Arc<dyn crate::ports::Notifier>) -> Self {
         self.notifier = notifier;
@@ -314,6 +325,11 @@ impl ArkService {
     /// Get a reference to the wallet service.
     pub fn wallet(&self) -> Arc<dyn WalletService> {
         Arc::clone(&self.wallet)
+    }
+
+    /// Get a reference to the scheduled-session repository.
+    pub fn scheduled_session_repo(&self) -> &dyn crate::ports::ScheduledSessionRepository {
+        self.scheduled_session_repo.as_ref()
     }
 
     /// Get the Ark configuration.

--- a/crates/arkd-core/src/domain/mod.rs
+++ b/crates/arkd-core/src/domain/mod.rs
@@ -18,8 +18,11 @@ pub mod indexer;
 pub mod intent;
 pub mod offchain_tx;
 pub mod round;
+pub mod scheduled_session;
 pub mod signing;
 pub mod vtxo;
+
+pub use scheduled_session::ScheduledSessionConfig;
 
 pub use asset::{Asset, AssetAmount, AssetId, AssetIssuance, AssetKind, AssetRecord};
 pub use ban::{BanReason, BanRecord, InMemoryBanRepository};

--- a/crates/arkd-core/src/domain/scheduled_session.rs
+++ b/crates/arkd-core/src/domain/scheduled_session.rs
@@ -1,0 +1,56 @@
+//! Scheduled session configuration domain model.
+//!
+//! Represents the persisted configuration for automatic round scheduling,
+//! including timing windows, period, duration, and participant limits.
+
+use serde::{Deserialize, Serialize};
+
+/// Persisted scheduled-session configuration.
+///
+/// When present, the ASP runs automatic rounds according to these parameters.
+/// When absent (cleared), the ASP falls back to static config defaults.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScheduledSessionConfig {
+    /// Round interval in seconds (how often a new round starts).
+    pub round_interval_secs: u32,
+    /// Round lifetime in seconds (how long a single round stays open).
+    pub round_lifetime_secs: u32,
+    /// Maximum number of intents accepted per round.
+    pub max_intents_per_round: u32,
+}
+
+impl ScheduledSessionConfig {
+    /// Create a new scheduled session configuration.
+    pub fn new(
+        round_interval_secs: u32,
+        round_lifetime_secs: u32,
+        max_intents_per_round: u32,
+    ) -> Self {
+        Self {
+            round_interval_secs,
+            round_lifetime_secs,
+            max_intents_per_round,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_scheduled_session_config_creation() {
+        let config = ScheduledSessionConfig::new(10, 30, 128);
+        assert_eq!(config.round_interval_secs, 10);
+        assert_eq!(config.round_lifetime_secs, 30);
+        assert_eq!(config.max_intents_per_round, 128);
+    }
+
+    #[test]
+    fn test_scheduled_session_config_serde_roundtrip() {
+        let config = ScheduledSessionConfig::new(15, 60, 256);
+        let json = serde_json::to_string(&config).unwrap();
+        let deserialized: ScheduledSessionConfig = serde_json::from_str(&json).unwrap();
+        assert_eq!(config, deserialized);
+    }
+}

--- a/crates/arkd-core/src/lib.rs
+++ b/crates/arkd-core/src/lib.rs
@@ -46,7 +46,7 @@ pub use domain::{
     BoardingTransaction, CheckpointTx, CollaborativeExitRequest, Conviction, ConvictionKind,
     CrimeType, Exit, ExitError, ExitStatus, ExitSummary, ExitType, FlatTxTree, ForfeitRecord,
     ForfeitTx, InMemoryBanRepository, Intent, Receiver, Round, RoundConfig, RoundStage, RoundStats,
-    Stage, TxTreeNode, UnilateralExitRequest, Vtxo, VtxoId, VtxoOutpoint,
+    ScheduledSessionConfig, Stage, TxTreeNode, UnilateralExitRequest, Vtxo, VtxoId, VtxoOutpoint,
     DEFAULT_CHECKPOINT_EXIT_DELAY, DEFAULT_EVENT_CHANNEL_CAPACITY,
 };
 pub use error::{ArkError, ArkResult};
@@ -59,9 +59,9 @@ pub use ports::{
     FraudDetector, IndexerService, IndexerStats, LoggingEventPublisher, NoopAlerts,
     NoopBlockchainScanner, NoopCheckpointRepository, NoopConvictionRepository, NoopFeeManager,
     NoopForfeitRepository, NoopFraudDetector, NoopIndexerService, NoopOffchainTxRepository,
-    NoopSweepService, NoopTxDecoder, OffchainTxRepository, RoundRepository, ScriptSpentEvent,
-    SignerService, SweepResult, SweepService, TxBuilder, TxDecoder, Unlocker, VtxoRepository,
-    WalletBalance, WalletService,
+    NoopScheduledSessionRepository, NoopSweepService, NoopTxDecoder, OffchainTxRepository,
+    RoundRepository, ScheduledSessionRepository, ScriptSpentEvent, SignerService, SweepResult,
+    SweepService, TxBuilder, TxDecoder, Unlocker, VtxoRepository, WalletBalance, WalletService,
 };
 pub use round_loop::spawn_round_loop;
 pub use round_report::RoundReport;

--- a/crates/arkd-core/src/ports.rs
+++ b/crates/arkd-core/src/ports.rs
@@ -825,6 +825,7 @@ mod tests {
         _assert_object_safe::<dyn IndexerService>();
         _assert_object_safe::<dyn ConvictionRepository>();
         _assert_object_safe::<dyn BanRepository>();
+        _assert_object_safe::<dyn ScheduledSessionRepository>();
         _assert_object_safe::<dyn TxDecoder>();
         _assert_object_safe::<dyn Unlocker>();
         _assert_object_safe::<dyn Alerts>();
@@ -1701,6 +1702,40 @@ pub trait EventStore: Send + Sync {
 
     /// Load all events for the given aggregate, ordered by append time.
     async fn load_events(&self, aggregate_id: &str) -> ArkResult<Vec<Vec<u8>>>;
+}
+
+// ---------------------------------------------------------------------------
+// ScheduledSessionRepository — persisted session scheduling config (#271)
+// ---------------------------------------------------------------------------
+
+/// Repository for persisting scheduled-session configuration.
+///
+/// When a config is stored via `upsert`, it survives ASP restarts. `clear`
+/// removes the persisted override so the ASP falls back to static defaults.
+#[async_trait]
+pub trait ScheduledSessionRepository: Send + Sync {
+    /// Retrieve the current scheduled-session configuration, if any.
+    async fn get(&self) -> ArkResult<Option<crate::domain::ScheduledSessionConfig>>;
+    /// Insert or update the scheduled-session configuration (singleton row).
+    async fn upsert(&self, config: crate::domain::ScheduledSessionConfig) -> ArkResult<()>;
+    /// Remove the persisted configuration (fall back to static defaults).
+    async fn clear(&self) -> ArkResult<()>;
+}
+
+/// No-op scheduled-session repository — returns `None` and discards writes.
+pub struct NoopScheduledSessionRepository;
+
+#[async_trait]
+impl ScheduledSessionRepository for NoopScheduledSessionRepository {
+    async fn get(&self) -> ArkResult<Option<crate::domain::ScheduledSessionConfig>> {
+        Ok(None)
+    }
+    async fn upsert(&self, _config: crate::domain::ScheduledSessionConfig) -> ArkResult<()> {
+        Ok(())
+    }
+    async fn clear(&self) -> ArkResult<()> {
+        Ok(())
+    }
 }
 
 /// No-op event store — discards writes and returns empty streams.

--- a/crates/arkd-db/migrations/006_scheduled_sessions.sql
+++ b/crates/arkd-db/migrations/006_scheduled_sessions.sql
@@ -1,0 +1,9 @@
+-- Migration 006: Scheduled session configuration persistence (#271)
+-- Singleton table — only one row (id=1) is ever stored.
+
+CREATE TABLE IF NOT EXISTS scheduled_session_config (
+    id                      INTEGER PRIMARY KEY CHECK (id = 1),
+    round_interval_secs     INTEGER NOT NULL,
+    round_lifetime_secs     INTEGER NOT NULL,
+    max_intents_per_round   INTEGER NOT NULL
+);

--- a/crates/arkd-db/migrations/pg/004_scheduled_sessions.sql
+++ b/crates/arkd-db/migrations/pg/004_scheduled_sessions.sql
@@ -1,0 +1,9 @@
+-- Migration 004 (pg): Scheduled session configuration persistence (#271)
+-- Singleton table — only one row (id=1) is ever stored.
+
+CREATE TABLE IF NOT EXISTS scheduled_session_config (
+    id                      INTEGER PRIMARY KEY CHECK (id = 1),
+    round_interval_secs     INTEGER NOT NULL,
+    round_lifetime_secs     INTEGER NOT NULL,
+    max_intents_per_round   INTEGER NOT NULL
+);

--- a/crates/arkd-db/src/pool.rs
+++ b/crates/arkd-db/src/pool.rs
@@ -124,7 +124,17 @@ impl Database {
                 .execute(pool)
                 .await
                 .map_err(|e| DatabaseError::MigrationError(e.to_string()))?;
-            info!("Migrations applied successfully (001-004)");
+            let migration_005 = include_str!("../migrations/005_assets.sql");
+            sqlx::query(migration_005)
+                .execute(pool)
+                .await
+                .map_err(|e| DatabaseError::MigrationError(e.to_string()))?;
+            let migration_006 = include_str!("../migrations/006_scheduled_sessions.sql");
+            sqlx::query(migration_006)
+                .execute(pool)
+                .await
+                .map_err(|e| DatabaseError::MigrationError(e.to_string()))?;
+            info!("Migrations applied successfully (001-006)");
         }
         Ok(())
     }

--- a/crates/arkd-db/src/pool_postgres.rs
+++ b/crates/arkd-db/src/pool_postgres.rs
@@ -64,6 +64,12 @@ pub async fn run_postgres_migrations(pool: &PgPool) -> DatabaseResult<()> {
         .await
         .map_err(|e| DatabaseError::MigrationError(format!("PG migration 002 failed: {e}")))?;
 
+    let migration_004 = include_str!("../migrations/pg/004_scheduled_sessions.sql");
+    sqlx::query(migration_004)
+        .execute(pool)
+        .await
+        .map_err(|e| DatabaseError::MigrationError(format!("PG migration 004 failed: {e}")))?;
+
     info!("PostgreSQL migrations applied successfully");
     Ok(())
 }

--- a/crates/arkd-db/src/repos/mod.rs
+++ b/crates/arkd-db/src/repos/mod.rs
@@ -20,6 +20,8 @@ pub mod offchain_tx_repo;
 #[cfg(feature = "sqlite")]
 pub mod round_repo;
 #[cfg(feature = "sqlite")]
+pub mod scheduled_session_repo;
+#[cfg(feature = "sqlite")]
 pub mod signing_session_store;
 #[cfg(feature = "sqlite")]
 pub mod vtxo_repo;
@@ -48,13 +50,20 @@ pub use offchain_tx_repo::SqliteOffchainTxRepository;
 #[cfg(feature = "sqlite")]
 pub use round_repo::SqliteRoundRepository;
 #[cfg(feature = "sqlite")]
+pub use scheduled_session_repo::SqliteScheduledSessionRepository;
+#[cfg(feature = "sqlite")]
 pub use signing_session_store::SqliteSigningSessionStore;
 #[cfg(feature = "sqlite")]
 pub use vtxo_repo::SqliteVtxoRepository;
 
 #[cfg(feature = "postgres")]
+pub mod scheduled_session_repo_pg;
+
+#[cfg(feature = "postgres")]
 pub use offchain_tx_repo_pg::PgOffchainTxRepository;
 #[cfg(feature = "postgres")]
 pub use round_repo_pg::PgRoundRepository;
+#[cfg(feature = "postgres")]
+pub use scheduled_session_repo_pg::PgScheduledSessionRepository;
 #[cfg(feature = "postgres")]
 pub use vtxo_repo_pg::PgVtxoRepository;

--- a/crates/arkd-db/src/repos/scheduled_session_repo.rs
+++ b/crates/arkd-db/src/repos/scheduled_session_repo.rs
@@ -1,0 +1,157 @@
+//! Scheduled-session config repository — SQLite implementation of
+//! `arkd_core::ports::ScheduledSessionRepository`
+
+use arkd_core::domain::ScheduledSessionConfig;
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::ScheduledSessionRepository;
+use async_trait::async_trait;
+use sqlx::SqlitePool;
+use tracing::debug;
+
+/// SQLite-backed scheduled-session config repository (singleton row).
+pub struct SqliteScheduledSessionRepository {
+    pool: SqlitePool,
+}
+
+impl SqliteScheduledSessionRepository {
+    /// Create a new repository backed by the given SQLite pool.
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ScheduledSessionRepository for SqliteScheduledSessionRepository {
+    async fn get(&self) -> ArkResult<Option<ScheduledSessionConfig>> {
+        debug!("Getting scheduled session config");
+
+        let row = sqlx::query_as::<_, ScheduledSessionRow>(
+            "SELECT round_interval_secs, round_lifetime_secs, max_intents_per_round \
+             FROM scheduled_session_config WHERE id = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(row.map(|r| r.into_config()))
+    }
+
+    async fn upsert(&self, config: ScheduledSessionConfig) -> ArkResult<()> {
+        debug!(
+            interval = config.round_interval_secs,
+            lifetime = config.round_lifetime_secs,
+            max_intents = config.max_intents_per_round,
+            "Upserting scheduled session config"
+        );
+
+        sqlx::query(
+            "INSERT INTO scheduled_session_config (id, round_interval_secs, round_lifetime_secs, max_intents_per_round) \
+             VALUES (1, ?1, ?2, ?3) \
+             ON CONFLICT(id) DO UPDATE SET \
+                 round_interval_secs = excluded.round_interval_secs, \
+                 round_lifetime_secs = excluded.round_lifetime_secs, \
+                 max_intents_per_round = excluded.max_intents_per_round",
+        )
+        .bind(config.round_interval_secs as i32)
+        .bind(config.round_lifetime_secs as i32)
+        .bind(config.max_intents_per_round as i32)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn clear(&self) -> ArkResult<()> {
+        debug!("Clearing scheduled session config");
+
+        sqlx::query("DELETE FROM scheduled_session_config WHERE id = 1")
+            .execute(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct ScheduledSessionRow {
+    round_interval_secs: i32,
+    round_lifetime_secs: i32,
+    max_intents_per_round: i32,
+}
+
+impl ScheduledSessionRow {
+    fn into_config(self) -> ScheduledSessionConfig {
+        ScheduledSessionConfig {
+            round_interval_secs: self.round_interval_secs as u32,
+            round_lifetime_secs: self.round_lifetime_secs as u32,
+            max_intents_per_round: self.max_intents_per_round as u32,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn setup() -> (Database, SqliteScheduledSessionRepository) {
+        let db = Database::connect_in_memory().await.unwrap();
+        let repo = SqliteScheduledSessionRepository::new(db.sqlite_pool().unwrap().clone());
+        (db, repo)
+    }
+
+    #[tokio::test]
+    async fn test_get_returns_none_when_empty() {
+        let (_db, repo) = setup().await;
+        let result = repo.get().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_upsert_and_get() {
+        let (_db, repo) = setup().await;
+        let config = ScheduledSessionConfig::new(10, 30, 128);
+        repo.upsert(config.clone()).await.unwrap();
+
+        let found = repo.get().await.unwrap().unwrap();
+        assert_eq!(found, config);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_overwrites() {
+        let (_db, repo) = setup().await;
+
+        repo.upsert(ScheduledSessionConfig::new(10, 30, 128))
+            .await
+            .unwrap();
+        repo.upsert(ScheduledSessionConfig::new(20, 60, 256))
+            .await
+            .unwrap();
+
+        let found = repo.get().await.unwrap().unwrap();
+        assert_eq!(found.round_interval_secs, 20);
+        assert_eq!(found.round_lifetime_secs, 60);
+        assert_eq!(found.max_intents_per_round, 256);
+    }
+
+    #[tokio::test]
+    async fn test_clear() {
+        let (_db, repo) = setup().await;
+        repo.upsert(ScheduledSessionConfig::new(10, 30, 128))
+            .await
+            .unwrap();
+
+        repo.clear().await.unwrap();
+        let result = repo.get().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_clear_when_empty_is_ok() {
+        let (_db, repo) = setup().await;
+        // Should not error even when nothing to delete
+        repo.clear().await.unwrap();
+    }
+}

--- a/crates/arkd-db/src/repos/scheduled_session_repo_pg.rs
+++ b/crates/arkd-db/src/repos/scheduled_session_repo_pg.rs
@@ -1,0 +1,92 @@
+//! Scheduled-session config repository — PostgreSQL implementation of
+//! `arkd_core::ports::ScheduledSessionRepository`
+
+use arkd_core::domain::ScheduledSessionConfig;
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::ScheduledSessionRepository;
+use async_trait::async_trait;
+use sqlx::PgPool;
+use tracing::debug;
+
+/// PostgreSQL-backed scheduled-session config repository (singleton row).
+pub struct PgScheduledSessionRepository {
+    pool: PgPool,
+}
+
+impl PgScheduledSessionRepository {
+    /// Create a new repository backed by the given PostgreSQL pool.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl ScheduledSessionRepository for PgScheduledSessionRepository {
+    async fn get(&self) -> ArkResult<Option<ScheduledSessionConfig>> {
+        debug!("Getting scheduled session config (pg)");
+
+        let row = sqlx::query_as::<_, ScheduledSessionRow>(
+            "SELECT round_interval_secs, round_lifetime_secs, max_intents_per_round \
+             FROM scheduled_session_config WHERE id = 1",
+        )
+        .fetch_optional(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(row.map(|r| r.into_config()))
+    }
+
+    async fn upsert(&self, config: ScheduledSessionConfig) -> ArkResult<()> {
+        debug!(
+            interval = config.round_interval_secs,
+            lifetime = config.round_lifetime_secs,
+            max_intents = config.max_intents_per_round,
+            "Upserting scheduled session config (pg)"
+        );
+
+        sqlx::query(
+            "INSERT INTO scheduled_session_config (id, round_interval_secs, round_lifetime_secs, max_intents_per_round) \
+             VALUES (1, $1, $2, $3) \
+             ON CONFLICT (id) DO UPDATE SET \
+                 round_interval_secs = EXCLUDED.round_interval_secs, \
+                 round_lifetime_secs = EXCLUDED.round_lifetime_secs, \
+                 max_intents_per_round = EXCLUDED.max_intents_per_round",
+        )
+        .bind(config.round_interval_secs as i32)
+        .bind(config.round_lifetime_secs as i32)
+        .bind(config.max_intents_per_round as i32)
+        .execute(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn clear(&self) -> ArkResult<()> {
+        debug!("Clearing scheduled session config (pg)");
+
+        sqlx::query("DELETE FROM scheduled_session_config WHERE id = 1")
+            .execute(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct ScheduledSessionRow {
+    round_interval_secs: i32,
+    round_lifetime_secs: i32,
+    max_intents_per_round: i32,
+}
+
+impl ScheduledSessionRow {
+    fn into_config(self) -> ScheduledSessionConfig {
+        ScheduledSessionConfig {
+            round_interval_secs: self.round_interval_secs as u32,
+            round_lifetime_secs: self.round_lifetime_secs as u32,
+            max_intents_per_round: self.max_intents_per_round as u32,
+        }
+    }
+}


### PR DESCRIPTION
Closes #271

Persists scheduled session configuration across restarts.

**Changes:**
- `ScheduledSession` domain model in `arkd-core`
- `ScheduledSessionRepository` trait in ports
- SQLite implementation + migration (`006_scheduled_sessions.sql`)
- PostgreSQL implementation + migration (`pg/004_scheduled_sessions.sql`)
- Wired into AdminService UpdateScheduledSessionConfig / Clear / Get handlers