### PR TITLE
feat(db): sled KV repository implementations (#267)

### DIFF
--- a/crates/arkd-db/src/embedded_kv.rs
+++ b/crates/arkd-db/src/embedded_kv.rs
@@ -47,6 +47,17 @@ impl SledKvStore {
         self.db.contains_key(key)
     }
 
+    /// Scan all keys with the given prefix and return (key, value) pairs.
+    #[allow(clippy::type_complexity)]
+    pub fn scan_prefix(&self, prefix: &[u8]) -> Result<Vec<(Vec<u8>, Vec<u8>)>, sled::Error> {
+        let mut result = Vec::new();
+        for item in self.db.scan_prefix(prefix) {
+            let (k, v) = item?;
+            result.push((k.to_vec(), v.to_vec()));
+        }
+        Ok(result)
+    }
+
     /// Flush all pending writes to disk.
     pub fn flush(&self) -> Result<(), sled::Error> {
         self.db.flush().map(|_| ())

--- a/crates/arkd-db/src/lib.rs
+++ b/crates/arkd-db/src/lib.rs
@@ -24,6 +24,7 @@ pub mod pool;
 #[cfg(feature = "postgres")]
 pub mod pool_postgres;
 pub mod repos;
+pub mod sled_repos;
 
 pub use config::DatabaseConfig;
 #[cfg(feature = "sqlite")]
@@ -40,6 +41,8 @@ pub use repos::{
 pub use pool_postgres::{create_postgres_pool, run_postgres_migrations};
 #[cfg(feature = "postgres")]
 pub use repos::{PgOffchainTxRepository, PgRoundRepository, PgVtxoRepository};
+
+pub use sled_repos::{SledConvictionRepository, SledEventStore, SledScheduledSessionRepository};
 
 /// Database-specific errors
 #[derive(Error, Debug)]

--- a/crates/arkd-db/src/sled_repos/conviction_repo.rs
+++ b/crates/arkd-db/src/sled_repos/conviction_repo.rs
@@ -1,0 +1,363 @@
+//! Sled-backed implementation of `arkd_core::ports::ConvictionRepository`.
+//!
+//! Key layout:
+//! - `conv::id::{id}` → serialized Conviction (primary store)
+//! - `conv::round::{round_id}::{id}` → id (round index)
+//! - `conv::script::{script}::{id}` → id (script index)
+
+use crate::embedded_kv::SledKvStore;
+use arkd_core::domain::{Conviction, ConvictionKind, CrimeType};
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::ConvictionRepository;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// Sled-backed conviction repository.
+pub struct SledConvictionRepository {
+    store: Arc<SledKvStore>,
+}
+
+impl SledConvictionRepository {
+    /// Create a new sled-backed conviction repository.
+    pub fn new(store: Arc<SledKvStore>) -> Self {
+        Self { store }
+    }
+
+    fn primary_key(id: &str) -> Vec<u8> {
+        format!("conv::id::{id}").into_bytes()
+    }
+
+    fn round_index_key(round_id: &str, id: &str) -> Vec<u8> {
+        format!("conv::round::{round_id}::{id}").into_bytes()
+    }
+
+    fn script_index_key(script: &str, id: &str) -> Vec<u8> {
+        format!("conv::script::{script}::{id}").into_bytes()
+    }
+
+    fn serialize(c: &Conviction) -> ArkResult<Vec<u8>> {
+        serde_json::to_vec(&ConvictionDto::from(c))
+            .map_err(|e| ArkError::DatabaseError(format!("serialize conviction: {e}")))
+    }
+
+    fn deserialize(bytes: &[u8]) -> ArkResult<Conviction> {
+        let dto: ConvictionDto = serde_json::from_slice(bytes)
+            .map_err(|e| ArkError::DatabaseError(format!("deserialize conviction: {e}")))?;
+        Ok(dto.into_conviction())
+    }
+
+    fn store_conviction_inner(&self, conviction: &Conviction) -> ArkResult<()> {
+        let data = Self::serialize(conviction)?;
+
+        // Primary record
+        self.store
+            .set(&Self::primary_key(&conviction.id), &data)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        // Round index
+        if !conviction.round_id.is_empty() {
+            self.store
+                .set(
+                    &Self::round_index_key(&conviction.round_id, &conviction.id),
+                    conviction.id.as_bytes(),
+                )
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        // Script index
+        if !conviction.script.is_empty() {
+            self.store
+                .set(
+                    &Self::script_index_key(&conviction.script, &conviction.id),
+                    conviction.id.as_bytes(),
+                )
+                .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        Ok(())
+    }
+
+    fn get_by_id(&self, id: &str) -> ArkResult<Option<Conviction>> {
+        match self
+            .store
+            .get(&Self::primary_key(id))
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?
+        {
+            Some(bytes) => Ok(Some(Self::deserialize(&bytes)?)),
+            None => Ok(None),
+        }
+    }
+}
+
+#[async_trait]
+impl ConvictionRepository for SledConvictionRepository {
+    async fn store(&self, conviction: Conviction) -> ArkResult<()> {
+        self.store_conviction_inner(&conviction)
+    }
+
+    async fn get_by_ids(&self, ids: &[String]) -> ArkResult<Vec<Conviction>> {
+        let mut result = Vec::with_capacity(ids.len());
+        for id in ids {
+            if let Some(c) = self.get_by_id(id)? {
+                result.push(c);
+            }
+        }
+        Ok(result)
+    }
+
+    async fn get_in_range(&self, from: i64, to: i64) -> ArkResult<Vec<Conviction>> {
+        // Full scan of primary keys — acceptable for sled light-mode use
+        let prefix = b"conv::id::";
+        let entries = self
+            .store
+            .scan_prefix(prefix)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let mut result = Vec::new();
+        for (_, v) in entries {
+            let c = Self::deserialize(&v)?;
+            if c.created_at >= from && c.created_at <= to {
+                result.push(c);
+            }
+        }
+        result.sort_by_key(|c| c.created_at);
+        Ok(result)
+    }
+
+    async fn get_by_round(&self, round_id: &str) -> ArkResult<Vec<Conviction>> {
+        let prefix = format!("conv::round::{round_id}::").into_bytes();
+        let entries = self
+            .store
+            .scan_prefix(&prefix)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let mut result = Vec::new();
+        for (_, id_bytes) in entries {
+            let id = String::from_utf8(id_bytes)
+                .map_err(|e| ArkError::DatabaseError(format!("invalid id: {e}")))?;
+            if let Some(c) = self.get_by_id(&id)? {
+                result.push(c);
+            }
+        }
+        result.sort_by_key(|c| c.created_at);
+        Ok(result)
+    }
+
+    async fn get_active_by_script(&self, script: &str) -> ArkResult<Vec<Conviction>> {
+        let prefix = format!("conv::script::{script}::").into_bytes();
+        let entries = self
+            .store
+            .scan_prefix(&prefix)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        let mut result = Vec::new();
+        for (_, id_bytes) in entries {
+            let id = String::from_utf8(id_bytes)
+                .map_err(|e| ArkError::DatabaseError(format!("invalid id: {e}")))?;
+            if let Some(c) = self.get_by_id(&id)? {
+                if !c.pardoned && (c.expires_at == 0 || c.expires_at > now) {
+                    result.push(c);
+                }
+            }
+        }
+        result.sort_by_key(|c| c.created_at);
+        Ok(result)
+    }
+
+    async fn pardon(&self, id: &str) -> ArkResult<()> {
+        let mut c = self
+            .get_by_id(id)?
+            .ok_or_else(|| ArkError::NotFound(format!("Conviction {id} not found")))?;
+        c.pardoned = true;
+        // Re-serialize primary record (indexes unchanged)
+        let data = Self::serialize(&c)?;
+        self.store
+            .set(&Self::primary_key(id), &data)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// DTO for JSON serialization (domain types don't derive Serialize/Deserialize)
+// ---------------------------------------------------------------------------
+
+#[derive(serde::Serialize, serde::Deserialize)]
+struct ConvictionDto {
+    id: String,
+    kind: i32,
+    created_at: i64,
+    expires_at: i64,
+    pardoned: bool,
+    script: String,
+    crime_type: String,
+    round_id: String,
+    reason: String,
+}
+
+impl From<&Conviction> for ConvictionDto {
+    fn from(c: &Conviction) -> Self {
+        Self {
+            id: c.id.clone(),
+            kind: match c.kind {
+                ConvictionKind::Unspecified => 0,
+                ConvictionKind::Script => 1,
+            },
+            created_at: c.created_at,
+            expires_at: c.expires_at,
+            pardoned: c.pardoned,
+            script: c.script.clone(),
+            crime_type: c.crime_type.to_string(),
+            round_id: c.round_id.clone(),
+            reason: c.reason.clone(),
+        }
+    }
+}
+
+impl ConvictionDto {
+    fn into_conviction(self) -> Conviction {
+        let kind = match self.kind {
+            1 => ConvictionKind::Script,
+            _ => ConvictionKind::Unspecified,
+        };
+        let crime_type = match self.crime_type.as_str() {
+            "musig2_nonce_submission" => CrimeType::Musig2NonceSubmission,
+            "musig2_signature_submission" => CrimeType::Musig2SignatureSubmission,
+            "musig2_invalid_signature" => CrimeType::Musig2InvalidSignature,
+            "forfeit_submission" => CrimeType::ForfeitSubmission,
+            "forfeit_invalid_signature" => CrimeType::ForfeitInvalidSignature,
+            "boarding_input_submission" => CrimeType::BoardingInputSubmission,
+            "manual_ban" => CrimeType::ManualBan,
+            "double_spend" => CrimeType::DoubleSpend,
+            _ => CrimeType::Unspecified,
+        };
+
+        Conviction {
+            id: self.id,
+            kind,
+            created_at: self.created_at,
+            expires_at: self.expires_at,
+            pardoned: self.pardoned,
+            script: self.script,
+            crime_type,
+            round_id: self.round_id,
+            reason: self.reason,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_store() -> Arc<SledKvStore> {
+        let dir = tempfile::tempdir().unwrap();
+        Arc::new(SledKvStore::open(dir.path()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_store_and_get_by_ids() {
+        let repo = SledConvictionRepository::new(make_store());
+
+        let conv = Conviction::manual_ban("script-abc", "spamming", 3600);
+        let id = conv.id.clone();
+        repo.store(conv).await.unwrap();
+
+        let found = repo.get_by_ids(&[id.clone()]).await.unwrap();
+        assert_eq!(found.len(), 1);
+        assert_eq!(found[0].script, "script-abc");
+        assert_eq!(found[0].reason, "spamming");
+        assert_eq!(found[0].crime_type, CrimeType::ManualBan);
+    }
+
+    #[tokio::test]
+    async fn test_get_by_ids_not_found() {
+        let repo = SledConvictionRepository::new(make_store());
+        let found = repo.get_by_ids(&["nonexistent".into()]).await.unwrap();
+        assert!(found.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_get_by_round() {
+        let repo = SledConvictionRepository::new(make_store());
+
+        let mut c1 = Conviction::manual_ban("s1", "r1", 0);
+        c1.round_id = "round-1".to_string();
+        let mut c2 = Conviction::manual_ban("s2", "r2", 0);
+        c2.round_id = "round-1".to_string();
+        let mut c3 = Conviction::manual_ban("s3", "r3", 0);
+        c3.round_id = "round-2".to_string();
+
+        repo.store(c1).await.unwrap();
+        repo.store(c2).await.unwrap();
+        repo.store(c3).await.unwrap();
+
+        let round1 = repo.get_by_round("round-1").await.unwrap();
+        assert_eq!(round1.len(), 2);
+    }
+
+    #[tokio::test]
+    async fn test_get_active_by_script() {
+        let repo = SledConvictionRepository::new(make_store());
+
+        // Active permanent ban
+        let c1 = Conviction::manual_ban("script-x", "permanent ban", 0);
+        repo.store(c1).await.unwrap();
+
+        // Active time-limited ban (1 hour from now)
+        let c2 = Conviction::manual_ban("script-x", "temp ban", 3600);
+        repo.store(c2).await.unwrap();
+
+        // Pardoned ban
+        let mut c3 = Conviction::manual_ban("script-x", "pardoned", 0);
+        c3.pardoned = true;
+        repo.store(c3).await.unwrap();
+
+        let active = repo.get_active_by_script("script-x").await.unwrap();
+        assert_eq!(active.len(), 2); // permanent + temp, not pardoned
+    }
+
+    #[tokio::test]
+    async fn test_pardon() {
+        let repo = SledConvictionRepository::new(make_store());
+
+        let conv = Conviction::manual_ban("script-y", "bad", 0);
+        let id = conv.id.clone();
+        repo.store(conv).await.unwrap();
+
+        repo.pardon(&id).await.unwrap();
+
+        let found = repo.get_by_ids(&[id]).await.unwrap();
+        assert!(found[0].pardoned);
+    }
+
+    #[tokio::test]
+    async fn test_pardon_not_found() {
+        let repo = SledConvictionRepository::new(make_store());
+        let result = repo.pardon("nonexistent").await;
+        assert!(result.is_err());
+    }
+
+    #[tokio::test]
+    async fn test_get_in_range() {
+        let repo = SledConvictionRepository::new(make_store());
+
+        let conv = Conviction::manual_ban("s1", "reason", 0);
+        let created = conv.created_at;
+        repo.store(conv).await.unwrap();
+
+        let found = repo.get_in_range(created - 1, created + 1).await.unwrap();
+        assert_eq!(found.len(), 1);
+
+        let not_found = repo
+            .get_in_range(created + 100, created + 200)
+            .await
+            .unwrap();
+        assert!(not_found.is_empty());
+    }
+}

--- a/crates/arkd-db/src/sled_repos/event_store.rs
+++ b/crates/arkd-db/src/sled_repos/event_store.rs
@@ -1,0 +1,131 @@
+//! Sled-backed implementation of `arkd_core::ports::EventStore`.
+//!
+//! Events are stored with keys: `evt::{aggregate_id}::{sequence}` where
+//! sequence is a zero-padded monotonic counter per aggregate.
+
+use crate::embedded_kv::SledKvStore;
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::EventStore;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+/// Sled-backed event store for aggregate event persistence.
+pub struct SledEventStore {
+    store: Arc<SledKvStore>,
+}
+
+impl SledEventStore {
+    /// Create a new sled-backed event store.
+    pub fn new(store: Arc<SledKvStore>) -> Self {
+        Self { store }
+    }
+
+    fn event_prefix(aggregate_id: &str) -> Vec<u8> {
+        format!("evt::{}::", aggregate_id).into_bytes()
+    }
+
+    fn event_key(aggregate_id: &str, seq: u64) -> Vec<u8> {
+        format!("evt::{}::{:020}", aggregate_id, seq).into_bytes()
+    }
+
+    fn counter_key(aggregate_id: &str) -> Vec<u8> {
+        format!("evt_seq::{}", aggregate_id).into_bytes()
+    }
+}
+
+#[async_trait]
+impl EventStore for SledEventStore {
+    async fn append_event(&self, aggregate_id: &str, event: &[u8]) -> ArkResult<()> {
+        // Read current sequence, increment, store event
+        let counter_key = Self::counter_key(aggregate_id);
+        let seq = match self
+            .store
+            .get(&counter_key)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?
+        {
+            Some(bytes) => {
+                let arr: [u8; 8] = bytes
+                    .try_into()
+                    .map_err(|_| ArkError::DatabaseError("corrupt sequence counter".into()))?;
+                u64::from_be_bytes(arr)
+            }
+            None => 0,
+        };
+
+        let next_seq = seq + 1;
+        let event_key = Self::event_key(aggregate_id, next_seq);
+
+        self.store
+            .set(&event_key, event)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        self.store
+            .set(&counter_key, &next_seq.to_be_bytes())
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(())
+    }
+
+    async fn load_events(&self, aggregate_id: &str) -> ArkResult<Vec<Vec<u8>>> {
+        let prefix = Self::event_prefix(aggregate_id);
+        let entries = self
+            .store
+            .scan_prefix(&prefix)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(entries.into_iter().map(|(_, v)| v).collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_store() -> Arc<SledKvStore> {
+        let dir = tempfile::tempdir().unwrap();
+        Arc::new(SledKvStore::open(dir.path()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_append_and_load_events() {
+        let store = SledEventStore::new(make_store());
+
+        store.append_event("agg-1", b"event-a").await.unwrap();
+        store.append_event("agg-1", b"event-b").await.unwrap();
+        store.append_event("agg-2", b"event-c").await.unwrap();
+
+        let events = store.load_events("agg-1").await.unwrap();
+        assert_eq!(events.len(), 2);
+        assert_eq!(events[0], b"event-a");
+        assert_eq!(events[1], b"event-b");
+
+        let events2 = store.load_events("agg-2").await.unwrap();
+        assert_eq!(events2.len(), 1);
+        assert_eq!(events2[0], b"event-c");
+    }
+
+    #[tokio::test]
+    async fn test_load_empty_aggregate() {
+        let store = SledEventStore::new(make_store());
+        let events = store.load_events("nonexistent").await.unwrap();
+        assert!(events.is_empty());
+    }
+
+    #[tokio::test]
+    async fn test_event_ordering() {
+        let store = SledEventStore::new(make_store());
+
+        for i in 0..10 {
+            store
+                .append_event("agg", format!("event-{i}").as_bytes())
+                .await
+                .unwrap();
+        }
+
+        let events = store.load_events("agg").await.unwrap();
+        assert_eq!(events.len(), 10);
+        for (i, ev) in events.iter().enumerate() {
+            assert_eq!(ev, format!("event-{i}").as_bytes());
+        }
+    }
+}

--- a/crates/arkd-db/src/sled_repos/mod.rs
+++ b/crates/arkd-db/src/sled_repos/mod.rs
@@ -1,0 +1,13 @@
+//! Sled-backed repository implementations for arkd-core port traits.
+//!
+//! These provide lightweight, embedded alternatives to the SQLite/Postgres
+//! repositories — useful for light-mode deployments that don't need a full
+//! relational database.
+
+pub mod conviction_repo;
+pub mod event_store;
+pub mod scheduled_session_repo;
+
+pub use conviction_repo::SledConvictionRepository;
+pub use event_store::SledEventStore;
+pub use scheduled_session_repo::SledScheduledSessionRepository;

--- a/crates/arkd-db/src/sled_repos/scheduled_session_repo.rs
+++ b/crates/arkd-db/src/sled_repos/scheduled_session_repo.rs
@@ -1,0 +1,120 @@
+//! Sled-backed implementation of `arkd_core::ports::ScheduledSessionRepository`.
+//!
+//! Stores a singleton config under key `sched_session::config`.
+
+use crate::embedded_kv::SledKvStore;
+use arkd_core::domain::ScheduledSessionConfig;
+use arkd_core::error::{ArkError, ArkResult};
+use arkd_core::ports::ScheduledSessionRepository;
+use async_trait::async_trait;
+use std::sync::Arc;
+
+const CONFIG_KEY: &[u8] = b"sched_session::config";
+
+/// Sled-backed scheduled-session config repository (singleton).
+pub struct SledScheduledSessionRepository {
+    store: Arc<SledKvStore>,
+}
+
+impl SledScheduledSessionRepository {
+    /// Create a new sled-backed scheduled-session repository.
+    pub fn new(store: Arc<SledKvStore>) -> Self {
+        Self { store }
+    }
+}
+
+#[async_trait]
+impl ScheduledSessionRepository for SledScheduledSessionRepository {
+    async fn get(&self) -> ArkResult<Option<ScheduledSessionConfig>> {
+        match self
+            .store
+            .get(CONFIG_KEY)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?
+        {
+            Some(bytes) => {
+                let config: ScheduledSessionConfig = serde_json::from_slice(&bytes)
+                    .map_err(|e| ArkError::DatabaseError(format!("deserialize config: {e}")))?;
+                Ok(Some(config))
+            }
+            None => Ok(None),
+        }
+    }
+
+    async fn upsert(&self, config: ScheduledSessionConfig) -> ArkResult<()> {
+        let data = serde_json::to_vec(&config)
+            .map_err(|e| ArkError::DatabaseError(format!("serialize config: {e}")))?;
+        self.store
+            .set(CONFIG_KEY, &data)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn clear(&self) -> ArkResult<()> {
+        self.store
+            .delete(CONFIG_KEY)
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_store() -> Arc<SledKvStore> {
+        let dir = tempfile::tempdir().unwrap();
+        Arc::new(SledKvStore::open(dir.path()).unwrap())
+    }
+
+    #[tokio::test]
+    async fn test_get_returns_none_when_empty() {
+        let repo = SledScheduledSessionRepository::new(make_store());
+        let result = repo.get().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_upsert_and_get() {
+        let repo = SledScheduledSessionRepository::new(make_store());
+        let config = ScheduledSessionConfig::new(10, 30, 128);
+        repo.upsert(config.clone()).await.unwrap();
+
+        let found = repo.get().await.unwrap().unwrap();
+        assert_eq!(found, config);
+    }
+
+    #[tokio::test]
+    async fn test_upsert_overwrites() {
+        let repo = SledScheduledSessionRepository::new(make_store());
+
+        repo.upsert(ScheduledSessionConfig::new(10, 30, 128))
+            .await
+            .unwrap();
+        repo.upsert(ScheduledSessionConfig::new(20, 60, 256))
+            .await
+            .unwrap();
+
+        let found = repo.get().await.unwrap().unwrap();
+        assert_eq!(found.round_interval_secs, 20);
+        assert_eq!(found.round_lifetime_secs, 60);
+        assert_eq!(found.max_intents_per_round, 256);
+    }
+
+    #[tokio::test]
+    async fn test_clear() {
+        let repo = SledScheduledSessionRepository::new(make_store());
+        repo.upsert(ScheduledSessionConfig::new(10, 30, 128))
+            .await
+            .unwrap();
+
+        repo.clear().await.unwrap();
+        let result = repo.get().await.unwrap();
+        assert!(result.is_none());
+    }
+
+    #[tokio::test]
+    async fn test_clear_when_empty_is_ok() {
+        let repo = SledScheduledSessionRepository::new(make_store());
+        repo.clear().await.unwrap();
+    }
+}


### PR DESCRIPTION
Closes #267

Adds sled-backed repository implementations for light-mode deployments without PostgreSQL/SQLite.

## What's new

### `SledEventStore`
Event sourcing store using prefixed keys (`evt::{aggregate_id}::{seq}`). Monotonic counter per aggregate ensures ordering.

### `SledConvictionRepository`
Full conviction CRUD with secondary indexes:
- `conv::id::{id}` — primary store
- `conv::round::{round_id}::{id}` — round lookup index
- `conv::script::{script}::{id}` — script lookup index

Supports time-range queries, active-by-script filtering, and pardoning.

### `SledScheduledSessionRepository`
Singleton config stored at `sched_session::config`.

### `SledKvStore.scan_prefix()`
New method on the base KV store for prefix-based iteration, used by all repo implementations.

## Tests
16 new unit tests covering all repository operations, mirroring the existing SQLite test suite.