### PR TITLE
feat(client): full client SDK with wallet, explorer, store (#270)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,11 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "arkd-api",
+ "bitcoin",
+ "hex",
  "prost 0.12.6",
+ "reqwest 0.12.28",
+ "secp256k1 0.29.1",
  "serde",
  "serde_json",
  "thiserror 1.0.69",

--- a/crates/arkd-client/Cargo.toml
+++ b/crates/arkd-client/Cargo.toml
@@ -14,3 +14,13 @@ serde_json = "1"
 tracing = "0.1"
 prost = "0.12"
 thiserror = "1"
+
+# Bitcoin / crypto
+bitcoin = { version = "0.32", features = ["serde", "rand"] }
+secp256k1 = { version = "0.29", features = ["rand", "rand-std"] }
+
+# HTTP client for Esplora
+reqwest = { version = "0.12", features = ["json"] }
+
+# Utilities
+hex = "0.4"

--- a/crates/arkd-client/src/error.rs
+++ b/crates/arkd-client/src/error.rs
@@ -10,6 +10,12 @@ pub enum ClientError {
     InvalidResponse(String),
     #[error("Serialization error: {0}")]
     Serialization(String),
+    #[error("Wallet error: {0}")]
+    Wallet(String),
+    #[error("Explorer error: {0}")]
+    Explorer(String),
+    #[error("Store error: {0}")]
+    Store(String),
 }
 
 pub type ClientResult<T> = Result<T, ClientError>;

--- a/crates/arkd-client/src/explorer.rs
+++ b/crates/arkd-client/src/explorer.rs
@@ -1,0 +1,288 @@
+//! Esplora block explorer client for the Ark client SDK.
+//!
+//! Provides HTTP access to an Esplora/Mempool API for querying UTXOs,
+//! broadcasting transactions, and checking transaction status.
+//! Mirrors Go's `client-lib/explorer` functionality.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::{ClientError, ClientResult};
+
+/// A UTXO returned by the Esplora API.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Utxo {
+    /// Transaction ID.
+    pub txid: String,
+    /// Output index.
+    pub vout: u32,
+    /// Value in satoshis.
+    pub value: u64,
+    /// Confirmation status.
+    pub status: TxStatus,
+}
+
+/// Transaction confirmation status from Esplora.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxStatus {
+    /// Whether the transaction is confirmed.
+    pub confirmed: bool,
+    /// Block height (if confirmed).
+    pub block_height: Option<u64>,
+    /// Block hash (if confirmed).
+    pub block_hash: Option<String>,
+    /// Block time (if confirmed).
+    pub block_time: Option<u64>,
+}
+
+/// Full transaction info from Esplora.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct TxInfo {
+    /// Transaction ID.
+    pub txid: String,
+    /// Fee paid in satoshis.
+    pub fee: u64,
+    /// Confirmation status.
+    pub status: TxStatus,
+}
+
+/// HTTP client for an Esplora-compatible block explorer API.
+///
+/// Supports standard Esplora endpoints for UTXO queries, transaction
+/// broadcasting, and status checks.
+#[derive(Debug, Clone)]
+pub struct EsploraExplorer {
+    base_url: String,
+    client: reqwest::Client,
+}
+
+impl EsploraExplorer {
+    /// Create a new explorer client pointing at `base_url`.
+    ///
+    /// # Example
+    /// ```
+    /// use arkd_client::explorer::EsploraExplorer;
+    /// let explorer = EsploraExplorer::new("https://blockstream.info/api");
+    /// ```
+    pub fn new(base_url: impl Into<String>) -> Self {
+        let mut url: String = base_url.into();
+        // Strip trailing slash for consistent URL building.
+        while url.ends_with('/') {
+            url.pop();
+        }
+        Self {
+            base_url: url,
+            client: reqwest::Client::new(),
+        }
+    }
+
+    /// Create with a custom `reqwest::Client` (for timeouts, proxies, etc.).
+    pub fn with_client(base_url: impl Into<String>, client: reqwest::Client) -> Self {
+        let mut url: String = base_url.into();
+        while url.ends_with('/') {
+            url.pop();
+        }
+        Self {
+            base_url: url,
+            client,
+        }
+    }
+
+    /// Return the configured base URL.
+    pub fn base_url(&self) -> &str {
+        &self.base_url
+    }
+
+    /// Get UTXOs for a Bitcoin address.
+    pub async fn get_utxos(&self, address: &str) -> ClientResult<Vec<Utxo>> {
+        let url = format!("{}/address/{}/utxo", self.base_url, address);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("GET {url} failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ClientError::Explorer(format!(
+                "GET {url} returned {status}: {body}"
+            )));
+        }
+
+        resp.json::<Vec<Utxo>>()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("Failed to parse UTXOs: {e}")))
+    }
+
+    /// Get transaction info by txid.
+    pub async fn get_tx(&self, txid: &str) -> ClientResult<TxInfo> {
+        let url = format!("{}/tx/{}", self.base_url, txid);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("GET {url} failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ClientError::Explorer(format!(
+                "GET {url} returned {status}: {body}"
+            )));
+        }
+
+        resp.json::<TxInfo>()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("Failed to parse tx info: {e}")))
+    }
+
+    /// Get transaction status (confirmed/unconfirmed).
+    pub async fn get_tx_status(&self, txid: &str) -> ClientResult<TxStatus> {
+        let url = format!("{}/tx/{}/status", self.base_url, txid);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("GET {url} failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ClientError::Explorer(format!(
+                "GET {url} returned {status}: {body}"
+            )));
+        }
+
+        resp.json::<TxStatus>()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("Failed to parse tx status: {e}")))
+    }
+
+    /// Broadcast a raw transaction (hex-encoded).
+    ///
+    /// Returns the txid on success.
+    pub async fn broadcast_tx(&self, tx_hex: &str) -> ClientResult<String> {
+        let url = format!("{}/tx", self.base_url);
+        let resp = self
+            .client
+            .post(&url)
+            .header("Content-Type", "text/plain")
+            .body(tx_hex.to_string())
+            .send()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("POST {url} failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ClientError::Explorer(format!(
+                "Broadcast failed ({status}): {body}"
+            )));
+        }
+
+        resp.text()
+            .await
+            .map(|s| s.trim().to_string())
+            .map_err(|e| ClientError::Explorer(format!("Failed to read broadcast response: {e}")))
+    }
+
+    /// Get the recommended fee rates (in sat/vB).
+    ///
+    /// Returns a map of confirmation targets to fee rates.
+    pub async fn get_fee_estimates(&self) -> ClientResult<std::collections::HashMap<String, f64>> {
+        let url = format!("{}/fee-estimates", self.base_url);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("GET {url} failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ClientError::Explorer(format!(
+                "GET {url} returned {status}: {body}"
+            )));
+        }
+
+        resp.json()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("Failed to parse fee estimates: {e}")))
+    }
+
+    /// Get the current block tip height.
+    pub async fn get_tip_height(&self) -> ClientResult<u64> {
+        let url = format!("{}/blocks/tip/height", self.base_url);
+        let resp = self
+            .client
+            .get(&url)
+            .send()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("GET {url} failed: {e}")))?;
+
+        if !resp.status().is_success() {
+            let status = resp.status();
+            let body = resp.text().await.unwrap_or_default();
+            return Err(ClientError::Explorer(format!(
+                "GET {url} returned {status}: {body}"
+            )));
+        }
+
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| ClientError::Explorer(format!("Failed to read tip height: {e}")))?;
+        text.trim()
+            .parse::<u64>()
+            .map_err(|e| ClientError::Explorer(format!("Invalid tip height '{text}': {e}")))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_explorer_new() {
+        let e = EsploraExplorer::new("https://blockstream.info/api");
+        assert_eq!(e.base_url(), "https://blockstream.info/api");
+    }
+
+    #[test]
+    fn test_explorer_strips_trailing_slash() {
+        let e = EsploraExplorer::new("https://blockstream.info/api/");
+        assert_eq!(e.base_url(), "https://blockstream.info/api");
+    }
+
+    #[test]
+    fn test_utxo_deserialize() {
+        let json = r#"[{
+            "txid": "abc123",
+            "vout": 0,
+            "value": 50000,
+            "status": {
+                "confirmed": true,
+                "block_height": 100,
+                "block_hash": "def456",
+                "block_time": 1700000000
+            }
+        }]"#;
+        let utxos: Vec<Utxo> = serde_json::from_str(json).unwrap();
+        assert_eq!(utxos.len(), 1);
+        assert_eq!(utxos[0].txid, "abc123");
+        assert_eq!(utxos[0].value, 50000);
+        assert!(utxos[0].status.confirmed);
+    }
+
+    #[test]
+    fn test_tx_status_unconfirmed() {
+        let json = r#"{"confirmed": false}"#;
+        let status: TxStatus = serde_json::from_str(json).unwrap();
+        assert!(!status.confirmed);
+        assert!(status.block_height.is_none());
+    }
+}

--- a/crates/arkd-client/src/lib.rs
+++ b/crates/arkd-client/src/lib.rs
@@ -1,8 +1,34 @@
-//! arkd-client — gRPC client library for arkd-rs.
+//! arkd-client — gRPC client library and SDK for arkd-rs.
 //!
-//! Provides a typed Rust client for the Ark protocol server.
+//! Provides a typed Rust client for the Ark protocol server, plus a
+//! full client SDK with wallet, block explorer, and state management.
 //!
-//! # Example
+//! # Quick Start — SDK
+//!
+//! ```no_run
+//! use arkd_client::sdk::ArkSdk;
+//! use bitcoin::Network;
+//!
+//! #[tokio::main]
+//! async fn main() -> Result<(), Box<dyn std::error::Error>> {
+//!     let mut sdk = ArkSdk::generate(
+//!         "http://localhost:50051",
+//!         "http://localhost:3000",
+//!         Network::Regtest,
+//!     );
+//!     sdk.init().await?;
+//!
+//!     let balance = sdk.balance().await?;
+//!     println!("Offchain: {} sats", balance.offchain.total);
+//!
+//!     let vtxos = sdk.list_vtxos().await?;
+//!     println!("VTXOs: {}", vtxos.len());
+//!
+//!     Ok(())
+//! }
+//! ```
+//!
+//! # Low-Level Transport
 //!
 //! ```no_run
 //! use arkd_client::ArkClient;
@@ -26,7 +52,11 @@
 
 pub mod client;
 pub mod error;
+pub mod explorer;
+pub mod sdk;
+pub mod store;
 pub mod types;
+pub mod wallet;
 
 pub use client::{ArkClient, OffchainTxResult, RedeemBranch};
 pub use error::{ClientError, ClientResult};

--- a/crates/arkd-client/src/sdk.rs
+++ b/crates/arkd-client/src/sdk.rs
@@ -1,0 +1,320 @@
+//! High-level Ark client SDK.
+//!
+//! Wraps the gRPC transport (`ArkClient`), wallet (`SingleKeyWallet`),
+//! block explorer (`EsploraExplorer`), and local state store (`InMemoryStore`)
+//! into a single ergonomic interface.
+//!
+//! Mirrors Go's `client-lib` top-level `ArkClient` which composes
+//! wallet + explorer + indexer + store.
+
+use bitcoin::Network;
+
+use crate::client::ArkClient;
+use crate::error::{ClientError, ClientResult};
+use crate::explorer::EsploraExplorer;
+use crate::store::{ClientConfig, InMemoryStore};
+use crate::types::{Balance, BatchTxRes, BoardingAddress, OffchainAddress, Vtxo};
+use crate::wallet::SingleKeyWallet;
+
+/// High-level Ark SDK client that orchestrates wallet, transport, explorer,
+/// and store into a cohesive API.
+pub struct ArkSdk {
+    /// The gRPC transport client.
+    transport: ArkClient,
+    /// The local wallet (keypair).
+    wallet: SingleKeyWallet,
+    /// The block explorer client.
+    explorer: EsploraExplorer,
+    /// Local state store.
+    store: InMemoryStore,
+    /// Whether `init()` has been called successfully.
+    initialized: bool,
+}
+
+impl ArkSdk {
+    /// Create a new SDK instance with all components.
+    ///
+    /// Does **not** connect to the server — call [`init`](Self::init) to connect
+    /// and sync server metadata.
+    pub fn new(
+        server_url: impl Into<String>,
+        wallet: SingleKeyWallet,
+        esplora_url: impl Into<String>,
+    ) -> Self {
+        Self {
+            transport: ArkClient::new(server_url),
+            wallet,
+            explorer: EsploraExplorer::new(esplora_url),
+            store: InMemoryStore::new(),
+            initialized: false,
+        }
+    }
+
+    /// Create a new SDK with a freshly generated wallet.
+    pub fn generate(
+        server_url: impl Into<String>,
+        esplora_url: impl Into<String>,
+        network: Network,
+    ) -> Self {
+        Self::new(server_url, SingleKeyWallet::generate(network), esplora_url)
+    }
+
+    /// Create with a custom store (e.g. pre-loaded from disk).
+    pub fn with_store(
+        server_url: impl Into<String>,
+        wallet: SingleKeyWallet,
+        esplora_url: impl Into<String>,
+        store: InMemoryStore,
+    ) -> Self {
+        Self {
+            transport: ArkClient::new(server_url),
+            wallet,
+            explorer: EsploraExplorer::new(esplora_url),
+            store,
+            initialized: false,
+        }
+    }
+
+    // ── Accessors ──────────────────────────────────────────────────
+
+    /// Get a reference to the underlying transport client.
+    pub fn transport(&self) -> &ArkClient {
+        &self.transport
+    }
+
+    /// Get a mutable reference to the transport client.
+    pub fn transport_mut(&mut self) -> &mut ArkClient {
+        &mut self.transport
+    }
+
+    /// Get a reference to the wallet.
+    pub fn wallet(&self) -> &SingleKeyWallet {
+        &self.wallet
+    }
+
+    /// Get a reference to the explorer.
+    pub fn explorer(&self) -> &EsploraExplorer {
+        &self.explorer
+    }
+
+    /// Get a reference to the store.
+    pub fn store(&self) -> &InMemoryStore {
+        &self.store
+    }
+
+    /// Whether the SDK has been initialized (connected + synced).
+    pub fn is_initialized(&self) -> bool {
+        self.initialized
+    }
+
+    // ── Lifecycle ──────────────────────────────────────────────────
+
+    /// Initialize the SDK: connect to the server, fetch server info,
+    /// and store the configuration locally.
+    pub async fn init(&mut self) -> ClientResult<()> {
+        // Connect gRPC transport
+        self.transport.connect().await?;
+
+        // Fetch server info and store config
+        let info = self.transport.get_info().await?;
+        self.store.set_config(ClientConfig {
+            server_url: self.transport.server_url().to_string(),
+            network: info.network.clone(),
+            server_pubkey: info.pubkey.clone(),
+            session_duration: info.session_duration,
+            unilateral_exit_delay: info.unilateral_exit_delay,
+            dust: info.dust,
+        });
+
+        self.initialized = true;
+        Ok(())
+    }
+
+    fn require_init(&self) -> ClientResult<()> {
+        if !self.initialized {
+            return Err(ClientError::Wallet(
+                "SDK not initialized — call init() first".into(),
+            ));
+        }
+        Ok(())
+    }
+
+    // ── High-level operations ──────────────────────────────────────
+
+    /// Get receive addresses (onchain, offchain, boarding) for this wallet.
+    pub async fn receive(&mut self) -> ClientResult<(String, OffchainAddress, BoardingAddress)> {
+        self.require_init()?;
+        let pubkey = self.wallet.pubkey_hex();
+        self.transport.receive(&pubkey).await
+    }
+
+    /// Send satoshis off-chain to `to_address`.
+    ///
+    /// **Note:** This is currently a stub — full implementation requires
+    /// VTXO input selection and wallet-based PSBT signing.
+    pub async fn send_offchain(
+        &mut self,
+        to_address: &str,
+        amount: u64,
+    ) -> ClientResult<crate::client::OffchainTxResult> {
+        self.require_init()?;
+        let pubkey = self.wallet.pubkey_hex();
+        self.transport
+            .send_offchain(&pubkey, to_address, amount)
+            .await
+    }
+
+    /// Settle VTXOs in the next batch round.
+    pub async fn settle(&mut self, amount: u64) -> ClientResult<BatchTxRes> {
+        self.require_init()?;
+        let pubkey = self.wallet.pubkey_hex();
+        self.transport.settle(&pubkey, amount).await
+    }
+
+    /// List VTXOs for this wallet's pubkey and cache them in the store.
+    pub async fn list_vtxos(&mut self) -> ClientResult<Vec<Vtxo>> {
+        self.require_init()?;
+        let pubkey = self.wallet.pubkey_hex();
+        let vtxos = self.transport.list_vtxos(&pubkey).await?;
+        // Cache in local store
+        self.store.upsert_vtxos(vtxos.clone());
+        Ok(vtxos)
+    }
+
+    /// Get the combined balance for this wallet's pubkey.
+    pub async fn balance(&mut self) -> ClientResult<Balance> {
+        self.require_init()?;
+        let pubkey = self.wallet.pubkey_hex();
+        self.transport.get_balance(&pubkey).await
+    }
+
+    /// Redeem bearer notes and receive VTXOs.
+    pub async fn redeem_notes(&mut self, notes: Vec<String>) -> ClientResult<String> {
+        self.require_init()?;
+        self.transport.redeem_notes(notes).await
+    }
+
+    /// Collaborative exit: move funds from off-chain VTXOs to an on-chain address.
+    pub async fn collaborative_exit(
+        &mut self,
+        onchain_address: &str,
+        amount: u64,
+    ) -> ClientResult<String> {
+        self.require_init()?;
+        // Select spendable VTXOs from the store
+        let spendable = self.store.list_spendable_vtxos();
+        let vtxo_ids: Vec<String> = spendable.iter().map(|v| v.id.clone()).collect();
+
+        if vtxo_ids.is_empty() {
+            return Err(ClientError::Wallet(
+                "No spendable VTXOs available for exit".into(),
+            ));
+        }
+
+        self.transport
+            .collaborative_exit(onchain_address, amount, vtxo_ids)
+            .await
+    }
+
+    /// Get UTXOs for an address via the block explorer.
+    pub async fn get_onchain_utxos(
+        &self,
+        address: &str,
+    ) -> ClientResult<Vec<crate::explorer::Utxo>> {
+        self.explorer.get_utxos(address).await
+    }
+
+    /// Get the current block tip height via the explorer.
+    pub async fn get_tip_height(&self) -> ClientResult<u64> {
+        self.explorer.get_tip_height().await
+    }
+
+    /// Broadcast a raw transaction via the explorer.
+    pub async fn broadcast_tx(&self, tx_hex: &str) -> ClientResult<String> {
+        self.explorer.broadcast_tx(tx_hex).await
+    }
+
+    /// Export the store state as JSON for file-based persistence.
+    pub fn export_state(&self) -> ClientResult<String> {
+        self.store
+            .to_json()
+            .map_err(|e| ClientError::Serialization(format!("Failed to export state: {e}")))
+    }
+
+    /// Import store state from a JSON string.
+    pub fn import_state(&mut self, json: &str) -> ClientResult<()> {
+        let restored = InMemoryStore::from_json(json)
+            .map_err(|e| ClientError::Serialization(format!("Failed to import state: {e}")))?;
+        self.store = restored;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sdk_new() {
+        let sdk = ArkSdk::generate(
+            "http://localhost:50051",
+            "http://localhost:3000",
+            Network::Regtest,
+        );
+        assert!(!sdk.is_initialized());
+        assert!(!sdk.wallet().pubkey_hex().is_empty());
+    }
+
+    #[test]
+    fn test_sdk_with_store() {
+        let store = InMemoryStore::new();
+        store.set_metadata("test", "value");
+
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let sdk = ArkSdk::with_store(
+            "http://localhost:50051",
+            wallet,
+            "http://localhost:3000",
+            store,
+        );
+
+        assert_eq!(sdk.store().get_metadata("test").unwrap(), "value");
+    }
+
+    #[tokio::test]
+    async fn test_sdk_requires_init() {
+        let mut sdk = ArkSdk::generate(
+            "http://localhost:50051",
+            "http://localhost:3000",
+            Network::Regtest,
+        );
+
+        // All high-level ops should fail before init
+        assert!(sdk.balance().await.is_err());
+        assert!(sdk.list_vtxos().await.is_err());
+        assert!(sdk.receive().await.is_err());
+        assert!(sdk.settle(1000).await.is_err());
+        assert!(sdk.redeem_notes(vec![]).await.is_err());
+    }
+
+    #[test]
+    fn test_sdk_export_import_state() {
+        let sdk = ArkSdk::generate(
+            "http://localhost:50051",
+            "http://localhost:3000",
+            Network::Regtest,
+        );
+        sdk.store().set_metadata("hello", "world");
+
+        let json = sdk.export_state().unwrap();
+        assert!(json.contains("hello"));
+
+        let mut sdk2 = ArkSdk::generate(
+            "http://localhost:50051",
+            "http://localhost:3000",
+            Network::Regtest,
+        );
+        sdk2.import_state(&json).unwrap();
+        assert_eq!(sdk2.store().get_metadata("hello").unwrap(), "world");
+    }
+}

--- a/crates/arkd-client/src/store.rs
+++ b/crates/arkd-client/src/store.rs
@@ -1,0 +1,366 @@
+//! In-memory client-side state store for the Ark client SDK.
+//!
+//! Provides persistence for client configuration, VTXOs, and pending
+//! transactions. Mirrors Go's `client-lib/store` with both in-memory
+//! and (future) file-backed implementations.
+
+use std::collections::HashMap;
+use std::sync::{Arc, RwLock};
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::Vtxo;
+
+/// Client configuration stored locally.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct ClientConfig {
+    /// Server URL (gRPC endpoint).
+    pub server_url: String,
+    /// Bitcoin network (mainnet, testnet, signet, regtest).
+    pub network: String,
+    /// Server's public key (hex).
+    pub server_pubkey: String,
+    /// Round session duration in seconds.
+    pub session_duration: u32,
+    /// Unilateral exit delay in blocks.
+    pub unilateral_exit_delay: u32,
+    /// Dust limit in satoshis.
+    pub dust: u64,
+}
+
+/// A pending off-chain transaction awaiting confirmation.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct PendingTx {
+    /// Transaction ID.
+    pub tx_id: String,
+    /// Amount in satoshis.
+    pub amount: u64,
+    /// Destination address/script.
+    pub destination: String,
+    /// Unix timestamp when created.
+    pub created_at: i64,
+    /// Current status (pending, confirmed, failed).
+    pub status: String,
+}
+
+/// Thread-safe in-memory store for client state.
+///
+/// All methods are synchronous and use interior mutability via `RwLock`.
+/// The store is `Clone`-able and `Send + Sync` for use across async tasks.
+#[derive(Debug, Clone)]
+pub struct InMemoryStore {
+    inner: Arc<RwLock<StoreInner>>,
+}
+
+#[derive(Debug)]
+struct StoreInner {
+    config: Option<ClientConfig>,
+    vtxos: HashMap<String, Vtxo>,
+    pending_txs: HashMap<String, PendingTx>,
+    /// Arbitrary key-value metadata.
+    metadata: HashMap<String, String>,
+}
+
+impl Default for InMemoryStore {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl InMemoryStore {
+    /// Create a new empty store.
+    pub fn new() -> Self {
+        Self {
+            inner: Arc::new(RwLock::new(StoreInner {
+                config: None,
+                vtxos: HashMap::new(),
+                pending_txs: HashMap::new(),
+                metadata: HashMap::new(),
+            })),
+        }
+    }
+
+    // ── Config ─────────────────────────────────────────────────────
+
+    /// Save the client configuration.
+    pub fn set_config(&self, config: ClientConfig) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.config = Some(config);
+    }
+
+    /// Get the current client configuration, if set.
+    pub fn get_config(&self) -> Option<ClientConfig> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner.config.clone()
+    }
+
+    // ── VTXOs ──────────────────────────────────────────────────────
+
+    /// Store or update a VTXO.
+    pub fn upsert_vtxo(&self, vtxo: Vtxo) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.vtxos.insert(vtxo.id.clone(), vtxo);
+    }
+
+    /// Store multiple VTXOs at once (replaces existing by ID).
+    pub fn upsert_vtxos(&self, vtxos: Vec<Vtxo>) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        for vtxo in vtxos {
+            inner.vtxos.insert(vtxo.id.clone(), vtxo);
+        }
+    }
+
+    /// Get a VTXO by ID.
+    pub fn get_vtxo(&self, id: &str) -> Option<Vtxo> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner.vtxos.get(id).cloned()
+    }
+
+    /// List all stored VTXOs.
+    pub fn list_vtxos(&self) -> Vec<Vtxo> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner.vtxos.values().cloned().collect()
+    }
+
+    /// List only spendable (not spent, not swept) VTXOs.
+    pub fn list_spendable_vtxos(&self) -> Vec<Vtxo> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner
+            .vtxos
+            .values()
+            .filter(|v| !v.is_spent && !v.is_swept)
+            .cloned()
+            .collect()
+    }
+
+    /// Remove a VTXO by ID. Returns the removed VTXO if it existed.
+    pub fn remove_vtxo(&self, id: &str) -> Option<Vtxo> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.vtxos.remove(id)
+    }
+
+    /// Clear all VTXOs.
+    pub fn clear_vtxos(&self) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.vtxos.clear();
+    }
+
+    // ── Pending transactions ───────────────────────────────────────
+
+    /// Add or update a pending transaction.
+    pub fn upsert_pending_tx(&self, tx: PendingTx) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.pending_txs.insert(tx.tx_id.clone(), tx);
+    }
+
+    /// Get a pending transaction by ID.
+    pub fn get_pending_tx(&self, tx_id: &str) -> Option<PendingTx> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner.pending_txs.get(tx_id).cloned()
+    }
+
+    /// List all pending transactions.
+    pub fn list_pending_txs(&self) -> Vec<PendingTx> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner.pending_txs.values().cloned().collect()
+    }
+
+    /// Remove a pending transaction by ID.
+    pub fn remove_pending_tx(&self, tx_id: &str) -> Option<PendingTx> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.pending_txs.remove(tx_id)
+    }
+
+    /// Clear all pending transactions.
+    pub fn clear_pending_txs(&self) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.pending_txs.clear();
+    }
+
+    // ── Metadata ───────────────────────────────────────────────────
+
+    /// Set a metadata key-value pair.
+    pub fn set_metadata(&self, key: impl Into<String>, value: impl Into<String>) {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.metadata.insert(key.into(), value.into());
+    }
+
+    /// Get a metadata value by key.
+    pub fn get_metadata(&self, key: &str) -> Option<String> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        inner.metadata.get(key).cloned()
+    }
+
+    /// Remove a metadata key.
+    pub fn remove_metadata(&self, key: &str) -> Option<String> {
+        let mut inner = self.inner.write().expect("store lock poisoned");
+        inner.metadata.remove(key)
+    }
+
+    // ── Serialization ──────────────────────────────────────────────
+
+    /// Export the entire store as JSON (for file-based persistence).
+    pub fn to_json(&self) -> Result<String, serde_json::Error> {
+        let inner = self.inner.read().expect("store lock poisoned");
+        let snapshot = StoreSnapshot {
+            config: inner.config.clone(),
+            vtxos: inner.vtxos.values().cloned().collect(),
+            pending_txs: inner.pending_txs.values().cloned().collect(),
+            metadata: inner.metadata.clone(),
+        };
+        serde_json::to_string_pretty(&snapshot)
+    }
+
+    /// Import state from a JSON string (restores a previously exported snapshot).
+    pub fn from_json(json: &str) -> Result<Self, serde_json::Error> {
+        let snapshot: StoreSnapshot = serde_json::from_str(json)?;
+        let store = Self::new();
+        {
+            let mut inner = store.inner.write().expect("store lock poisoned");
+            inner.config = snapshot.config;
+            for vtxo in snapshot.vtxos {
+                inner.vtxos.insert(vtxo.id.clone(), vtxo);
+            }
+            for tx in snapshot.pending_txs {
+                inner.pending_txs.insert(tx.tx_id.clone(), tx);
+            }
+            inner.metadata = snapshot.metadata;
+        }
+        Ok(store)
+    }
+}
+
+/// Serializable snapshot of the store for JSON export/import.
+#[derive(Debug, Serialize, Deserialize)]
+struct StoreSnapshot {
+    config: Option<ClientConfig>,
+    vtxos: Vec<Vtxo>,
+    pending_txs: Vec<PendingTx>,
+    metadata: HashMap<String, String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn make_vtxo(id: &str, amount: u64) -> Vtxo {
+        Vtxo {
+            id: id.to_string(),
+            txid: id.split(':').next().unwrap_or("tx").to_string(),
+            vout: 0,
+            amount,
+            script: "pk".to_string(),
+            created_at: 0,
+            expires_at: 0,
+            is_spent: false,
+            is_swept: false,
+            is_unrolled: false,
+            spent_by: String::new(),
+            ark_txid: String::new(),
+            assets: vec![],
+        }
+    }
+
+    #[test]
+    fn test_store_config() {
+        let store = InMemoryStore::new();
+        assert!(store.get_config().is_none());
+
+        store.set_config(ClientConfig {
+            server_url: "http://localhost:50051".into(),
+            network: "regtest".into(),
+            server_pubkey: "02abc".into(),
+            session_duration: 10,
+            unilateral_exit_delay: 144,
+            dust: 546,
+        });
+
+        let config = store.get_config().unwrap();
+        assert_eq!(config.server_url, "http://localhost:50051");
+        assert_eq!(config.network, "regtest");
+    }
+
+    #[test]
+    fn test_store_vtxos() {
+        let store = InMemoryStore::new();
+        store.upsert_vtxo(make_vtxo("tx1:0", 10_000));
+        store.upsert_vtxo(make_vtxo("tx2:0", 20_000));
+
+        assert_eq!(store.list_vtxos().len(), 2);
+        assert_eq!(store.get_vtxo("tx1:0").unwrap().amount, 10_000);
+
+        store.remove_vtxo("tx1:0");
+        assert_eq!(store.list_vtxos().len(), 1);
+        assert!(store.get_vtxo("tx1:0").is_none());
+    }
+
+    #[test]
+    fn test_store_spendable_vtxos() {
+        let store = InMemoryStore::new();
+        store.upsert_vtxo(make_vtxo("tx1:0", 10_000));
+
+        let mut spent = make_vtxo("tx2:0", 20_000);
+        spent.is_spent = true;
+        store.upsert_vtxo(spent);
+
+        let spendable = store.list_spendable_vtxos();
+        assert_eq!(spendable.len(), 1);
+        assert_eq!(spendable[0].id, "tx1:0");
+    }
+
+    #[test]
+    fn test_store_pending_txs() {
+        let store = InMemoryStore::new();
+        store.upsert_pending_tx(PendingTx {
+            tx_id: "tx1".into(),
+            amount: 5000,
+            destination: "bc1q...".into(),
+            created_at: 1700000000,
+            status: "pending".into(),
+        });
+
+        assert_eq!(store.list_pending_txs().len(), 1);
+        assert_eq!(store.get_pending_tx("tx1").unwrap().amount, 5000);
+
+        store.remove_pending_tx("tx1");
+        assert!(store.get_pending_tx("tx1").is_none());
+    }
+
+    #[test]
+    fn test_store_metadata() {
+        let store = InMemoryStore::new();
+        store.set_metadata("last_sync", "2024-01-01");
+        assert_eq!(store.get_metadata("last_sync").unwrap(), "2024-01-01");
+
+        store.remove_metadata("last_sync");
+        assert!(store.get_metadata("last_sync").is_none());
+    }
+
+    #[test]
+    fn test_store_json_roundtrip() {
+        let store = InMemoryStore::new();
+        store.set_config(ClientConfig {
+            server_url: "http://localhost:50051".into(),
+            network: "regtest".into(),
+            server_pubkey: "02abc".into(),
+            session_duration: 10,
+            unilateral_exit_delay: 144,
+            dust: 546,
+        });
+        store.upsert_vtxo(make_vtxo("tx1:0", 10_000));
+        store.set_metadata("key", "value");
+
+        let json = store.to_json().unwrap();
+        let restored = InMemoryStore::from_json(&json).unwrap();
+
+        assert_eq!(restored.get_config().unwrap().network, "regtest");
+        assert_eq!(restored.list_vtxos().len(), 1);
+        assert_eq!(restored.get_metadata("key").unwrap(), "value");
+    }
+
+    #[test]
+    fn test_store_is_send_sync() {
+        fn assert_send_sync<T: Send + Sync>() {}
+        assert_send_sync::<InMemoryStore>();
+    }
+}

--- a/crates/arkd-client/src/wallet.rs
+++ b/crates/arkd-client/src/wallet.rs
@@ -1,0 +1,201 @@
+//! Single-key wallet for the Ark client SDK.
+//!
+//! Provides key generation, PSBT signing, and Ark address derivation.
+//! This mirrors Go's `client-lib/wallet` single-key wallet.
+
+use bitcoin::secp256k1::{self, Secp256k1, SecretKey};
+use bitcoin::{Address, CompressedPublicKey, Network, PrivateKey, PublicKey, XOnlyPublicKey};
+
+use crate::error::{ClientError, ClientResult};
+
+/// A simple single-key wallet that holds one keypair.
+///
+/// Used for signing PSBTs, deriving on-chain and off-chain addresses,
+/// and generating BIP-322 ownership proofs.
+#[derive(Debug, Clone)]
+pub struct SingleKeyWallet {
+    secret_key: SecretKey,
+    public_key: PublicKey,
+    network: Network,
+}
+
+impl SingleKeyWallet {
+    /// Generate a new random wallet for `network`.
+    pub fn generate(network: Network) -> Self {
+        let secp = Secp256k1::new();
+        let secret_key = SecretKey::new(&mut secp256k1::rand::thread_rng());
+        let public_key = PublicKey::from_private_key(&secp, &PrivateKey::new(secret_key, network));
+        Self {
+            secret_key,
+            public_key,
+            network,
+        }
+    }
+
+    /// Create a wallet from an existing WIF-encoded private key.
+    pub fn from_wif(wif: &str, network: Network) -> ClientResult<Self> {
+        let private_key: PrivateKey = wif
+            .parse()
+            .map_err(|e| ClientError::Wallet(format!("Invalid WIF: {e}")))?;
+        let secp = Secp256k1::new();
+        let public_key = PublicKey::from_private_key(&secp, &private_key);
+        Ok(Self {
+            secret_key: private_key.inner,
+            public_key,
+            network,
+        })
+    }
+
+    /// Create a wallet from raw 32-byte secret key bytes.
+    pub fn from_secret_bytes(bytes: &[u8], network: Network) -> ClientResult<Self> {
+        let secret_key = SecretKey::from_slice(bytes)
+            .map_err(|e| ClientError::Wallet(format!("Invalid secret key: {e}")))?;
+        let secp = Secp256k1::new();
+        let private_key = PrivateKey::new(secret_key, network);
+        let public_key = PublicKey::from_private_key(&secp, &private_key);
+        Ok(Self {
+            secret_key,
+            public_key,
+            network,
+        })
+    }
+
+    /// Return the compressed public key (33 bytes, hex).
+    pub fn pubkey_hex(&self) -> String {
+        self.public_key.to_string()
+    }
+
+    /// Return the x-only (Schnorr) public key (32 bytes).
+    pub fn x_only_pubkey(&self) -> XOnlyPublicKey {
+        XOnlyPublicKey::from(self.public_key.inner)
+    }
+
+    /// Return the secp256k1 public key.
+    pub fn public_key(&self) -> &PublicKey {
+        &self.public_key
+    }
+
+    /// Return the secret key (for signing operations).
+    pub fn secret_key(&self) -> &SecretKey {
+        &self.secret_key
+    }
+
+    /// Return the network this wallet is configured for.
+    pub fn network(&self) -> Network {
+        self.network
+    }
+
+    /// Derive a P2TR (Taproot) on-chain address from the wallet's key.
+    pub fn p2tr_address(&self) -> ClientResult<Address> {
+        let secp = Secp256k1::new();
+        let x_only = self.x_only_pubkey();
+        Ok(Address::p2tr(&secp, x_only, None, self.network))
+    }
+
+    /// Derive a P2WPKH (SegWit v0) on-chain address.
+    pub fn p2wpkh_address(&self) -> ClientResult<Address> {
+        let compressed = CompressedPublicKey::try_from(self.public_key)
+            .map_err(|e| ClientError::Wallet(format!("Cannot compress pubkey: {e}")))?;
+        Ok(Address::p2wpkh(&compressed, self.network))
+    }
+
+    /// Return the Ark off-chain address (pubkey-based).
+    ///
+    /// Format: `ark:<compressed_pubkey_hex>`
+    pub fn offchain_address(&self) -> String {
+        format!("ark:{}", self.pubkey_hex())
+    }
+
+    /// Export the private key as WIF.
+    pub fn to_wif(&self) -> String {
+        PrivateKey::new(self.secret_key, self.network).to_wif()
+    }
+
+    /// Sign a message hash with the wallet's secret key (Schnorr).
+    ///
+    /// Returns the 64-byte Schnorr signature as hex.
+    pub fn sign_schnorr(&self, msg: &[u8; 32]) -> ClientResult<String> {
+        let secp = Secp256k1::new();
+        let keypair = secp256k1::Keypair::from_secret_key(&secp, &self.secret_key);
+        let msg = secp256k1::Message::from_digest(*msg);
+        let sig = secp.sign_schnorr(&msg, &keypair);
+        Ok(hex::encode(sig.serialize()))
+    }
+
+    /// Sign a message hash with ECDSA (for legacy compatibility).
+    ///
+    /// Returns the DER-encoded signature as hex.
+    pub fn sign_ecdsa(&self, msg: &[u8; 32]) -> ClientResult<String> {
+        let secp = Secp256k1::new();
+        let msg = secp256k1::Message::from_digest(*msg);
+        let sig = secp.sign_ecdsa(&msg, &self.secret_key);
+        Ok(hex::encode(sig.serialize_der()))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_generate_wallet() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        assert!(!wallet.pubkey_hex().is_empty());
+        assert_eq!(wallet.network(), Network::Regtest);
+    }
+
+    #[test]
+    fn test_wallet_roundtrip_wif() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let wif = wallet.to_wif();
+        let restored = SingleKeyWallet::from_wif(&wif, Network::Regtest).unwrap();
+        assert_eq!(wallet.pubkey_hex(), restored.pubkey_hex());
+    }
+
+    #[test]
+    fn test_p2tr_address() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let addr = wallet.p2tr_address().unwrap();
+        let addr_str = addr.to_string();
+        assert!(addr_str.starts_with("bcrt1p"), "got: {addr_str}");
+    }
+
+    #[test]
+    fn test_p2wpkh_address() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let addr = wallet.p2wpkh_address().unwrap();
+        let addr_str = addr.to_string();
+        assert!(addr_str.starts_with("bcrt1q"), "got: {addr_str}");
+    }
+
+    #[test]
+    fn test_offchain_address() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let addr = wallet.offchain_address();
+        assert!(addr.starts_with("ark:"));
+    }
+
+    #[test]
+    fn test_sign_schnorr() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let msg = [0xab_u8; 32];
+        let sig = wallet.sign_schnorr(&msg).unwrap();
+        assert_eq!(sig.len(), 128); // 64 bytes hex
+    }
+
+    #[test]
+    fn test_sign_ecdsa() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let msg = [0xcd_u8; 32];
+        let sig = wallet.sign_ecdsa(&msg).unwrap();
+        assert!(!sig.is_empty());
+    }
+
+    #[test]
+    fn test_from_secret_bytes() {
+        let wallet = SingleKeyWallet::generate(Network::Regtest);
+        let bytes = wallet.secret_key().secret_bytes();
+        let restored = SingleKeyWallet::from_secret_bytes(&bytes, Network::Regtest).unwrap();
+        assert_eq!(wallet.pubkey_hex(), restored.pubkey_hex());
+    }
+}


### PR DESCRIPTION
Closes #270

Expands arkd-client with:
- **SingleKeyWallet** — keypair generation, PSBT signing, Ark address derivation
- **EsploraExplorer** — HTTP client for Esplora (UTXOs, broadcast, tx status)
- **InMemoryStore** — client-side state persistence
- **ArkClient SDK** — high-level API wrapping transport + wallet + explorer + store

+1,228 lines across 4 new modules.