### PR TITLE
fix(e2e): start round immediately on boot + real P2TR boarding address

### DIFF
--- a/crates/arkd-client/src/client.rs
+++ b/crates/arkd-client/src/client.rs
@@ -246,8 +246,43 @@ impl ArkClient {
             "OP_CHECKSEQUENCEVERIFY {} OP_CHECKSIG pubkey:{}",
             exit_delay, pubkey
         );
+        // Build a real P2TR (bech32m) boarding address from the user pubkey.
+        let network = match info.network.as_str() {
+            "mainnet" | "bitcoin" => bitcoin::Network::Bitcoin,
+            "testnet" => bitcoin::Network::Testnet,
+            "signet" => bitcoin::Network::Signet,
+            _ => bitcoin::Network::Regtest,
+        };
+        let boarding_address_str = {
+            let secp = bitcoin::secp256k1::Secp256k1::new();
+            let pubkey_bytes: Option<Vec<u8>> = {
+                if !pubkey.len().is_multiple_of(2) {
+                    None
+                } else {
+                    (0..pubkey.len())
+                        .step_by(2)
+                        .map(|i| u8::from_str_radix(&pubkey[i..i + 2], 16).ok())
+                        .collect()
+                }
+            };
+            let xonly = pubkey_bytes
+                .as_deref()
+                .and_then(|b| bitcoin::secp256k1::XOnlyPublicKey::from_slice(b).ok());
+            match xonly {
+                Some(xpk) => {
+                    let builder = bitcoin::taproot::TaprootBuilder::new();
+                    let spend_info = builder
+                        .finalize(&secp, xpk)
+                        .expect("valid taproot spend info");
+                    let output_key = spend_info.output_key();
+                    let address = bitcoin::Address::p2tr_tweaked(output_key, network);
+                    address.to_string()
+                }
+                None => format!("bc1p_boarding_{}", &pubkey[..pubkey.len().min(32)]),
+            }
+        };
         let boarding_address = BoardingAddress {
-            address: format!("bc1p_boarding_{}", &pubkey[..pubkey.len().min(32)]),
+            address: boarding_address_str,
             tapscripts: vec![coop_leaf, exit_leaf],
         };
 

--- a/crates/arkd-fee-manager/src/static_fee.rs
+++ b/crates/arkd-fee-manager/src/static_fee.rs
@@ -91,16 +91,22 @@ mod tests {
     async fn test_static_fee_manager_zero_rate() {
         let mgr = StaticFeeManager::new(0);
         assert_eq!(
-            mgr.estimate_fee_rate(FeeStrategy::Conservative).await.unwrap(),
+            mgr.estimate_fee_rate(FeeStrategy::Conservative)
+                .await
+                .unwrap(),
             0
         );
         assert_eq!(
-            mgr.estimate_fee_rate(FeeStrategy::Economical).await.unwrap(),
+            mgr.estimate_fee_rate(FeeStrategy::Economical)
+                .await
+                .unwrap(),
             0
         );
         // Custom still overrides even when configured rate is 0
         assert_eq!(
-            mgr.estimate_fee_rate(FeeStrategy::Custom(99)).await.unwrap(),
+            mgr.estimate_fee_rate(FeeStrategy::Custom(99))
+                .await
+                .unwrap(),
             99
         );
     }
@@ -119,7 +125,9 @@ mod tests {
     async fn test_static_fee_manager_high_rate() {
         let mgr = StaticFeeManager::new(1_000_000);
         assert_eq!(
-            mgr.estimate_fee_rate(FeeStrategy::Conservative).await.unwrap(),
+            mgr.estimate_fee_rate(FeeStrategy::Conservative)
+                .await
+                .unwrap(),
             1_000_000
         );
     }
@@ -129,7 +137,9 @@ mod tests {
         let mgr = StaticFeeManager::new(25);
         for _ in 0..10 {
             assert_eq!(
-                mgr.estimate_fee_rate(FeeStrategy::Conservative).await.unwrap(),
+                mgr.estimate_fee_rate(FeeStrategy::Conservative)
+                    .await
+                    .unwrap(),
                 25
             );
         }
@@ -142,7 +152,9 @@ mod tests {
         mgr.invalidate_cache().await.unwrap();
         mgr.invalidate_cache().await.unwrap();
         assert_eq!(
-            mgr.estimate_fee_rate(FeeStrategy::Economical).await.unwrap(),
+            mgr.estimate_fee_rate(FeeStrategy::Economical)
+                .await
+                .unwrap(),
             15
         );
     }

--- a/crates/arkd-live-store/src/memory.rs
+++ b/crates/arkd-live-store/src/memory.rs
@@ -947,14 +947,8 @@ mod tests {
     #[tokio::test]
     async fn test_live_store_round_isolation() {
         let store = InMemoryLiveStore::new();
-        store
-            .set_intent("r1", "i1", b"data1", 60)
-            .await
-            .unwrap();
-        store
-            .set_intent("r2", "i2", b"data2", 60)
-            .await
-            .unwrap();
+        store.set_intent("r1", "i1", b"data1", 60).await.unwrap();
+        store.set_intent("r2", "i2", b"data2", 60).await.unwrap();
 
         // Each round only sees its own intents
         let r1_ids = store.list_intents("r1").await.unwrap();
@@ -973,10 +967,7 @@ mod tests {
     #[tokio::test]
     async fn test_live_store_session_isolation() {
         let store = InMemoryLiveStore::new();
-        store
-            .set_nonce("s1", "pk1", b"nonce1", 60)
-            .await
-            .unwrap();
+        store.set_nonce("s1", "pk1", b"nonce1", 60).await.unwrap();
         store
             .set_partial_sig("s2", "pk1", b"sig1", 60)
             .await

--- a/crates/arkd-scheduler/src/time_scheduler.rs
+++ b/crates/arkd-scheduler/src/time_scheduler.rs
@@ -10,6 +10,9 @@ use arkd_core::error::ArkResult;
 use arkd_core::ports::TimeScheduler;
 
 /// A scheduler that fires a tick at a fixed time interval.
+///
+/// The first tick is sent immediately so that a round starts as soon as the
+/// server boots, then subsequent ticks fire every `interval`.
 pub struct SimpleTimeScheduler;
 
 #[async_trait]
@@ -17,9 +20,13 @@ impl TimeScheduler for SimpleTimeScheduler {
     async fn schedule(&self, interval: Duration) -> ArkResult<mpsc::Receiver<()>> {
         let (tx, rx) = mpsc::channel(1);
         tokio::spawn(async move {
+            // Send an immediate first tick so a round starts on server boot.
+            if tx.send(()).await.is_err() {
+                return;
+            }
             let mut ticker = tokio::time::interval(interval);
-            // The first tick fires immediately — skip it so the consumer
-            // only sees ticks after the first full interval has elapsed.
+            // Consume the immediate first tick from tokio::time::interval
+            // (we already sent our own above).
             ticker.tick().await;
             loop {
                 ticker.tick().await;

--- a/crates/arkd-wallet-bin/src/encryption.rs
+++ b/crates/arkd-wallet-bin/src/encryption.rs
@@ -183,7 +183,10 @@ mod tests {
         let encrypted = encrypt_seed("my seed phrase", "password").unwrap();
         let json = serde_json::to_string(&encrypted).unwrap();
         let deserialized: EncryptedSeed = serde_json::from_str(&json).unwrap();
-        assert_eq!(decrypt_seed(&deserialized, "password").unwrap(), "my seed phrase");
+        assert_eq!(
+            decrypt_seed(&deserialized, "password").unwrap(),
+            "my seed phrase"
+        );
     }
 
     #[test]
@@ -193,7 +196,10 @@ mod tests {
         let path = dir.join("arkd_test_encrypted_seed.json");
         save_encrypted_seed(&path, &encrypted).unwrap();
         let loaded = load_encrypted_seed(&path).unwrap();
-        assert_eq!(decrypt_seed(&loaded, "secret").unwrap(), "file roundtrip seed");
+        assert_eq!(
+            decrypt_seed(&loaded, "secret").unwrap(),
+            "file roundtrip seed"
+        );
         // Cleanup
         let _ = std::fs::remove_file(&path);
     }


### PR DESCRIPTION
## Summary

Fixes 8 failing e2e tests across two root causes.

---

### Issue 1: "No active round" (5 tests)

`SimpleTimeScheduler` was skipping the first tick, so the first round only started after `round_duration_secs` (30s). Tests calling `settle()` → `register_intent()` right after server start would fail with `Internal error: No active round`.

**Fix:** Send an immediate tick on startup so `start_round()` is called as soon as the server boots. Subsequent ticks still fire every `interval`.

Affected tests:
- `test_ban_protocol_violations`
- `test_collaborative_exit_invalid_with_boarding`
- `test_collaborative_exit_with_change`
- `test_collaborative_exit_without_change`
- `test_delegate_refresh`

---

### Issue 2: Invalid boarding address (3 tests)

`receive()` was returning `bc1p_boarding_{pubkey}` — a fake placeholder. Bitcoin RPC `sendtoaddress` returns `null` for this invalid address, causing `expect("sendtoaddress result string")` to panic at `tests/e2e_regtest.rs:204`.

**Fix:** Use the `bitcoin` crate (`TaprootBuilder`) to derive a real P2TR bech32m address from the user's x-only pubkey. Network is inferred from `GetInfo` response.

Affected tests:
- `test_batch_session_refresh_vtxos`
- `test_offchain_tx`
- `test_react_to_fraud_forfeited_vtxo`