### PR TITLE
fix(e2e): start first round synchronously before accepting gRPC connections

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -334,6 +334,14 @@ async fn main() -> Result<()> {
         "Round loop started"
     );
 
+    // Start the first round synchronously before accepting connections.
+    // This eliminates the race where a client connects and calls register_intent
+    // before the async round-loop task has had a chance to process its first tick.
+    match core.start_round().await {
+        Ok(r) => info!(round_id = %r.id, "Initial round started"),
+        Err(e) => info!("Initial round skipped: {e}"),
+    }
+
     let server = arkd_api::Server::new(
         config,
         core,


### PR DESCRIPTION
## Problem

After #289 added an immediate tick to `SimpleTimeScheduler`, the round is started by an async tokio task. There is still a small race window: the gRPC server becomes reachable on its port before that task gets scheduled, so the very first test to call `register_intent` still hits `No active round`.

`test_ban_protocol_violations` (and the other 4 collaborative/delegate tests) were all failing because they ran within this window.

## Fix

Call `core.start_round()` **synchronously** in `main()` after spawning the round loop but before `server.run()` starts accepting connections. This eliminates the race entirely — the round is guaranteed to exist before the first gRPC connection arrives.

The round loop's next tick will hit `Round already active` and be silently ignored (existing behaviour).

## Change

8 lines added to `src/main.rs` only.