### PR TITLE
fix(e2e): rebuild binary before e2e + auto-start round in register_intent

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -179,7 +179,7 @@ watch:
 # =============================================================================
 
 # Run E2E regtest suite (starts Nigiri, waits for readiness, runs tests, stops Nigiri)
-e2e *args:
+e2e *args: build-release
     nigiri start
     @echo "⏳ Waiting for Esplora to be ready..."
     @until curl -sf http://localhost:5000/blocks/tip/height > /dev/null 2>&1; do sleep 1; done

--- a/crates/arkd-core/src/application.rs
+++ b/crates/arkd-core/src/application.rs
@@ -748,6 +748,25 @@ impl ArkService {
     /// Register an intent
     #[instrument(skip(self, intent))]
     pub async fn register_intent(&self, intent: Intent) -> ArkResult<String> {
+        // If no round is active (or the current round has ended), start one now.
+        // This is a self-healing guard: the round loop starts a round on the first
+        // scheduler tick, but there is a small window at startup where a client
+        // can connect before the scheduler tick is processed.  Auto-starting here
+        // eliminates any residual race without requiring exact startup ordering.
+        {
+            let needs_round = self
+                .current_round
+                .read()
+                .await
+                .as_ref()
+                .map(|r| r.is_ended())
+                .unwrap_or(true); // None → needs a round
+            if needs_round {
+                // Ignore "already active" — another task may have beaten us to it.
+                let _ = self.start_round().await;
+            }
+        }
+
         let mut guard = self.current_round.write().await;
         let round = guard
             .as_mut()


### PR DESCRIPTION
## Problem

The `just e2e` recipe ran the e2e test suite against a stale `./target/release/arkd` binary. Any server-side fix merged to `main` would not take effect until the user manually ran `cargo build --release` — which is easy to forget and caused the previous fixes (#289, #290) to appear ineffective.

Additionally, even with a fresh binary, there is a small startup-race window where a client connects and calls `register_intent` before the scheduler tick starts the first round.

## Fixes

### 1. Justfile — always rebuild before e2e

```diff
-e2e *args:
+e2e *args: build-release
     nigiri start
```

The `build-release` recipe runs `cargo build --release`, ensuring the binary used by the test script always reflects the current source.

### 2. `register_intent` — auto-start a round if none is active

If `current_round` is `None` (server just started) or the round has ended, `register_intent` calls `start_round()` before proceeding. Errors from `start_round()` are silently ignored — the only expected error is `Round already active`, which means another task beat us to it.

This is a belt-and-suspenders guard: the startup race is already closed by the synchronous `start_round()` in `main.rs` (#290), but this makes the entire system self-healing regardless of startup ordering.