### PR TITLE
fix(e2e): use debug build for e2e (10x faster)

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -179,7 +179,7 @@ watch:
 # =============================================================================
 
 # Run E2E regtest suite (starts Nigiri, waits for readiness, runs tests, stops Nigiri)
-e2e *args: build-release
+e2e *args: build
     nigiri start
     @echo "⏳ Waiting for Esplora to be ready..."
     @until curl -sf http://localhost:5000/blocks/tip/height > /dev/null 2>&1; do sleep 1; done

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -61,9 +61,9 @@ fi
 echo "  ✅ bitcoind running"
 
 # 3. Check binary exists
-BINARY="./target/release/arkd"
+BINARY="./target/debug/arkd"
 if [ ! -f "$BINARY" ]; then
-    BINARY="./target/debug/arkd"
+    BINARY="./target/release/arkd"
 fi
 if [ ! -f "$BINARY" ]; then
     echo "⚠  arkd binary not found. Building..."


### PR DESCRIPTION
## Why

The e2e suite was running `cargo build --release` which takes 1m37s on a Mac. Debug build takes ~20s and is functionally identical for correctness testing.

## Changes

- `Justfile`: `e2e` now depends on `build` (debug) instead of `build-release`
- `e2e-test.sh`: prefer `./target/debug/arkd`, fallback to release

No functional change to the tests themselves.