### PR TITLE
ci: move e2e tests to nightly + workflow_dispatch

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -1,10 +1,9 @@
 name: Integration Tests
 
 on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
+  schedule:
+    - cron: "0 3 * * *"  # 3 AM UTC nightly
+  workflow_dispatch:
 
 env:
   CARGO_TERM_COLOR: always


### PR DESCRIPTION
Closes #307

## What

Removes `pull_request` and `push` triggers from `integration.yml`. E2e tests now run:
- **Nightly** at 3 AM UTC via `schedule`
- **On-demand** via `workflow_dispatch` from the Actions tab

## Why

PR CI was slow and flaky because of the regtest Bitcoin node spin-up. Unit tests, clippy, fmt, and audit are enough signal for day-to-day PRs. Nightly gives a daily health check.

## Changes

- `.github/workflows/integration.yml`: changed `on:` from `push`/`pull_request` to `schedule` + `workflow_dispatch`