### PR TITLE
fix: return 33-byte compressed pubkeys in GetInfo response (#310)

### DIFF
--- a/crates/dark-api/tests/grpc_integration.rs
+++ b/crates/dark-api/tests/grpc_integration.rs
@@ -414,6 +414,54 @@ async fn test_get_info_new_fields() {
 }
 
 #[tokio::test]
+async fn test_get_info_pubkeys_are_compressed() {
+    let mut client = start_ark_server().await;
+    let resp = client.get_info(GetInfoRequest {}).await.unwrap();
+    let info = resp.into_inner();
+
+    // signer_pubkey and forfeit_pubkey must be 33-byte compressed (66 hex chars)
+    // with 02 or 03 prefix — matching arkade-os/arkd's SerializeCompressed() format.
+    assert_eq!(
+        info.signer_pubkey.len(),
+        66,
+        "signer_pubkey must be 66 hex chars (33 bytes compressed), got {} chars: {}",
+        info.signer_pubkey.len(),
+        info.signer_pubkey
+    );
+    assert!(
+        info.signer_pubkey.starts_with("02") || info.signer_pubkey.starts_with("03"),
+        "signer_pubkey must start with 02 or 03, got: {}",
+        info.signer_pubkey
+    );
+    assert_eq!(
+        info.forfeit_pubkey.len(),
+        66,
+        "forfeit_pubkey must be 66 hex chars (33 bytes compressed), got {} chars: {}",
+        info.forfeit_pubkey.len(),
+        info.forfeit_pubkey
+    );
+    assert!(
+        info.forfeit_pubkey.starts_with("02") || info.forfeit_pubkey.starts_with("03"),
+        "forfeit_pubkey must start with 02 or 03, got: {}",
+        info.forfeit_pubkey
+    );
+
+    // checkpoint_tapscript still uses x-only (32-byte / 64 hex) — correct for BIP-340 tapscript
+    // Format: "20" + <64 hex chars> + "ac"  (PUSH32 <pubkey> OP_CHECKSIG)
+    assert!(
+        info.checkpoint_tapscript.starts_with("20") && info.checkpoint_tapscript.ends_with("ac"),
+        "checkpoint_tapscript should be OP_CHECKSIG script with x-only pubkey, got: {}",
+        info.checkpoint_tapscript
+    );
+    assert_eq!(
+        info.checkpoint_tapscript.len(),
+        68, // "20" (2) + 64 hex chars + "ac" (2)
+        "checkpoint_tapscript should be 68 chars, got: {}",
+        info.checkpoint_tapscript.len()
+    );
+}
+
+#[tokio::test]
 async fn test_get_info_default_values_are_sensible() {
     let mut client = start_ark_server().await;
     let resp = client.get_info(GetInfoRequest {}).await.unwrap();

--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -379,12 +379,26 @@ impl ArkService {
         )
         .to_string();
 
-        // Derive checkpoint tapscript from the signer pubkey (hex-encoded OP_CHECKSIG script)
+        // Derive checkpoint tapscript from the signer pubkey (hex-encoded OP_CHECKSIG script).
+        // Uses x-only (32-byte) pubkey as required by BIP-340 tapscript.
         let checkpoint_tapscript = format!("20{}ac", signer_pubkey);
 
+        // Serialize pubkeys as 33-byte compressed (02/03 prefix) for protocol compatibility
+        // with the reference Go implementation (arkade-os/arkd), which uses
+        // `btcec.PublicKey.SerializeCompressed()` in its GetInfo response.
+        // We assume even parity (02 prefix) when lifting x-only keys to compressed form.
+        let signer_pubkey_compressed = bitcoin::secp256k1::PublicKey::from_x_only_public_key(
+            signer_pubkey,
+            bitcoin::secp256k1::Parity::Even,
+        );
+        let forfeit_pubkey_compressed = bitcoin::secp256k1::PublicKey::from_x_only_public_key(
+            forfeit_pubkey,
+            bitcoin::secp256k1::Parity::Even,
+        );
+
         Ok(ServiceInfo {
-            signer_pubkey: signer_pubkey.to_string(),
-            forfeit_pubkey: forfeit_pubkey.to_string(),
+            signer_pubkey: hex::encode(signer_pubkey_compressed.serialize()),
+            forfeit_pubkey: hex::encode(forfeit_pubkey_compressed.serialize()),
             unilateral_exit_delay: self.config.unilateral_exit_delay as i64,
             session_duration: self.config.session_duration_secs as i64,
             network: self.config.network.clone(),


### PR DESCRIPTION
## Problem

Closes #310.

The reference Go implementation (`arkade-os/arkd`) serializes pubkeys using `SerializeCompressed()`, producing **33-byte hex strings** with a `02`/`03` prefix.

Our server was calling `XOnlyPublicKey::to_string()`, which yields a **32-byte x-only (BIP-340)** hex string. The Go e2e client rejected every `GetInfo` response with:

```
failed to parse signer pubkey: malformed public key: invalid length: 32
```

This was a **blocking parity gap** — no Go e2e test could proceed past the initial handshake.

## Fix

Lift both `signer_pubkey` and `forfeit_pubkey` to `secp256k1::PublicKey` with even parity before serializing, producing the expected 33-byte compressed representation.

`checkpoint_tapscript` continues to use the x-only (32-byte) key, as required by BIP-340 tapscript OP_CHECKSIG.

## Tests

Added `test_get_info_pubkeys_are_compressed` which asserts:
- `signer_pubkey` and `forfeit_pubkey` are exactly 66 hex chars (33 bytes) with `02`/`03` prefix
- `checkpoint_tapscript` still uses x-only format (`20<64 hex chars>ac`)