### PR TITLE
fix: map round_duration_secs to ArkConfig.session_duration_secs

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -260,6 +260,7 @@ async fn main() -> Result<()> {
     // --- Core service (with stub impls for now) ---
     let ark_config = dark_core::ArkConfig {
         allow_csv_block_type: config.allow_csv_block_type,
+        session_duration_secs: config.round_duration_secs,
         fee_program: dark_core::domain::FeeProgram {
             offchain_input_fee: file_config.fees.offchain_input_fee.unwrap_or(0),
             onchain_input_fee: file_config.fees.onchain_input_fee.unwrap_or(0),


### PR DESCRIPTION
## Summary

The TOML config `round_duration_secs` was used for the scheduler tick interval but never propagated to `ArkConfig.session_duration_secs`, which controls the auto-finalize timer in `round_loop.rs`.

This caused the round loop to always use `DEFAULT_SESSION_DURATION_SECS` (10s) regardless of the configured value.

## Change

One-liner in `src/main.rs`: pass `config.round_duration_secs` into `ark_config.session_duration_secs` when constructing the `ArkConfig`.

## Impact

- Round auto-finalization now respects the configured round duration
- Required for Go e2e test compatibility (tests expect round timing to match config)