### PR TITLE
fix(e2e): allow start_round when current round is in Finalization stage

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -432,7 +432,11 @@ impl ArkService {
     #[instrument(skip(self))]
     pub async fn start_round(&self) -> ArkResult<Round> {
         if let Some(round) = self.current_round.read().await.as_ref() {
-            if !round.is_ended() {
+            // Allow starting a new round when the current one is ended OR when it
+            // has transitioned to Finalization (tree signing in progress but no new
+            // registrations are possible). In the latter case, the finalizing round
+            // keeps going in the background while a fresh registration window opens.
+            if !round.is_ended() && round.is_accepting_registrations() {
                 return Err(ArkError::Internal("Round already active".to_string()));
             }
         }


### PR DESCRIPTION
## Problem

All e2e tests calling `RegisterForRound` after a prior round enters Finalization fail with:
```
Internal error: Not in registration stage
```

This broke nightly e2e runs starting Mar 22 after #318 introduced the two-phase `finalize_round` → `complete_round` protocol.

## Root Cause

When a round transitions Registration → Finalization:
- `is_accepting_registrations()` → `false` ✓
- `register_intent` correctly calls `start_round()` ✓
- But `start_round()` checks `!round.is_ended()` → returns `"Round already active"` ✗
- `register_intent` ignores the error and tries to register on the Finalization-stage round → "Not in registration stage" ✗

## Fix

`start_round()` now only blocks when the current round is actively accepting registrations. A Finalization-stage round is replaceable — a new Registration window can open while tree signing completes in the background.

## Tests Unblocked

- `test_delegate_refresh`
- `test_fee_programs_applied`
- `test_intent_concurrent_register`
- `test_intent_join_round`
- `test_intent_register_and_delete`
- `test_offchain_tx`
- `test_offchain_tx_multiple`
- `test_react_to_fraud_*` (3 tests)
- `test_sweep_batch` / `test_sweep_checkpoint` / `test_sweep_force_by_admin`
- `test_unilateral_exit_leaf_vtxo` / `test_unilateral_exit_preconfirmed_vtxo`