### PR TITLE
fix(e2e): GetVirtualTxs returns tree PSBTs + admin sweep returns txid (#326, #333)

### DIFF
--- a/crates/dark-api/src/grpc/admin_service.rs
+++ b/crates/dark-api/src/grpc/admin_service.rs
@@ -334,17 +334,32 @@ impl AdminServiceTrait for AdminGrpcService {
     ) -> Result<Response<SweepResponse>, Status> {
         info!("AdminService::Sweep called");
 
-        let swept_count = self
+        let current_height = self
             .core
-            .sweep_expired_vtxos()
+            .wallet()
+            .get_current_block_time()
+            .await
+            .map(|bt| bt.height as u32)
+            .unwrap_or(0);
+
+        let sweep_result = self
+            .core
+            .run_scheduled_sweep_with_result(current_height)
             .await
             .map_err(|e| Status::internal(e.to_string()))?;
 
-        // TODO: sweep_expired_vtxos returns count only; to return a txid we'd
-        // need SweepService to return the actual transaction hash(es). For now
-        // sweep_txid is empty — callers should check swept_count.
+        let swept_count = sweep_result.vtxos_swept as u32;
+        let sweep_txid = sweep_result.tx_ids.first().cloned().unwrap_or_default();
+
+        info!(
+            swept_vtxos = swept_count,
+            sats_recovered = sweep_result.sats_recovered,
+            current_height,
+            "Admin sweep complete"
+        );
+
         Ok(Response::new(SweepResponse {
-            sweep_txid: String::new(),
+            sweep_txid,
             swept_count,
             recovery_txid: String::new(),
         }))

--- a/crates/dark-api/src/grpc/indexer_service.rs
+++ b/crates/dark-api/src/grpc/indexer_service.rs
@@ -530,18 +530,43 @@ impl IndexerServiceTrait for IndexerGrpcService {
             "IndexerService::GetVirtualTxs called"
         );
 
-        // Virtual transactions are the serialized VTXO tree node transactions.
         // Search all rounds' vtxo_tree for matching txids.
-        // TODO(#237): Add a dedicated virtual-tx index for efficient lookups
-        // instead of scanning rounds.
-        let txs: Vec<String> = Vec::new();
+        // The vtxo_tree field of each Round holds TreeNode entries with txid + tx (base64 PSBT).
+        let mut txs: Vec<String> = Vec::new();
+        let target_txids: std::collections::HashSet<&str> =
+            req.txids.iter().map(|s| s.as_str()).collect();
 
-        for txid in &req.txids {
-            // Try to find this txid in the VTXO tree of any round.
-            // For now, we return empty since we can't efficiently search
-            // across all rounds without a dedicated index.
-            // TODO(#237): Implement virtual-tx store for cross-round lookups.
-            let _ = txid;
+        if !target_txids.is_empty() {
+            // Scan all rounds (paginated in batches of 100)
+            let mut offset = 0u32;
+            loop {
+                let rounds = self.core.list_rounds(offset, 100).await.unwrap_or_default();
+                if rounds.is_empty() {
+                    break;
+                }
+                for round in &rounds {
+                    for node in &round.vtxo_tree {
+                        if !node.tx.is_empty() && target_txids.contains(node.txid.as_str()) {
+                            txs.push(node.tx.clone());
+                        }
+                    }
+                    // Also search connector tree
+                    for node in &round.connectors {
+                        if !node.tx.is_empty() && target_txids.contains(node.txid.as_str()) {
+                            txs.push(node.tx.clone());
+                        }
+                    }
+                }
+                offset += 100;
+                if rounds.len() < 100 {
+                    break;
+                }
+            }
+            info!(
+                requested = req.txids.len(),
+                found = txs.len(),
+                "GetVirtualTxs: searched rounds for tree node PSBTs"
+            );
         }
 
         let (page_size, page_index) = req

--- a/crates/dark-api/src/rest.rs
+++ b/crates/dark-api/src/rest.rs
@@ -467,6 +467,8 @@ async fn admin_sweep(
         Ok(resp) => {
             let inner = resp.into_inner();
             Json(serde_json::json!({
+                "txid": inner.sweep_txid,
+                "hex": "",
                 "sweepTxid": inner.sweep_txid,
                 "sweptCount": inner.swept_count,
                 "recoveryTxid": inner.recovery_txid,


### PR DESCRIPTION
## Summary

Two fixes for Go e2e test failures.

## GetVirtualTxs (#326)

`GetVirtualTxs` was returning empty for all txids. Go SDK calls this from `Unroll()` to get VTXO tree node PSBTs for unilateral exit.

Fix: scan all rounds (paginated) and return tree node PSBTs that match the requested txids.

## Admin sweep response format (#333)

Go test expects `{"txid": "...", "hex": ""}` from `POST /v1/admin/sweep`, but dark returned `{"sweepTxid": "", ...}` with an empty txid.

Fix:
- Add `txid` field to REST response
- Wire `run_scheduled_sweep_with_result()` so the actual sweep txid from `SweepService` is returned

Relates to #326, closes #333