### PR TITLE
fix(e2e): wire fraud detection broadcast + sweep tx building (#331, #334)

### DIFF
--- a/crates/dark-scanner/src/fraud.rs
+++ b/crates/dark-scanner/src/fraud.rs
@@ -145,17 +145,56 @@ impl FraudDetector for EsploraFraudDetector {
     async fn react_to_fraud(&self, vtxo_id: &str, forfeit_tx_hex: &str) -> ArkResult<()> {
         warn!(
             vtxo_id = %vtxo_id,
-            "Queuing forfeit tx for broadcast (fraud detected)"
+            "Fraud detected — broadcasting forfeit tx"
         );
 
-        self.pending_forfeit_txs.write().await.push(PendingForfeit {
-            vtxo_id: vtxo_id.to_string(),
-            forfeit_tx_hex: forfeit_tx_hex.to_string(),
-        });
+        // Broadcast the forfeit tx directly via Esplora's broadcast endpoint.
+        // This is the same endpoint used by the wallet for other transactions.
+        let broadcast_url = format!("{}/tx", self.base_url);
+        let response = self
+            .client
+            .post(&broadcast_url)
+            .body(forfeit_tx_hex.to_string())
+            .header("Content-Type", "text/plain")
+            .send()
+            .await;
 
-        // TODO(#246): Actually broadcast the forfeit tx via the wallet service.
-        // For now we queue it; the round loop or a background task should
-        // drain pending_forfeit_txs and call wallet.broadcast_transaction().
+        match response {
+            Ok(resp) if resp.status().is_success() => {
+                let txid = resp.text().await.unwrap_or_default();
+                info!(
+                    vtxo_id = %vtxo_id,
+                    forfeit_txid = %txid.trim(),
+                    "Forfeit tx broadcast successfully"
+                );
+            }
+            Ok(resp) => {
+                let status = resp.status();
+                let body = resp.text().await.unwrap_or_default();
+                warn!(
+                    vtxo_id = %vtxo_id,
+                    %status,
+                    body = %body,
+                    "Forfeit tx broadcast returned error — queuing for retry"
+                );
+                // Queue for retry
+                self.pending_forfeit_txs.write().await.push(PendingForfeit {
+                    vtxo_id: vtxo_id.to_string(),
+                    forfeit_tx_hex: forfeit_tx_hex.to_string(),
+                });
+            }
+            Err(e) => {
+                warn!(
+                    vtxo_id = %vtxo_id,
+                    error = %e,
+                    "Forfeit tx broadcast request failed — queuing for retry"
+                );
+                self.pending_forfeit_txs.write().await.push(PendingForfeit {
+                    vtxo_id: vtxo_id.to_string(),
+                    forfeit_tx_hex: forfeit_tx_hex.to_string(),
+                });
+            }
+        }
 
         Ok(())
     }

--- a/crates/dark-scanner/src/sweep.rs
+++ b/crates/dark-scanner/src/sweep.rs
@@ -62,18 +62,39 @@ struct EsploraTxResponse {
 pub struct EsploraSweepService {
     base_url: String,
     client: reqwest::Client,
+    /// Optional VTXO repository for querying expired VTXOs.
+    vtxo_repo: Option<Arc<dyn dark_core::ports::VtxoRepository>>,
+    /// Optional wallet service for broadcasting sweep transactions.
+    wallet: Option<Arc<dyn dark_core::ports::WalletService>>,
+    /// Optional tx builder for constructing sweep transactions.
+    tx_builder: Option<Arc<dyn dark_core::ports::TxBuilder>>,
 }
+
+use std::sync::Arc;
 
 impl EsploraSweepService {
     /// Create a new Esplora-based sweep service.
-    ///
-    /// # Arguments
-    /// * `base_url` — Esplora API base URL (e.g. `https://blockstream.info/testnet/api`)
     pub fn new(base_url: &str) -> Self {
         Self {
             base_url: base_url.trim_end_matches('/').to_string(),
             client: reqwest::Client::new(),
+            vtxo_repo: None,
+            wallet: None,
+            tx_builder: None,
         }
+    }
+
+    /// Wire in the dependencies needed for actual sweep transaction building.
+    pub fn with_deps(
+        mut self,
+        vtxo_repo: Arc<dyn dark_core::ports::VtxoRepository>,
+        wallet: Arc<dyn dark_core::ports::WalletService>,
+        tx_builder: Arc<dyn dark_core::ports::TxBuilder>,
+    ) -> Self {
+        self.vtxo_repo = Some(vtxo_repo);
+        self.wallet = Some(wallet);
+        self.tx_builder = Some(tx_builder);
+        self
     }
 
     /// Get the current chain tip height from Esplora.
@@ -231,30 +252,83 @@ impl EsploraSweepService {
 #[async_trait]
 impl SweepService for EsploraSweepService {
     async fn sweep_expired_vtxos(&self, current_height: u32) -> ArkResult<SweepResult> {
-        // TODO(#246): full tx building needs TxBuilder wiring.
-        //
-        // This stub:
-        // 1. Logs that a sweep check is being performed
-        // 2. Returns an empty result since we don't yet have the VtxoRepository
-        //    injected to query for expired VTXOs
-        //
-        // Full implementation would:
-        // - Query VtxoRepository for expired VTXOs (expires_at < now)
-        // - For each, call check_sweepable() to verify on-chain state
-        // - Build sweep transactions via TxBuilder
-        // - Broadcast via WalletService
-
         info!(
             current_height,
             "EsploraSweepService: checking for expired VTXOs to sweep"
         );
 
-        warn!(
-            "EsploraSweepService: sweep_expired_vtxos is a stub — \
-             full tx building needs TxBuilder wiring (see #246)"
+        let (vtxo_repo, wallet, tx_builder) = match (
+            &self.vtxo_repo,
+            &self.wallet,
+            &self.tx_builder,
+        ) {
+            (Some(r), Some(w), Some(t)) => (r, w, t),
+            _ => {
+                warn!("EsploraSweepService: missing deps (vtxo_repo/wallet/tx_builder) — skipping sweep");
+                return Ok(SweepResult::default());
+            }
+        };
+
+        // Get all unspent, unswept VTXOs from the repository
+        let (spendable, _spent) = vtxo_repo.list_all().await.unwrap_or_default();
+        let all_vtxos = spendable;
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_secs() as i64;
+
+        // Filter: expired (expires_at < now) and not already swept/spent
+        let expired: Vec<_> = all_vtxos
+            .into_iter()
+            .filter(|v| !v.spent && !v.swept && v.expires_at > 0 && v.expires_at < now)
+            .collect();
+
+        if expired.is_empty() {
+            debug!("EsploraSweepService: no expired VTXOs to sweep");
+            return Ok(SweepResult::default());
+        }
+
+        info!(
+            count = expired.len(),
+            "EsploraSweepService: found expired VTXOs"
         );
 
-        Ok(SweepResult::default())
+        // Build sweep inputs
+        let sweep_inputs: Vec<dark_core::ports::SweepInput> = expired
+            .iter()
+            .map(|v| dark_core::ports::SweepInput {
+                txid: v.outpoint.txid.clone(),
+                vout: v.outpoint.vout,
+                amount: v.amount,
+                tapscripts: vec![],
+            })
+            .collect();
+
+        // Build sweep tx
+        let (sweep_tx_hex, sweep_txid) = match tx_builder.build_sweep_tx(&sweep_inputs).await {
+            Ok(result) => result,
+            Err(e) => {
+                warn!(error = %e, "EsploraSweepService: failed to build sweep tx");
+                return Ok(SweepResult::default());
+            }
+        };
+
+        // Broadcast
+        match wallet.broadcast_transaction(vec![sweep_tx_hex]).await {
+            Ok(txid) => {
+                let sats: u64 = expired.iter().map(|v| v.amount).sum();
+                info!(txid = %txid, vtxos = expired.len(), sats, "EsploraSweepService: sweep tx broadcast");
+                Ok(SweepResult {
+                    vtxos_swept: expired.len(),
+                    sats_recovered: sats,
+                    tx_ids: vec![sweep_txid],
+                })
+            }
+            Err(e) => {
+                warn!(error = %e, "EsploraSweepService: broadcast failed");
+                Ok(SweepResult::default())
+            }
+        }
     }
 
     async fn sweep_connectors(&self, round_id: &str) -> ArkResult<SweepResult> {

--- a/src/main.rs
+++ b/src/main.rs
@@ -228,15 +228,8 @@ async fn main() -> Result<()> {
             Arc::new(dark_core::NoopFraudDetector)
         };
 
-    // --- Sweep service ---
-    let sweep_service: Arc<dyn dark_core::ports::SweepService> =
-        if let Some(ref esplora_url) = config.esplora_url {
-            info!(url = %esplora_url, "Using EsploraSweepService for VTXO sweep monitoring");
-            Arc::new(dark_scanner::EsploraSweepService::new(esplora_url))
-        } else {
-            info!("No esplora_url — using NoopSweepService");
-            Arc::new(dark_core::NoopSweepService)
-        };
+    // --- Sweep service (wired with vtxo_repo/wallet/tx_builder later) ---
+    let sweep_esplora_url = config.esplora_url.clone();
 
     // --- Nostr notifier (Issue #247) ---
     let notifier: Arc<dyn dark_core::ports::Notifier> =
@@ -302,6 +295,26 @@ async fn main() -> Result<()> {
         info!("No asp_key_hex configured — generating random ASP key (dev mode)");
         Arc::new(LocalSigner::random())
     };
+
+    // Pre-compute sweep service deps before wallet/ark_config are moved
+    let sweep_service: Arc<dyn dark_core::ports::SweepService> =
+        if let Some(ref esplora_url) = sweep_esplora_url {
+            info!(url = %esplora_url, "Using EsploraSweepService for VTXO sweep monitoring");
+            let sweep_tx_builder = Arc::new(
+                LocalTxBuilder::new(&ark_config.network)
+                    .with_csv_delay(ark_config.unilateral_exit_delay as u16),
+            );
+            Arc::new(
+                dark_scanner::EsploraSweepService::new(esplora_url).with_deps(
+                    vtxo_repo.clone(),
+                    Arc::clone(&wallet),
+                    sweep_tx_builder as Arc<dyn dark_core::ports::TxBuilder>,
+                ),
+            )
+        } else {
+            info!("No esplora_url — using NoopSweepService");
+            Arc::new(dark_core::NoopSweepService)
+        };
 
     let core = Arc::new(
         dark_core::ArkService::new(


### PR DESCRIPTION
## Summary

### Fraud detection (#334)

`react_to_fraud()` was queuing forfeit txs but never broadcasting them. The server needs to broadcast the forfeit tx immediately when a double-spend is detected so it claims the VTXO before Alice's CSV timelock expires.

Fix: broadcast directly via `POST {esplora_url}/tx` with fallback to queue-for-retry.

### Sweep service (#331)

`EsploraSweepService.sweep_expired_vtxos()` was a stub returning empty results. The Go e2e tests wait for dark to automatically sweep expired VTXO outputs after blocks are mined past the CSV delay.

Fix:
- Add optional `vtxo_repo`/`wallet`/`tx_builder` deps via `with_deps()` builder
- `sweep_expired_vtxos()` queries expired VTXOs, builds sweep tx, broadcasts
- `main.rs` wires the deps before they are moved into `ArkService`

Relates to #331, #334