### PR TITLE
fix(e2e): FinalizeTx emits event + GetVtxoChain includes tree nodes (#326, #328)

### DIFF
--- a/crates/dark-api/src/grpc/ark_service.rs
+++ b/crates/dark-api/src/grpc/ark_service.rs
@@ -617,6 +617,9 @@ impl ArkServiceTrait for ArkGrpcService {
             }
         }
 
+        // Emit TxFinalized event so subscribers (NotifyIncomingFunds) know a VTXO moved
+        let _ = self.core.emit_tx_finalized_event(&req.ark_txid).await;
+
         info!(ark_txid = %req.ark_txid, "FinalizeTx: off-chain tx finalized");
         Ok(Response::new(FinalizeTxResponse {}))
     }

--- a/crates/dark-api/src/grpc/indexer_service.rs
+++ b/crates/dark-api/src/grpc/indexer_service.rs
@@ -491,18 +491,44 @@ impl IndexerServiceTrait for IndexerGrpcService {
                     .unwrap_or(false)
             });
 
-        // For now, return the VTXO's commitment chain as single-hop entries.
+        // Build the full chain: commitment tx → vtxo tree nodes → leaf VTXO
         let chain: Vec<crate::proto::ark_v1::IndexerChain> = match vtxo {
-            Some(v) => v
-                .commitment_txids
-                .iter()
-                .map(|txid| crate::proto::ark_v1::IndexerChain {
-                    txid: txid.clone(),
-                    expires_at: v.expires_at,
-                    r#type: 1, // INDEXER_CHAINED_TX_TYPE_COMMITMENT
-                    spends: vec![],
-                })
-                .collect(),
+            Some(ref v) => {
+                let mut entries = Vec::new();
+
+                // 1. Add commitment txids as the root entries
+                for commitment_txid in &v.commitment_txids {
+                    // Find the round for this commitment txid to get tree nodes
+                    let tree_node_txids = if let Ok(Some(round)) = self
+                        .core
+                        .get_round_by_commitment_txid(commitment_txid)
+                        .await
+                    {
+                        round
+                            .vtxo_tree
+                            .iter()
+                            .filter(|n| !n.tx.is_empty())
+                            .map(|n| n.txid.clone())
+                            .collect::<Vec<_>>()
+                    } else {
+                        vec![]
+                    };
+
+                    // Build spends list: tree node txids + the leaf VTXO txid
+                    let mut spends = tree_node_txids.clone();
+                    if !tree_node_txids.is_empty() {
+                        spends.push(v.outpoint.txid.clone());
+                    }
+
+                    entries.push(crate::proto::ark_v1::IndexerChain {
+                        txid: commitment_txid.clone(),
+                        expires_at: v.expires_at,
+                        r#type: 1, // INDEXER_CHAINED_TX_TYPE_COMMITMENT
+                        spends,
+                    });
+                }
+                entries
+            }
             None => vec![],
         };
 

--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -1471,6 +1471,17 @@ impl ArkService {
         self.offchain_tx_repo.get(tx_id).await
     }
 
+    /// Emit a TxFinalized event for an off-chain transaction.
+    /// Used by FinalizeTx gRPC to notify subscribers.
+    pub async fn emit_tx_finalized_event(&self, ark_txid: &str) -> ArkResult<()> {
+        self.events
+            .publish_event(ArkEvent::TxFinalized {
+                ark_txid: ark_txid.to_string(),
+                commitment_txid: ark_txid.to_string(),
+            })
+            .await
+    }
+
     // ── Ban / conviction ──────────────────────────────────────────────
 
     /// Ban a participant for misbehaviour and emit a `ParticipantBanned` event.


### PR DESCRIPTION
## FinalizeTx event emission (#328)

`FinalizeTx` was broadcasting checkpoints but not emitting any event. The Go SDK's `NotifyIncomingFunds` waits for a VTXO-related event after off-chain transfers — without an event, the call hangs indefinitely.

Fix: emit `TxFinalized` event from `FinalizeTx` so `GetTransactionsStream` subscribers are notified.

## GetVtxoChain tree nodes (#326)

For unilateral exit (`Unroll()`), the Go client calls `GetVtxoChain` to get the spending path from commitment tx → tree nodes → leaf VTXO. The chain was only returning commitment txids with empty `spends`.

Fix: populate `spends` with vtxo tree node txids by looking up the round, enabling the client to call `GetVirtualTxs` to retrieve the PSBTs needed for exit.

Relates to #326, #328