### PR TITLE
fix(e2e): store offchain tx by ark_txid + finalize on FinalizeTx (#328)

### DIFF
--- a/crates/dark-api/src/grpc/ark_service.rs
+++ b/crates/dark-api/src/grpc/ark_service.rs
@@ -569,12 +569,13 @@ impl ArkServiceTrait for ArkGrpcService {
         // Co-sign checkpoint txs (ASP adds its signature)
         let signed_checkpoint_txs = req.checkpoint_txs.clone();
 
-        // Store pending tx for FinalizeTx
+        // Store pending tx keyed by ark_txid so FinalizeTx can retrieve it
         let inputs = vec![dark_core::domain::VtxoInput {
             vtxo_id: ark_txid.clone(),
             signed_tx: req.signed_ark_tx.as_bytes().to_vec(),
         }];
-        let offchain_tx = dark_core::domain::OffchainTx::new(inputs, vec![]);
+        let offchain_tx =
+            dark_core::domain::OffchainTx::new_with_id(ark_txid.clone(), inputs, vec![]);
         let _ = self.offchain_tx_repo.create(&offchain_tx).await;
 
         info!(ark_txid, "SubmitTx: off-chain tx accepted and co-signed");
@@ -616,6 +617,9 @@ impl ArkServiceTrait for ArkGrpcService {
                 }
             }
         }
+
+        // Mark the offchain tx as finalized in the repo
+        let _ = self.core.finalize_offchain_tx(&req.ark_txid).await;
 
         // Emit TxFinalized event so subscribers (NotifyIncomingFunds) know a VTXO moved
         let _ = self.core.emit_tx_finalized_event(&req.ark_txid).await;

--- a/crates/dark-core/src/domain/offchain_tx.rs
+++ b/crates/dark-core/src/domain/offchain_tx.rs
@@ -87,12 +87,17 @@ pub struct VtxoOutput {
 impl OffchainTx {
     /// Create a new offchain transaction in the Requested stage.
     pub fn new(inputs: Vec<VtxoInput>, outputs: Vec<VtxoOutput>) -> Self {
+        Self::new_with_id(Uuid::new_v4().to_string(), inputs, outputs)
+    }
+
+    /// Create with a specific ID (e.g. the ark_txid from SubmitTx).
+    pub fn new_with_id(id: String, inputs: Vec<VtxoInput>, outputs: Vec<VtxoOutput>) -> Self {
         let now = SystemTime::now()
             .duration_since(UNIX_EPOCH)
             .unwrap_or_default()
             .as_secs();
         Self {
-            id: Uuid::new_v4().to_string(),
+            id,
             inputs,
             outputs,
             stage: OffchainTxStage::Requested,


### PR DESCRIPTION
## Summary

- `OffchainTx::new_with_id()` — allows creating with a specific ID
- `SubmitTx`: stores pending tx keyed by `ark_txid` so `FinalizeTx` can look it up
- `FinalizeTx`: calls `finalize_offchain_tx()` to update stage before emitting the `TxFinalized` event

Relates to #328