### PR TITLE
fix: pubkey format mismatch in GetVtxos — use x-only key for VTXO lookup

### DIFF
--- a/crates/dark-api/src/grpc/indexer_service.rs
+++ b/crates/dark-api/src/grpc/indexer_service.rs
@@ -398,22 +398,22 @@ impl IndexerServiceTrait for IndexerGrpcService {
         );
 
         // Scripts arrive as P2TR scriptpubkeys: "5120<32-byte-xonly-hex>" (68 hex chars).
-        // Our VTXOs are indexed by the 33-byte compressed pubkey (66 hex chars).
-        // Convert the xonly tapkey to compressed form (try 02 prefix; if not found, try 03).
-        // We also accept the raw xonly (64 chars) or compressed (66 chars) directly.
+        // Our VTXOs are indexed by the 32-byte x-only pubkey (64 hex chars).
+        // Extract the raw x-only key from the P2TR script.
+        // We also accept compressed (66 chars, strip prefix) or raw xonly (64 chars) directly.
         let script_tapkeys: Vec<String> = req
             .scripts
             .iter()
             .map(|s| {
                 // P2TR: OP_1(51) OP_PUSH32(20) <32-byte-key> = 34 bytes = 68 hex chars
                 if s.len() == 68 && s.starts_with("5120") {
-                    // Convert xonly → compressed (even parity = 02 prefix).
-                    // Ark always uses even-parity keys in practice.
-                    format!("02{}", &s[4..])
-                } else if s.len() == 64 {
-                    // Raw xonly → assume even parity
-                    format!("02{}", s)
+                    // Extract x-only key (strip "5120" prefix)
+                    s[4..].to_string()
+                } else if s.len() == 66 && (s.starts_with("02") || s.starts_with("03")) {
+                    // Compressed pubkey → strip prefix to get x-only
+                    s[2..].to_string()
                 } else {
+                    // Already x-only (64 chars) or other format — use as-is
                     s.clone()
                 }
             })


### PR DESCRIPTION
## Problem

VTXOs are stored with 32-byte x-only pubkeys (64 hex chars) when created via `RegisterIntent`. However, `GetVtxos` was converting P2TR scripts to 33-byte compressed pubkeys (`02` prefix + x-only = 66 hex chars) before querying the database, causing zero results.

### Affected flows
- **`Balance()`** returning 0 after round settlement (`TestBatchSession/refresh_vtxos`)
- **`not enough funds`** errors when `getSpendableVtxos` found no VTXOs
- Any flow relying on `GetVtxos` with P2TR script filters

## Root cause

In `indexer_service.rs::GetVtxos`, P2TR scripts (`5120<x-only-key>`) were being converted to compressed pubkeys:
```rust
// Before (broken): converts to 66-char compressed key
format!("02{}", &s[4..])  // "02" + x-only = doesn't match DB
```

But VTXOs are stored with 64-char x-only keys (from `RegisterIntent`):
```rust
// RegisterIntent extracts x-only from P2TR output:
hex::encode(&script_bytes[2..34])  // 64 hex chars, no prefix
```

## Fix

Extract the raw x-only key (strip `5120` prefix) instead of converting to compressed format:
```rust
// After (fixed): extracts 64-char x-only key
s[4..].to_string()  // matches DB storage format
```

Also handles compressed pubkey input by stripping the `02`/`03` prefix.