### PR TITLE
fix(server): spawn event bridge before round loop to avoid missing BatchStarted

### DIFF
--- a/crates/dark-api/src/server.rs
+++ b/crates/dark-api/src/server.rs
@@ -238,11 +238,13 @@ impl Server {
         // Load TLS config once (before spawning tasks)
         let tls_config = self.load_tls_config().await?;
 
+        // Bridge core ArkService domain events → gRPC EventBroker.
+        // Must subscribe BEFORE spawning gRPC/admin servers and BEFORE the
+        // round loop fires its first tick, so no BatchStarted events are missed.
+        self.spawn_event_bridge();
+
         let grpc_handle = self.spawn_grpc_server(tls_config.clone())?;
         let admin_handle = self.spawn_admin_server(tls_config)?;
-
-        // Bridge core ArkService domain events → gRPC EventBroker
-        self.spawn_event_bridge();
 
         info!(
             grpc_addr = %self.config.grpc_addr,

--- a/crates/dark-scheduler/src/time_scheduler.rs
+++ b/crates/dark-scheduler/src/time_scheduler.rs
@@ -20,7 +20,14 @@ impl TimeScheduler for SimpleTimeScheduler {
     async fn schedule(&self, interval: Duration) -> ArkResult<mpsc::Receiver<()>> {
         let (tx, rx) = mpsc::channel(1);
         tokio::spawn(async move {
-            // Send an immediate first tick so a round starts on server boot.
+            // Wait a short startup grace period before firing the first tick.
+            // This ensures the gRPC event bridge has subscribed to the core event
+            // bus before the first BatchStarted event is emitted, so no clients
+            // miss it. 500ms is sufficient since the bridge subscribes synchronously
+            // in its spawned task which runs immediately after server start.
+            tokio::time::sleep(Duration::from_millis(500)).await;
+
+            // Send the first tick to start the initial round.
             if tx.send(()).await.is_err() {
                 return;
             }


### PR DESCRIPTION
## Root cause

The round loop started before `server.run()` called `spawn_event_bridge()`. The first `BatchStarted` event fired before the bridge subscribed — lost forever. Tests waited 60s for an event that had already passed.

## Fix
1. Move `spawn_event_bridge()` to the top of `server.run()` (before gRPC/admin spawn)
2. Add 500ms startup grace in `SimpleTimeScheduler` before first tick so the event bridge task has time to subscribe before the first round fires