### PR TITLE
fix(core): auto-complete round when no cosigners to avoid stuck Finalization

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -3025,6 +3025,8 @@ mod tests {
         intent
             .add_receivers(vec![Receiver::offchain(25_000, "rcv_pk".into())])
             .unwrap();
+        // Add a cosigner so the round doesn't auto-complete (zero-cosigner path)
+        intent.cosigners_public_keys = vec!["cd".repeat(33)];
         svc.register_intent(intent).await.unwrap();
 
         // Finalize (phase 1): enters tree signing, round stays in Finalization


### PR DESCRIPTION
## Problem

When `finalize_round()` transitions a round to Finalization stage with 0 cosigners (no MuSig2 participants), the round stays stuck forever in Finalization — no tree nonces/signatures will ever arrive.

This blocks all subsequent rounds: the round loop skips finalization for rounds already in Finalization stage, and `start_round()` rejects with "Round already active" since the stuck round has not ended.

**Impact:** 22/39 Rust e2e tests fail with `Timeout waiting for round to start (registration stage)` after 60s.

## Root Cause

`finalize_round()` always enters the tree signing phase and returns the round in Finalization stage, regardless of whether there are actual cosigners. With 0 cosigners, `complete_round()` is never called because no `SubmitTreeNonces`/`SubmitTreeSignatures` RPCs arrive.

## Fix

At the end of `finalize_round()`, detect when `cosigners_pubkeys` is empty and immediately complete the round inline:
- Create VTXOs from intents
- Persist VTXOs to the database
- End the round successfully
- Emit `RoundFinalized` event

This allows the round loop to start fresh rounds on subsequent ticks.