### PR TITLE
fix: convert ASP-signed VTXO tree PSBTs from hex to base64

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -2892,12 +2892,18 @@ impl ArkService {
         // Re-encode and sign with ASP signer
         let psbt_b64_with_utxo = base64::engine::general_purpose::STANDARD.encode(psbt.serialize());
 
-        let signed = self
+        let signed_hex = self
             .signer
             .sign_transaction(&psbt_b64_with_utxo, false)
             .await?;
 
-        Ok(signed)
+        // sign_transaction returns hex-encoded PSBT, but tree nodes must be
+        // base64 because the Go SDK parses them with psbt.NewFromRawBytes(_, true).
+        let signed_bytes = hex::decode(&signed_hex)
+            .map_err(|e| ArkError::Internal(format!("Signed PSBT is not valid hex: {e}")))?;
+        let signed_b64 = base64::engine::general_purpose::STANDARD.encode(&signed_bytes);
+
+        Ok(signed_b64)
     }
 }
 


### PR DESCRIPTION
## Problem

`TestUnilateralExit/leaf_vtxo` fails with `invalid tx, unable to finalize` because the VTXO tree PSBTs stored by dark are hex-encoded, but the Go SDK expects base64.

## Root Cause

`LocalSigner::sign_transaction()` returns hex-encoded PSBTs (`hex::encode(psbt.serialize())`). The `asp_sign_single_tree_psbt()` function stores this hex directly as the tree node `tx` field. When the Go SDK calls `GetVirtualTxs` and passes the result to `psbt.NewFromRawBytes(_, true)`, it expects base64 — so it either fails to parse or produces a garbled PSBT with no signature fields, leading to `invalid tx, unable to finalize`.

## Fix

Convert the hex output from the signer back to base64 in `asp_sign_single_tree_psbt()`, matching the encoding used when tree PSBTs are originally built (`base64::engine::general_purpose::STANDARD.encode(psbt.serialize())`).

One-line change in `crates/dark-core/src/application.rs`.