### PR TITLE
fix(round): emit TreeTx events before BatchStarted for Go SDK compatibility

### DIFF
--- a/crates/dark-api/src/server.rs
+++ b/crates/dark-api/src/server.rs
@@ -340,6 +340,7 @@ impl Server {
     /// between the spawned task scheduling and events being published.
     async fn spawn_event_bridge(&self) {
         let broker = Arc::clone(&self.broker);
+        let batch_expiry = self.core.config().unilateral_exit_delay as i64;
 
         // Subscribe synchronously BEFORE spawning the task.
         // This ensures we're subscribed to the event bus before any events can fire.
@@ -378,7 +379,7 @@ impl Server {
                                         BatchStartedEvent {
                                             id: round_id.clone(),
                                             intent_id_hashes: hashes,
-                                            batch_expiry: 0,
+                                            batch_expiry,
                                         },
                                     )),
                                 })
@@ -431,6 +432,7 @@ impl Server {
                                 txid,
                                 tx,
                                 cosigners,
+                                children,
                             } => Some(RoundEvent {
                                 event: Some(round_event::Event::TreeTx(TreeTxEvent {
                                     id: round_id.clone(),
@@ -438,7 +440,10 @@ impl Server {
                                     batch_index: 0, // vtxo tree
                                     txid: txid.clone(),
                                     tx: tx.clone(),
-                                    children: std::collections::HashMap::new(),
+                                    children: children
+                                        .iter()
+                                        .map(|(k, v)| (*k, v.clone()))
+                                        .collect(),
                                 })),
                             }),
                             dark_core::domain::ArkEvent::TreeSigningPhaseStarted {

--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -532,17 +532,10 @@ impl ArkService {
             round.start_finalization().map_err(ArkError::Internal)?;
         }
 
-        // Emit BatchStarted so GetEventStream clients know the batch is forming
+        // NOTE: BatchStarted is emitted AFTER TreeTxReady events (below) so
+        // that Go SDK clients can collect tree nodes before advancing their
+        // internal step machine past the "batchStarted" state.
         let intent_ids: Vec<String> = intents.iter().map(|i| i.id.clone()).collect();
-        let timestamp = chrono::Utc::now().timestamp();
-        self.events
-            .publish_event(ArkEvent::BatchStarted {
-                round_id: round.id.clone(),
-                intent_ids: intent_ids.clone(),
-                unsigned_vtxo_tree: String::new(),
-                timestamp,
-            })
-            .await?;
 
         // Collect boarding inputs from intent proof tx inputs.
         // Only include inputs that are on-chain boarding UTXOs (NOT already
@@ -652,7 +645,12 @@ impl ArkService {
             .init_session(&round.id, cosigners_pubkeys.len())
             .await?;
 
-        // Emit TreeTxReady for each vtxo tree node
+        // Emit TreeTxReady for each vtxo tree node BEFORE BatchStarted.
+        // The Go SDK's step machine only processes TreeTx events while in
+        // the initial "batchStarted" state (step 0). Once BatchStarted is
+        // received the step advances to 1 and subsequent TreeTx events are
+        // ignored. Sending them first ensures the client collects all tree
+        // nodes before the step transition.
         for node in &round.vtxo_tree {
             if node.tx.is_empty() {
                 continue;
@@ -663,9 +661,22 @@ impl ArkService {
                     txid: node.txid.clone(),
                     tx: node.tx.clone(),
                     cosigners: cosigners_pubkeys.clone(),
+                    children: node.children.clone(),
                 })
                 .await?;
         }
+
+        // NOW emit BatchStarted — Go clients will see their intent hash,
+        // call ConfirmRegistration, and advance to the tree-signing step.
+        let timestamp = chrono::Utc::now().timestamp();
+        self.events
+            .publish_event(ArkEvent::BatchStarted {
+                round_id: round.id.clone(),
+                intent_ids: intent_ids.clone(),
+                unsigned_vtxo_tree: String::new(),
+                timestamp,
+            })
+            .await?;
 
         // When there are no cosigners, skip the tree signing phase and complete
         // the round immediately.  Otherwise the round stays in Finalization

--- a/crates/dark-core/src/domain/events.rs
+++ b/crates/dark-core/src/domain/events.rs
@@ -201,6 +201,8 @@ pub enum ArkEvent {
         tx: String,
         /// Cosigner pubkeys involved in this tree node
         cosigners: Vec<String>,
+        /// Maps output index → child txid (for tree structure)
+        children: std::collections::HashMap<u32, String>,
     },
 
     /// Tree signing phase has started — cosigners should submit nonces.


### PR DESCRIPTION
## Problem

The Go e2e test suite hangs at `TestBatchSession/refresh_vtxos` — the test times out after 1 hour.

### Root Cause

The Go SDK's `JoinBatchSession` step machine processes `TreeTxEvent` only during the initial `batchStarted` state (step 0). Once a `BatchStartedEvent` is received and matched, the step advances to 1 (`treeSigningStarted`), and any subsequent `TreeTxEvent` is silently ignored.

Our `finalize_round()` emitted events in this order:
1. `BatchStarted` (step 0 → 1)
2. `TreeTxReady` (step 1 → **skipped**)
3. `TreeSigningStarted` (step 1 → tries to build vtxo tree from empty `flatVtxoTree` → error)

The Go client's `Settle()` would fail, but `NotifyIncomingFunds()` goroutines would hang forever waiting for `VtxoCreated` events that never arrive. The test's `wg.Wait()` blocks indefinitely.

### Fix

- **Reorder events**: Emit `TreeTxReady` events **before** `BatchStarted` in `finalize_round()`. New order: TreeTx → BatchStarted → TreeSigningStarted
- **Set `batch_expiry`** from `unilateral_exit_delay` config (was hardcoded to 0)
- **Include `children` map** in `TreeTxEvent` for proper tree reconstruction

This also fixes the `TestBatchSession/refresh_vtxos` `LockedAmount` assertion — boarding UTXOs were never spent because rounds never completed successfully.