### PR TITLE
fix: defer BatchFinalized until commitment tx is broadcast

### DIFF
--- a/crates/dark-api/src/grpc/ark_service.rs
+++ b/crates/dark-api/src/grpc/ark_service.rs
@@ -1327,13 +1327,25 @@ impl ArkServiceTrait for ArkGrpcService {
             "SubmitSignedForfeitTxs called"
         );
 
-        // If the client sent a signed commitment tx, finalize and broadcast it
+        // If the client sent a signed commitment tx, finalize and broadcast it.
+        // The round_id is resolved inside broadcast_signed_commitment_tx from
+        // the stored partial PSBTs (the first partial carries the round_id).
+        // We pass the best-effort current round id as a fallback.
         if !req.signed_commitment_tx.is_empty() {
             let signed_commitment_str = &req.signed_commitment_tx;
-            info!("Client sent signed_commitment_tx — attempting broadcast");
+            let fallback_round_id = self
+                .core
+                .current_round_snapshot()
+                .await
+                .map(|r| r.id.clone())
+                .unwrap_or_default();
+            info!(
+                round_id = %fallback_round_id,
+                "Client sent signed_commitment_tx — attempting broadcast"
+            );
             match self
                 .core
-                .broadcast_signed_commitment_tx(signed_commitment_str)
+                .broadcast_signed_commitment_tx(signed_commitment_str, &fallback_round_id)
                 .await
             {
                 Ok(txid) => info!(txid = %txid, "Commitment tx broadcast from client signature"),

--- a/crates/dark-api/src/server.rs
+++ b/crates/dark-api/src/server.rs
@@ -387,9 +387,11 @@ impl Server {
                             dark_core::domain::ArkEvent::RoundFinalized {
                                 round_id,
                                 commitment_tx,
+                                has_boarding_inputs,
                                 ..
                             } => {
-                                // Emit both BatchFinalization and BatchFinalized
+                                // Always emit BatchFinalization so clients can
+                                // sign boarding inputs and submit forfeits.
                                 broker.publish(RoundEvent {
                                     event: Some(round_event::Event::BatchFinalization(
                                         BatchFinalizationEvent {
@@ -399,26 +401,51 @@ impl Server {
                                     )),
                                 });
 
-                                // Extract txid from commitment tx PSBT (base64-encoded)
-                                let txid = {
-                                    use base64::Engine;
-                                    base64::engine::general_purpose::STANDARD
-                                        .decode(commitment_tx)
-                                        .ok()
-                                        .and_then(|b| bitcoin::psbt::Psbt::deserialize(&b).ok())
-                                        .map(|psbt| psbt.unsigned_tx.compute_txid().to_string())
-                                        .unwrap_or_default()
-                                };
+                                // When there are no boarding inputs the
+                                // commitment tx doesn't need to be broadcast
+                                // on-chain, so we can emit BatchFinalized
+                                // immediately.  When there ARE boarding inputs,
+                                // BatchFinalized is deferred until the
+                                // commitment tx is actually broadcast
+                                // (RoundBroadcast event).
+                                if !has_boarding_inputs {
+                                    let txid = {
+                                        use base64::Engine;
+                                        base64::engine::general_purpose::STANDARD
+                                            .decode(commitment_tx)
+                                            .ok()
+                                            .and_then(|b| bitcoin::psbt::Psbt::deserialize(&b).ok())
+                                            .map(|psbt| psbt.unsigned_tx.compute_txid().to_string())
+                                            .unwrap_or_default()
+                                    };
 
-                                Some(RoundEvent {
-                                    event: Some(round_event::Event::BatchFinalized(
-                                        BatchFinalizedEvent {
-                                            id: round_id.clone(),
-                                            commitment_txid: txid,
-                                        },
-                                    )),
-                                })
+                                    Some(RoundEvent {
+                                        event: Some(round_event::Event::BatchFinalized(
+                                            BatchFinalizedEvent {
+                                                id: round_id.clone(),
+                                                commitment_txid: txid,
+                                            },
+                                        )),
+                                    })
+                                } else {
+                                    // BatchFinalized will be emitted when
+                                    // RoundBroadcast fires after the
+                                    // commitment tx is broadcast.
+                                    None
+                                }
                             }
+                            dark_core::domain::ArkEvent::RoundBroadcast {
+                                round_id,
+                                commitment_txid,
+                                ..
+                            } => Some(RoundEvent {
+                                event: Some(round_event::Event::BatchFinalized(
+                                    BatchFinalizedEvent {
+                                        id: round_id.clone(),
+                                        commitment_txid: commitment_txid.clone(),
+                                    },
+                                )),
+                            }),
                             dark_core::domain::ArkEvent::RoundFailed {
                                 round_id, reason, ..
                             } => Some(RoundEvent {

--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -200,8 +200,9 @@ pub struct ArkService {
     /// Active exits indexed by ID
     /// TODO(#9): Back with SQLite persistence to survive restarts
     exits: RwLock<std::collections::HashMap<uuid::Uuid, Exit>>,
-    /// Partial commitment tx PSBTs from clients (for merging before broadcast)
-    partial_commitment_psbts: tokio::sync::Mutex<Vec<String>>,
+    /// Partial commitment tx PSBTs from clients (for merging before broadcast).
+    /// Tuple: (round_id, base64 PSBT).
+    partial_commitment_psbts: tokio::sync::Mutex<Vec<(String, String)>>,
 }
 
 impl ArkService {
@@ -771,14 +772,29 @@ impl ArkService {
                 warn!(error = %e, "Failed to persist round (non-fatal, auto-complete)");
             }
 
+            let has_boarding = !boarding_inputs.is_empty();
             self.events
                 .publish_event(ArkEvent::RoundFinalized {
                     round_id: round.id.clone(),
                     commitment_tx: round.commitment_tx.clone(),
                     timestamp: round.ending_timestamp,
                     vtxo_count: vtxos.len() as u32,
+                    has_boarding_inputs: has_boarding,
                 })
                 .await?;
+
+            // For rounds without boarding inputs there is no commitment tx to
+            // broadcast, so emit RoundBroadcast immediately so clients see
+            // BatchFinalized.
+            if !has_boarding {
+                self.events
+                    .publish_event(ArkEvent::RoundBroadcast {
+                        round_id: round.id.clone(),
+                        commitment_txid: commitment_txid.clone(),
+                        timestamp: chrono::Utc::now().timestamp(),
+                    })
+                    .await?;
+            }
 
             return Ok(round.clone());
         }
@@ -891,14 +907,31 @@ impl ArkService {
             }
         }
 
-        // NOTE: commitment tx broadcast is handled by the client via SubmitSignedForfeitTxs.signed_commitment_tx
-        // The client signs the boarding inputs with their own key, then the ASP co-signs and broadcasts.
+        // Commitment tx broadcast is handled by the client via
+        // SubmitSignedForfeitTxs.signed_commitment_tx.  The client signs the
+        // boarding inputs, then the ASP co-signs and broadcasts.
+        // BatchFinalized is deferred until broadcast (RoundBroadcast event).
+
+        // Detect whether the commitment tx has on-chain (boarding) inputs.
+        // If it does, the client must submit a signed commitment tx before
+        // BatchFinalized is emitted.  If it doesn't, we emit BatchFinalized
+        // immediately because there is no transaction to broadcast.
+        let has_boarding = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD
+                .decode(&round.commitment_tx)
+                .ok()
+                .and_then(|b| bitcoin::psbt::Psbt::deserialize(&b).ok())
+                .map(|psbt| !psbt.unsigned_tx.input.is_empty())
+                .unwrap_or(false)
+        };
 
         round.end_successfully();
 
         info!(
             round_id = %round.id,
             intent_count = intents.len(),
+            has_boarding_inputs = has_boarding,
             "Round completed with commitment tx"
         );
 
@@ -914,8 +947,21 @@ impl ArkService {
                 commitment_tx: round.commitment_tx.clone(),
                 timestamp: round.ending_timestamp,
                 vtxo_count: vtxos.len() as u32,
+                has_boarding_inputs: has_boarding,
             })
             .await?;
+
+        // For rounds without boarding inputs, emit RoundBroadcast immediately
+        // so clients see BatchFinalized without waiting for a broadcast.
+        if !has_boarding {
+            self.events
+                .publish_event(ArkEvent::RoundBroadcast {
+                    round_id: round.id.clone(),
+                    commitment_txid: commitment_txid.clone(),
+                    timestamp: chrono::Utc::now().timestamp(),
+                })
+                .await?;
+        }
 
         Ok(round.clone())
     }
@@ -2429,6 +2475,7 @@ impl ArkService {
     pub async fn broadcast_signed_commitment_tx(
         &self,
         signed_commitment_tx: &str,
+        round_id: &str,
     ) -> ArkResult<String> {
         use base64::Engine;
 
@@ -2443,7 +2490,7 @@ impl ArkService {
 
         // Store this partial PSBT
         let mut partials = self.partial_commitment_psbts.lock().await;
-        partials.push(signed_commitment_tx.to_string());
+        partials.push((round_id.to_string(), signed_commitment_tx.to_string()));
 
         info!(
             partial_count = partials.len(),
@@ -2456,7 +2503,7 @@ impl ArkService {
         // may have already been replaced by a new round when the scheduler
         // ticks between clients submitting their signed PSBTs.
         let mut merged = incoming_psbt;
-        for partial_b64 in partials.iter() {
+        for (_rid, partial_b64) in partials.iter() {
             if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(partial_b64) {
                 if let Ok(partial) = bitcoin::psbt::Psbt::deserialize(&bytes) {
                     for (i, input) in partial.inputs.iter().enumerate() {
@@ -2524,6 +2571,12 @@ impl ArkService {
                 "Merged PSBT input state"
             );
         }
+
+        // Grab the round_id from the stored partials before clearing.
+        let effective_round_id = partials
+            .first()
+            .map(|(rid, _)| rid.clone())
+            .unwrap_or_else(|| round_id.to_string());
 
         // Clear partials for next round
         partials.clear();
@@ -2628,6 +2681,16 @@ impl ArkService {
         let txid = self.wallet.broadcast_transaction(vec![raw_tx]).await?;
 
         info!(txid = %txid, "Merged commitment tx broadcast successfully");
+
+        // Emit RoundBroadcast so the event bridge publishes BatchFinalized.
+        self.events
+            .publish_event(ArkEvent::RoundBroadcast {
+                round_id: effective_round_id,
+                commitment_txid: txid.clone(),
+                timestamp: chrono::Utc::now().timestamp(),
+            })
+            .await?;
+
         Ok(txid)
     }
 

--- a/crates/dark-core/src/domain/events.rs
+++ b/crates/dark-core/src/domain/events.rs
@@ -50,6 +50,12 @@ pub enum ArkEvent {
         timestamp: i64,
         /// Number of VTXOs created in this round
         vtxo_count: u32,
+        /// Whether the commitment tx includes boarding (on-chain) inputs that
+        /// require client signatures before broadcast.  When `true`, the
+        /// `BatchFinalized` proto event is deferred until the commitment tx is
+        /// actually broadcast (via `RoundBroadcast`).
+        #[serde(default)]
+        has_boarding_inputs: bool,
     },
 
     /// Registration phase ended; confirmation phase has started.
@@ -311,6 +317,7 @@ mod tests {
                     commitment_tx: "tx".into(),
                     timestamp: 200,
                     vtxo_count: 5,
+                    has_boarding_inputs: false,
                 },
                 "round.finalized",
             ),
@@ -448,6 +455,7 @@ mod tests {
             commitment_tx: "deadbeef".into(),
             timestamp: 1234567890,
             vtxo_count: 3,
+            has_boarding_inputs: false,
         };
 
         let json = serde_json::to_string(&event).expect("serialize");

--- a/crates/dark-core/src/round_scheduler.rs
+++ b/crates/dark-core/src/round_scheduler.rs
@@ -369,6 +369,7 @@ impl RoundScheduler {
                 commitment_tx: round.commitment_tx.clone(),
                 timestamp: round.ending_timestamp,
                 vtxo_count: 0, // TODO: populate from round vtxo tree
+                has_boarding_inputs: false,
             })
             .await?;
 


### PR DESCRIPTION
## Problem
After `alice.Settle()` completes, `alice.Balance().OnchainBalance.LockedAmount` still contains the boarding UTXO amount because the commitment tx was never broadcast before the client received `BatchFinalized`.

## Root Cause
Dark was emitting both `BatchFinalization` and `BatchFinalized` simultaneously from the `RoundFinalized` event. The Go client processes events sequentially:
1. Receives `BatchFinalization` → signs boarding inputs → submits via `SubmitSignedForfeitTxs`
2. Receives `BatchFinalized` → `Settle()` returns

Since both events were emitted at the same time, client A's `Settle()` could return (after processing `BatchFinalized`) before client B submitted their signed commitment tx. The commitment tx broadcast (which merges all partial signatures) wouldn't happen until both clients had submitted, but by then `Balance()` was already being checked.

## Fix
- **Split event emission:** `RoundFinalized` now only emits `BatchFinalization`. `BatchFinalized` is deferred until the commitment tx is actually broadcast (`RoundBroadcast` event).
- **For virtual rounds** (no boarding inputs / no on-chain tx to broadcast): emit `BatchFinalized` immediately since there's nothing to wait for.
- **`broadcast_signed_commitment_tx()`** now emits `RoundBroadcast` after successful broadcast, which the event bridge converts to `BatchFinalized`.
- Track `round_id` alongside partial commitment PSBTs for correct event attribution.

## Testing
- `cargo fmt --all` ✓
- `cargo clippy --workspace --message-format=short` ✓ (zero warnings)

Fixes TestBatchSession/refresh_vtxos LockedAmount assertion.