### PR TITLE
fix: complete_round() emits BatchFinalized for VTXO-only refresh rounds

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -621,6 +621,7 @@ impl ArkService {
         round.commitment_tx = commitment_tx;
         round.connectors = result.connectors;
         round.connector_address = result.connector_address;
+        round.has_boarding_inputs = !boarding_inputs.is_empty();
 
         // ASP-sign all VTXO tree PSBTs so they are finalizable for unilateral exit.
         // Each tree tx spends a parent output keyed to the ASP; we set witness_utxo
@@ -912,19 +913,13 @@ impl ArkService {
         // boarding inputs, then the ASP co-signs and broadcasts.
         // BatchFinalized is deferred until broadcast (RoundBroadcast event).
 
-        // Detect whether the commitment tx has on-chain (boarding) inputs.
-        // If it does, the client must submit a signed commitment tx before
-        // BatchFinalized is emitted.  If it doesn't, we emit BatchFinalized
-        // immediately because there is no transaction to broadcast.
-        let has_boarding = {
-            use base64::Engine;
-            base64::engine::general_purpose::STANDARD
-                .decode(&round.commitment_tx)
-                .ok()
-                .and_then(|b| bitcoin::psbt::Psbt::deserialize(&b).ok())
-                .map(|psbt| !psbt.unsigned_tx.input.is_empty())
-                .unwrap_or(false)
-        };
+        // Use the flag set during finalize_round() to know whether there are
+        // on-chain boarding inputs.  The previous approach of checking
+        // `!psbt.unsigned_tx.input.is_empty()` was wrong because the PSBT
+        // always has inputs (e.g. connector inputs) even when there are no
+        // boarding UTXOs, causing BatchFinalized to never be emitted for
+        // VTXO-only refresh rounds.
+        let has_boarding = round.has_boarding_inputs;
 
         round.end_successfully();
 

--- a/crates/dark-core/src/domain/round.rs
+++ b/crates/dark-core/src/domain/round.rs
@@ -150,6 +150,11 @@ pub struct Round {
     pub fail_reason: String,
     /// Confirmation status per intent (intent_id -> status)
     pub confirmation_status: HashMap<String, ConfirmationStatus>,
+    /// Whether the round includes on-chain boarding inputs.
+    /// Set during `finalize_round()` so that `complete_round()` knows
+    /// whether to defer `BatchFinalized` until broadcast.
+    #[serde(default)]
+    pub has_boarding_inputs: bool,
 }
 
 impl Round {
@@ -173,6 +178,7 @@ impl Round {
             sweep_txs: HashMap::new(),
             fail_reason: String::new(),
             confirmation_status: HashMap::new(),
+            has_boarding_inputs: false,
         }
     }
 

--- a/crates/dark-db/src/repos/round_repo.rs
+++ b/crates/dark-db/src/repos/round_repo.rs
@@ -414,6 +414,7 @@ impl RoundRepository for SqliteRoundRepository {
             sweep_txs,
             fail_reason: row.fail_reason,
             confirmation_status: confirmation_status_map,
+            has_boarding_inputs: false, // Not persisted; only needed during live round processing
         };
 
         Ok(Some(round))

--- a/crates/dark-db/src/repos/round_repo_pg.rs
+++ b/crates/dark-db/src/repos/round_repo_pg.rs
@@ -412,6 +412,7 @@ impl RoundRepository for PgRoundRepository {
             sweep_txs,
             fail_reason: row.fail_reason,
             confirmation_status: confirmation_status_map,
+            has_boarding_inputs: false, // Not persisted; only needed during live round processing
         };
 
         Ok(Some(round))


### PR DESCRIPTION
## Problem

`TestBatchSession/refresh_vtxos` in Go e2e hangs for 1 hour and times out.

The second round (VTXO refresh, no boarding inputs) never completes because:

1. `complete_round()` checks `!psbt.unsigned_tx.input.is_empty()` to decide if there are boarding inputs
2. This is **always true** — the PSBT always has inputs (connector inputs etc.) even without boarding UTXOs
3. Server defers `BatchFinalized` waiting for a signed commitment tx broadcast
4. Clients never submit a signed commitment tx (no boarding inputs to sign)
5. **Deadlock**: server waits for clients, clients wait for server

## Fix

Store `has_boarding_inputs` on the `Round` struct during `finalize_round()` when actual boarding inputs are known, and use that flag in `complete_round()` instead of the broken PSBT-based check.

## Changes

- **`domain/round.rs`**: Add `has_boarding_inputs: bool` field with `#[serde(default)]` for backwards compat
- **`application.rs`**: Set flag in `finalize_round()`, use it in `complete_round()`
- **`round_repo.rs`**: Default to `false` when loading from DB (runtime-only field)