### PR TITLE
fix: align tree_nonces proto type with Go SDK

### DIFF
--- a/crates/dark-api/src/grpc/ark_service.rs
+++ b/crates/dark-api/src/grpc/ark_service.rs
@@ -1260,22 +1260,7 @@ impl ArkServiceTrait for ArkGrpcService {
         // tree_nonces is map[txid → nonce_hex] where each value is a hex-encoded 66-byte MuSig2 nonce pair.
         // Go SDK sends one nonce per tree txid. Serialize the full map as JSON for storage.
         // The application layer will deserialize and emit one TreeNoncesEvent per txid.
-        let nonces_map: std::collections::HashMap<String, String> = req
-            .tree_nonces
-            .into_iter()
-            .map(|(txid, nonce_bytes)| {
-                // proto tree_nonces is map<string, bytes> in our proto, map<string, string> in Go proto
-                // Handle both: if it looks like raw bytes, hex-encode; if already hex string, keep as-is
-                let nonce_hex = if nonce_bytes.iter().all(|b| b.is_ascii_hexdigit()) {
-                    String::from_utf8_lossy(&nonce_bytes).to_string()
-                } else {
-                    hex::encode(&nonce_bytes)
-                };
-                (txid, nonce_hex)
-            })
-            .collect();
-
-        let nonces_json = serde_json::to_vec(&nonces_map).unwrap_or_default();
+        let nonces_json = serde_json::to_vec(&req.tree_nonces).unwrap_or_default();
 
         self.core
             .submit_tree_nonces(&req.batch_id, &req.pubkey, nonces_json)

--- a/crates/dark-client/src/batch.rs
+++ b/crates/dark-client/src/batch.rs
@@ -70,10 +70,10 @@ impl SignerState {
         }
     }
 
-    fn tree_nonces_bytes(&self) -> HashMap<String, Vec<u8>> {
+    fn tree_nonces_hex(&self) -> HashMap<String, String> {
         self.pub_nonces
             .iter()
-            .map(|(txid, pn)| (txid.clone(), pn.to_bytes().to_vec()))
+            .map(|(txid, pn)| (txid.clone(), hex::encode(pn.to_bytes())))
             .collect()
     }
 
@@ -263,7 +263,7 @@ pub(crate) async fn run_batch_protocol(
                 cosigner_pubkeys = e.cosigners_pubkeys.clone();
                 vtxo_tree_txids = flat_vtxo_tree.iter().map(|n| n.txid.clone()).collect();
                 signer.generate_nonces(&vtxo_tree_txids);
-                let tree_nonces: HashMap<String, Vec<u8>> = signer.tree_nonces_bytes();
+                let tree_nonces: HashMap<String, String> = signer.tree_nonces_hex();
                 client
                     .submit_tree_nonces(SubmitTreeNoncesRequest {
                         batch_id: e.id.clone(),

--- a/crates/dark-client/src/client.rs
+++ b/crates/dark-client/src/client.rs
@@ -550,7 +550,7 @@ impl ArkClient {
         &mut self,
         batch_id: &str,
         pubkey: &str,
-        tree_nonces: std::collections::HashMap<String, Vec<u8>>,
+        tree_nonces: std::collections::HashMap<String, String>,
     ) -> ClientResult<()> {
         let client = self.require_client()?;
         client

--- a/proto/ark/v1/ark_service.proto
+++ b/proto/ark/v1/ark_service.proto
@@ -396,7 +396,7 @@ message SubmitTreeNoncesRequest {
   // Cosigner public key
   string pubkey = 2;
   // Tree nonces: map from tree position to nonce bytes
-  map<string, bytes> tree_nonces = 3;
+  map<string, string> tree_nonces = 3;
 }
 
 message SubmitTreeNoncesResponse {


### PR DESCRIPTION
## Summary
- Aligns `SubmitTreeNoncesRequest.tree_nonces` proto type with Go SDK (`map<string, string>` instead of `map<string, bytes>`)
- Simplifies server-side nonce handling (no bytes→hex conversion needed since wire format now matches)
- Updates Rust client to send hex-encoded nonces directly

This fixes the Go E2E test timeout caused by proto wire format mismatch in the MuSig2 tree signing protocol.

## Test plan
- [ ] CI passes (Go E2E + Rust E2E)
- [ ] Tree signing protocol completes successfully