### PR TITLE
feat(client): real unilateral exit (unroll) with tree PSBT signing

### DIFF
--- a/crates/dark-client/src/client.rs
+++ b/crates/dark-client/src/client.rs
@@ -848,12 +848,10 @@ fn finalize_tree_psbt(psbt_b64: &str) -> ClientResult<String> {
         .map_err(|e| ClientError::Serialization(format!("Invalid PSBT: {e}")))?;
 
     for (idx, input) in psbt.inputs.iter_mut().enumerate() {
-        if input.tap_key_sig.is_some() {
-            let sig = input.tap_key_sig.unwrap();
+        if let Some(sig) = input.tap_key_sig.take() {
             let mut witness = bitcoin::Witness::new();
             witness.push(sig.to_vec());
             input.final_script_witness = Some(witness);
-            input.tap_key_sig = None;
             input.tap_internal_key = None;
             input.tap_merkle_root = None;
             input.tap_scripts.clear();


### PR DESCRIPTION
## Issue #398

Implements real unilateral exit (unroll) with tree PSBT signing in the Rust client.

### Changes

**`crates/dark-client/src/client.rs`:**
- Updated `unroll(pubkey)` to implement the full unilateral exit flow:
  1. Lists spendable VTXOs via `GetVtxos`
  2. For each VTXO, queries `GetVtxoChain` to get the chain (commitment → tree → leaf)
  3. Walks backwards to find the next offchain tree transaction to broadcast
  4. Fetches pre-signed PSBTs via `GetVirtualTxs`
  5. Finalizes each PSBT (taproot key-path and script-path spends)
  6. Returns raw tx hex strings for broadcasting

- Added `finalize_tree_psbt()` — finalizes pre-signed tree PSBTs by constructing witness data from `tap_key_sig` (key-path) or `tap_scripts`/`tap_script_sigs` (script-path)

- Replaced stub `RedeemBranch` with real implementation that queries the indexer's `GetVtxoChain` RPC

**`tests/e2e_regtest.rs`:**
- Updated `test_unilateral_exit_leaf_vtxo` — settles VTXOs, unrolls, broadcasts, verifies on-chain
- Updated `test_unilateral_exit_preconfirmed_vtxo` — multi-level unroll for preconfirmed VTXOs
- Updated `test_sweep_checkpoint` — unroll + sweep after expiry
- Added `broadcast_tx_hex()` helper for broadcasting via Esplora

**Note:** `unroll()` signature changed to `unroll(pubkey: &str)` — all callers updated.

### Reference
- Go unroll: `vendor/arkd/pkg/client-lib/unroll.go`
- Go redemption: `vendor/arkd/pkg/client-lib/redemption/redeem.go`