### PR TITLE
fix: wire up SqliteSigningSessionStore for MuSig2 tree signing

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -132,6 +132,8 @@ async fn main() -> Result<()> {
     let round_repo = Arc::new(dark_db::SqliteRoundRepository::new(sqlite_pool.clone()));
     let vtxo_repo = Arc::new(dark_db::SqliteVtxoRepository::new(sqlite_pool.clone()));
     let forfeit_repo = Arc::new(dark_db::SqliteForfeitRepository::new(sqlite_pool.clone()));
+    let signing_session_store =
+        Arc::new(dark_db::SqliteSigningSessionStore::new(sqlite_pool.clone()));
 
     // Build the RepositoryIndexer so GetVtxos queries actually work
     let indexer = Arc::new(dark_core::RepositoryIndexer::new(
@@ -335,7 +337,10 @@ async fn main() -> Result<()> {
         .with_notifier(notifier)
         .with_alerts(alerts)
         .with_indexer(indexer as Arc<dyn dark_core::ports::IndexerService>)
-        .with_round_repo(round_repo.clone() as Arc<dyn dark_core::ports::RoundRepository>),
+        .with_round_repo(round_repo.clone() as Arc<dyn dark_core::ports::RoundRepository>)
+        .with_signing_session_store(
+            signing_session_store as Arc<dyn dark_core::ports::SigningSessionStore>,
+        ),
     );
 
     // --- Unlocker ---


### PR DESCRIPTION
## Summary
- Wires up `SqliteSigningSessionStore` in server initialization, replacing the default `NoopSigningSessionStore`
- Enables proper MuSig2 tree signing protocol flow between Rust server and Go SDK clients

## Root Cause
The `NoopSigningSessionStore` was being used because `with_signing_session_store()` was never called. This caused:
1. `all_nonces_collected()` to always return `true` (even with 1 nonce when expecting 2)
2. `get_session()` to return `None`, making `nonces_by_txid` empty
3. No `TreeNoncesForwarded` events emitted
4. Go SDK clients never receiving aggregated nonces
5. Clients never submitting signatures
6. Round signing timeout after 10s

## Test plan
- [ ] CI passes (Go E2E + Rust E2E)
- [ ] Tree signing protocol completes (no more "signing timeout")