### PR TITLE
fix: merge ECDSA partial_sigs in PSBT combination

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -2613,10 +2613,7 @@ impl ArkService {
                             }
                             // Copy ECDSA partial sigs (for segwit v0 inputs)
                             for (key, sig) in &input.partial_sigs {
-                                merged.inputs[i]
-                                    .partial_sigs
-                                    .entry(*key)
-                                    .or_insert(sig.clone());
+                                merged.inputs[i].partial_sigs.entry(*key).or_insert(*sig);
                             }
                             // Copy final_script_witness if already finalized
                             if merged.inputs[i].final_script_witness.is_none() {


### PR DESCRIPTION
## Summary
- Copy `partial_sigs` (ECDSA signatures for segwit v0 inputs) during PSBT merge
- Copy `final_script_witness` and `final_script_sig` for already-finalized inputs
- Check all signature fields when determining if an input is signed
- Add detailed debug logging for PSBT input signature state

The Go E2E test was timing out because the server only checked Taproot signature fields (`tap_key_sig`, `tap_script_sigs`) when merging client PSBTs. If boarding inputs use segwit v0 (P2WPKH/P2WSH), their signatures are in `partial_sigs` instead, causing the server to think inputs were still unsigned.

## Test plan
- [ ] Go E2E tests pass
- [ ] Rust E2E tests pass