### PR TITLE
fix: copy tap_key_origins in PSBT merge for BDK signing

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -2611,9 +2611,23 @@ impl ArkService {
                             if merged.inputs[i].tap_merkle_root.is_none() {
                                 merged.inputs[i].tap_merkle_root = input.tap_merkle_root;
                             }
+                            // Copy tap_key_origins (needed for BDK to recognize inputs it should sign)
+                            for (key, origin) in &input.tap_key_origins {
+                                merged.inputs[i]
+                                    .tap_key_origins
+                                    .entry(*key)
+                                    .or_insert(origin.clone());
+                            }
                             // Copy ECDSA partial sigs (for segwit v0 inputs)
                             for (key, sig) in &input.partial_sigs {
                                 merged.inputs[i].partial_sigs.entry(*key).or_insert(*sig);
+                            }
+                            // Copy bip32_derivation (for BDK to recognize segwit v0 inputs)
+                            for (key, origin) in &input.bip32_derivation {
+                                merged.inputs[i]
+                                    .bip32_derivation
+                                    .entry(*key)
+                                    .or_insert(origin.clone());
                             }
                             // Copy final_script_witness if already finalized
                             if merged.inputs[i].final_script_witness.is_none() {


### PR DESCRIPTION
## Summary
- Copy `tap_key_origins` during PSBT merge (needed for BDK to recognize taproot inputs)
- Copy `bip32_derivation` during PSBT merge (needed for BDK to recognize segwit v0 inputs)

BDK needs these derivation path fields to determine which inputs belong to its wallet.
Without `tap_key_origins`, BDK's re-signing step skips the fee input because it can't
find any keys it owns.

## Test plan
- [ ] Go E2E tests pass
- [ ] Rust E2E tests pass