### PR TITLE
debug: add tap_key_origins to signing debug logs

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -2732,11 +2732,19 @@ impl ArkService {
                     && input.partial_sigs.is_empty()
                     && input.final_script_witness.is_none()
                     && input.final_script_sig.is_none();
+                let internal_key_hex = input
+                    .tap_internal_key
+                    .map(|k| hex::encode(k.serialize()))
+                    .unwrap_or_default();
                 info!(
                     input_idx = i,
                     is_unsigned,
                     tap_key_sig = input.tap_key_sig.is_some(),
                     tap_script_sigs = input.tap_script_sigs.len(),
+                    tap_key_origins = input.tap_key_origins.len(),
+                    tap_scripts = input.tap_scripts.len(),
+                    has_witness_utxo = input.witness_utxo.is_some(),
+                    internal_key = %internal_key_hex,
                     partial_sigs = input.partial_sigs.len(),
                     final_witness = input.final_script_witness.is_some(),
                     "Input signature state (waiting for more)"


### PR DESCRIPTION
## Summary
Add more debug logging to understand why the fee input isn't being signed by BDK:
- Log `tap_key_origins` count for each input
- Log `tap_internal_key` for each input
- Log `tap_scripts` count

This will help diagnose why BDK's re-signing succeeds but doesn't sign input 2.

## Test plan
- Check Go E2E logs for the new debug info