### PR TITLE
feat: implement real asset e2e tests (issue, transfer, burn, reissue)

### DIFF
--- a/tests/e2e_regtest.rs
+++ b/tests/e2e_regtest.rs
@@ -1758,6 +1758,9 @@ async fn test_fee_programs_applied() {
 // ─── TestAsset helpers ───────────────────────────────────────────────────────
 
 /// Filter VTXOs that contain a specific asset ID (mirrors Go `listVtxosWithAsset`).
+///
+/// Returns cloned VTXOs for test convenience. If moved to a shared test utility
+/// crate, consider returning references or indices instead.
 fn filter_vtxos_with_asset(
     vtxos: &[dark_client::types::Vtxo],
     asset_id: &str,
@@ -1879,6 +1882,10 @@ async fn test_asset_transfer_and_renew() {
         "Bob offchain address must not be empty"
     );
 
+    // NOTE: The Go reference passes Assets: [{AssetId, Amount: 1200}] alongside Amount: 400.
+    // The current Rust send_offchain does not accept an assets parameter — the server
+    // attaches assets based on VTXO ownership. When send_offchain gains explicit asset
+    // support, update this call to pass TRANSFER_AMOUNT.
     let send_result = alice
         .send_offchain(&alice_pubkey, bob_offchain, 400, &alice_sk)
         .await


### PR DESCRIPTION
## Summary

Replaces stub asset tests with production-correct implementations that exercise the full asset lifecycle via real gRPC calls.

### Tests implemented

1. **test_asset_transfer_and_renew** — Fund both clients via boarding, issue 5000 asset units, verify VTXO contains asset, transfer offchain to Bob, verify Bob's asset balance, both settle, verify asset survives renewal. (Go ref: `TestAsset/transfer and renew`)

2. **test_asset_issuance_variants** — Fund offchain, test three issuance modes: without control asset (1 asset), with new control (2 assets: control + asset), with existing control asset (reuse prior control). (Go ref: `TestAsset/issuance/*`)

3. **test_asset_burn_and_reissue** — Issue 5000 units with control asset, burn 1500 (verify 3500 remain), reissue 1000 (verify 2 VTXOs, total 4500). (Go ref: `TestAsset/burn` + `TestAsset/reissuance`)

### Helpers added

- `filter_vtxos_with_asset()` — mirrors Go `listVtxosWithAsset`
- `assert_vtxo_has_asset()` — mirrors Go `requireVtxoHasAsset`

### Depends on
- #397 (real settle for creating VTXOs)

Closes #401