### PR TITLE
fix(e2e): use reliable electrs setup in CI

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -67,8 +67,8 @@ jobs:
             --network nigiri \
             -p 5000:30000 \
             -v bitcoind-data:/config \
+            --entrypoint /build/electrs \
             ghcr.io/vulpemventures/electrs:latest \
-            /build/electrs \
             -vvvv \
             --network regtest \
             --daemon-rpc-addr bitcoind:18443 \


### PR DESCRIPTION
## Problem

All Rust e2e tests fail in CI because Esplora (electrs) is not reachable at `http://localhost:5000`. Every test calling `fund_and_settle()` fails with connection errors, and `test_esplora_reachable` logs: `Skipping: Esplora not reachable`.

## Root Cause

1. **`getmeemaw/electrs:latest`** — this image does not exist on Docker Hub
2. **Fallback `ghcr.io/vulpemventures/electrs:latest`** — had wrong port mapping (`5000→3002` instead of `5000→30000`) and no startup args
3. **Only 60s wait** — not enough for electrs to index 101 blocks
4. **`|| true`** silently swallowed all container startup failures

## Fix

- Use `ghcr.io/vulpemventures/electrs:latest` with the correct configuration matching [nigiri's docker-compose](https://github.com/vulpemventures/nigiri/blob/master/cmd/nigiri/resources/docker-compose.yml)
- Correct port mapping: `5000→30000` (the HTTP API port in this image)
- Pass proper args: `--network regtest`, `--daemon-rpc-addr`, `--cookie`, `--http-addr`, `--jsonrpc-import`, etc.
- Share bitcoind data volume so electrs can access blockchain data
- Increase wait to 150s (30 × 5s) with indexing verification (tip height ≥ 101)
- Add proper error checking with container logs on failure
- Remove the silent `|| true` that masked startup failures