### PR TITLE
fix(psbt): merge inputs by outpoint, not by index

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -2612,11 +2612,33 @@ impl ArkService {
         // least one signature. This avoids relying on `current_round` which
         // may have already been replaced by a new round when the scheduler
         // ticks between clients submitting their signed PSBTs.
+        //
+        // IMPORTANT: Match inputs by outpoint, not by index. Go SDK may return
+        // PSBTs with inputs in a different order than the server expects.
         let mut merged = incoming_psbt;
         for (_rid, partial_b64) in partials.iter() {
             if let Ok(bytes) = base64::engine::general_purpose::STANDARD.decode(partial_b64) {
                 if let Ok(partial) = bitcoin::psbt::Psbt::deserialize(&bytes) {
-                    for (i, input) in partial.inputs.iter().enumerate() {
+                    // Build outpoint -> index map for the partial PSBT
+                    let partial_outpoints: std::collections::HashMap<_, _> = partial
+                        .unsigned_tx
+                        .input
+                        .iter()
+                        .enumerate()
+                        .map(|(i, inp)| (inp.previous_output, i))
+                        .collect();
+
+                    for (merged_idx, merged_txin) in merged.unsigned_tx.input.iter().enumerate() {
+                        // Find matching input in partial PSBT by outpoint
+                        let Some(&partial_idx) =
+                            partial_outpoints.get(&merged_txin.previous_output)
+                        else {
+                            continue;
+                        };
+                        let Some(input) = partial.inputs.get(partial_idx) else {
+                            continue;
+                        };
+                        let i = merged_idx;
                         if i < merged.inputs.len() {
                             // Copy witness_utxo (needed for sighash computation)
                             if merged.inputs[i].witness_utxo.is_none() {


### PR DESCRIPTION
## Summary
- Match PSBT inputs by outpoint (txid:vout) instead of array index during merge
- Fixes "Invalid Schnorr signature" broadcast errors caused by input order mismatch

## Root Cause
The PSBT merge loop used index-based matching:
```rust
for (i, input) in partial.inputs.iter().enumerate() {
    if i < merged.inputs.len() {
        merged.inputs[i].tap_key_sig = input.tap_key_sig;
```

If Go SDK returns PSBTs with inputs in different order than server expects, signatures get applied to wrong inputs.

Logs showed signature types swapping between merges:
- First merge: input 0 had `tap_script_sigs=2`, input 1 had `tap_key_sig=true`
- Second merge: input 0 had `tap_key_sig=true`, input 1 had `tap_script_sigs=2`

## Fix
Build outpoint -> index map for partial PSBT, then match inputs by outpoint:
```rust
let partial_outpoints: HashMap<_, _> = partial.unsigned_tx.input
    .iter().enumerate()
    .map(|(i, inp)| (inp.previous_output, i))
    .collect();

for (merged_idx, merged_txin) in merged.unsigned_tx.input.iter().enumerate() {
    let Some(&partial_idx) = partial_outpoints.get(&merged_txin.previous_output);
    let input = &partial.inputs[partial_idx];
    // merge into merged.inputs[merged_idx]
```

## Test plan
- [x] CI builds
- [ ] Go E2E tests pass (boarding input signatures now match correct inputs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)