### PR TITLE
fix(e2e): use printf instead of heredoc to avoid YAML parse error

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -43,34 +43,34 @@ jobs:
 
       - name: Write dark config
         run: |
-          cat > /tmp/dark-e2e.toml <<'EOF'
-[bitcoin]
-network = "regtest"
-rpc_host = "127.0.0.1"
-rpc_port = 18443
-rpc_user = "admin1"
-rpc_password = "123"
-min_confirmations = 1
-
-[wallet]
-network = "regtest"
-esplora_url = "http://localhost:3000"
-database_path = "/tmp/dark-e2e-wallet.db"
-gap_limit = 20
-
-[database]
-backend = "sqlite"
-url = "sqlite:///tmp/dark-e2e.db"
-
-[ark]
-round_duration_secs = 10
-vtxo_expiry_blocks = 144
-connector_timelock_blocks = 12
-min_vtxo_amount_sats = 1000
-max_vtxo_amount_sats = 100000000
-utxo_min_amount = 1000
-utxo_max_amount = 100000000
-EOF
+          printf '%s\n' \
+            '[bitcoin]' \
+            'network = "regtest"' \
+            'rpc_host = "127.0.0.1"' \
+            'rpc_port = 18443' \
+            'rpc_user = "admin1"' \
+            'rpc_password = "123"' \
+            'min_confirmations = 1' \
+            '' \
+            '[wallet]' \
+            'network = "regtest"' \
+            'esplora_url = "http://localhost:3000"' \
+            'database_path = "/tmp/dark-e2e-wallet.db"' \
+            'gap_limit = 20' \
+            '' \
+            '[database]' \
+            'backend = "sqlite"' \
+            'url = "sqlite:///tmp/dark-e2e.db"' \
+            '' \
+            '[ark]' \
+            'round_duration_secs = 10' \
+            'vtxo_expiry_blocks = 144' \
+            'connector_timelock_blocks = 12' \
+            'min_vtxo_amount_sats = 1000' \
+            'max_vtxo_amount_sats = 100000000' \
+            'utxo_min_amount = 1000' \
+            'utxo_max_amount = 100000000' \
+            > /tmp/dark-e2e.toml
 
       - name: Start dark server
         run: |


### PR DESCRIPTION
The unindented TOML `[section]` headers inside the heredoc were being parsed as YAML mappings, causing the workflow to fail instantly with a YAML syntax error.

Use `printf` with quoted strings instead — keeps content inside the run block and avoids the YAML collision entirely.