### PR TITLE
fix(e2e): generate blocks to fund regtest wallet before sendtoaddress

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -171,11 +171,20 @@ jobs:
           sleep 15
           
           # Verify dark wallet balance
+          # REST endpoint returns: { "main_account": { "available": <sats>, "locked": <sats> }, ... }
           echo "Verifying dark wallet balance..."
           for i in $(seq 1 30); do
-            BAL=$(curl -s http://127.0.0.1:7071/v1/admin/wallet/balance \
-              -H "Authorization: Basic $(echo -n 'admin:admin' | base64)" 2>/dev/null \
-              | python3 -c "import json,sys; d=json.load(sys.stdin); print(d.get('confirmed',d.get('total',0)))" 2>/dev/null || echo "0")
+            RESP=$(curl -s http://127.0.0.1:7071/v1/admin/wallet/balance \
+              -H "Authorization: Basic $(echo -n 'admin:admin' | base64)" 2>/dev/null)
+            BAL=$(echo "$RESP" | python3 -c "
+import json,sys
+try:
+    d = json.load(sys.stdin)
+    ma = d.get('main_account', {}) or {}
+    print(ma.get('available', 0) + ma.get('locked', 0))
+except:
+    print(0)
+" 2>/dev/null || echo "0")
             if [ "$BAL" -gt 0 ] 2>/dev/null; then
               echo "✅ dark wallet funded and synced (balance: $BAL sats)"
               break


### PR DESCRIPTION
## Problem

E2E tests fail with `Insufficient funds` error when trying to fund the dark server wallet. The nigiri-github-action does not guarantee that the default Bitcoin Core wallet has mature coins available for spending.

## Root Cause

The workflow was calling `sendtoaddress` to fund the dark server wallet, but the regtest wallet had no spendable coins because:
1. nigiri-github-action may not generate blocks to the default wallet
2. Even if blocks were generated, coinbase outputs need 100 confirmations to mature

## Solution

Add a dedicated step to generate 101 blocks to a new address (100 for coinbase maturity + 1 to confirm), wait for electrs to index, then proceed with funding the dark server wallet.

## Changes

- Add `Fund regtest wallet` step before starting dark server
- Split `Start dark server` and `Fund dark server wallet` into separate steps for better debugging
- Add detailed error reporting when funding fails
- Re-enable push/PR triggers for the workflow

## Testing

This PR will be validated by the E2E workflow itself running on the PR.