### PR TITLE
ci: reduce Go e2e round_duration_secs from 10s to 5s

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -246,7 +246,7 @@ jobs:
           no_tls = true
 
           [ark]
-          round_duration_secs = 10
+          round_duration_secs = 5
           vtxo_expiry_blocks = 144
           connector_timelock_blocks = 12
           min_vtxo_amount_sats = 1000


### PR DESCRIPTION
Halves the round duration for the Go E2E job (10s → 5s), matching what the Rust E2E job already uses. No code changes — the Go client is event-driven and adapts automatically. Expected to cut overall E2E time significantly.