### PR TITLE
chore: update repository URL from arkd-rs to dark

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ edition = "2021"
 authors = ["Lobby <lobby.clawy@gmail.com>", "Andrea Carotti <ac.carotti@gmail.com>"]
 description = "Rust implementation of dark - Ark protocol server for Bitcoin Layer 2 scaling"
 license = "MIT"
-repository = "https://github.com/lobbyclawy/arkd-rs"
+repository = "https://github.com/lobbyclawy/dark"
 
 [features]
 default = []


### PR DESCRIPTION
Closes #470 (partial — cleanup before release)

Fixes the `repository` field in `Cargo.toml` which still pointed to `lobbyclawy/arkd-rs`.