### PR TITLE
ci(e2e): shard Rust e2e 3-way + swap to rust-cache

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,9 +20,13 @@ env:
 
 jobs:
   e2e:
-    name: E2E tests (native Rust)
+    name: E2E tests (native Rust) [shard ${{ matrix.shard }}/3]
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,16 +46,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-e2e-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-e2e-
-            ${{ runner.os }}-cargo-
+          shared-key: e2e-rust
+          cache-on-failure: true
 
       - name: Build dark
         run: cargo build --bin dark
@@ -144,16 +142,24 @@ jobs:
       - name: Install cargo-nextest
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
-      - name: Run Rust e2e tests
+      - name: Run Rust e2e tests (shard ${{ matrix.shard }}/3)
         env:
           INTEGRATION_TEST: "1"
           BITCOIN_RPC_URL: "http://admin1:123@localhost:18443"
           ESPLORA_URL: "http://localhost:3000"
           DARK_GRPC_URL: "http://127.0.0.1:7070"
           DARK_ADMIN_URL: "http://localhost:7071"
-        run: cargo nextest run --test e2e_regtest --run-ignored all --test-threads=1 --no-capture --fail-fast
+        run: >-
+          cargo nextest run
+          --test e2e_regtest
+          --run-ignored all
+          --test-threads=1
+          --no-capture
+          --fail-fast
+          --partition hash:${{ matrix.shard }}/3
 
       - name: Run integration tests
+        if: matrix.shard == 1
         env:
           INTEGRATION_TEST: "1"
           BITCOIN_RPC_URL: "http://admin1:123@localhost:18443"
@@ -206,16 +212,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-go-e2e-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-go-e2e-
-            ${{ runner.os }}-cargo-
+          shared-key: e2e-rust
+          cache-on-failure: true
 
       - name: Build dark
         run: cargo build --bin dark


### PR DESCRIPTION
Phase 1 of #491 — cut the Rust e2e job from ~20m to ~7m.

## What

- Shard the Rust e2e job with `cargo nextest run --partition hash:N/3` across a 3-runner matrix.
- Each shard keeps `--test-threads=1` and spins up its own nigiri + dark server, preserving the serial-within-process assumption the tests rely on.
- Swap the registry-only `actions/cache@v4` for `Swatinem/rust-cache@v2` in both Rust and Go e2e jobs (shared cache key) so `target/` is cached too — cuts the duplicated 2–3m `cargo build --bin dark`.
- `integration` test binary only runs on shard 1 (it's <20s, not worth duplicating).

## Expected impact

| Before | After (est.) |
|---|---|
| Rust: 20m 38s serial | ~7m / shard |
| Build dark: 2–3m (uncached target) | ~30s (warm) / 2–3m (cold) |
| Wall time: ~23m | ~17m (Go job becomes the bottleneck; Phase 2 will tackle it) |

## Risks

- Sharding can expose hidden test coupling masked by serial execution. `fail-fast: false` means we'll see all shard failures; budget a follow-up if flakiness surfaces.
- 3× regtest/docker spin-ups per run — increases port-cleanup pressure.
- ~3× runner minutes per run.

## Not in this PR

- Go e2e sharding (Phase 2 of #491).

## Test plan

- [ ] First run populates rust-cache; compare Rust shard times
- [ ] Second run should show sub-minute `cargo build --bin dark` from cache
- [ ] All 3 Rust shards green + Go e2e still green