### PR TITLE
ci(e2e): shard Go e2e 3-way by measured runtime

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -20,9 +20,13 @@ env:
 
 jobs:
   e2e:
-    name: E2E tests (native Rust)
+    name: E2E tests (native Rust) [shard ${{ matrix.shard }}/3]
     runs-on: ubuntu-latest
     timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3]
 
     steps:
       - uses: actions/checkout@v4
@@ -42,16 +46,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-e2e-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-e2e-
-            ${{ runner.os }}-cargo-
+          shared-key: e2e-rust
+          cache-on-failure: true
 
       - name: Build dark
         run: cargo build --bin dark
@@ -144,16 +142,24 @@ jobs:
       - name: Install cargo-nextest
         run: curl -LsSf https://get.nexte.st/latest/linux | tar zxf - -C ${CARGO_HOME:-~/.cargo}/bin
 
-      - name: Run Rust e2e tests
+      - name: Run Rust e2e tests (shard ${{ matrix.shard }}/3)
         env:
           INTEGRATION_TEST: "1"
           BITCOIN_RPC_URL: "http://admin1:123@localhost:18443"
           ESPLORA_URL: "http://localhost:3000"
           DARK_GRPC_URL: "http://127.0.0.1:7070"
           DARK_ADMIN_URL: "http://localhost:7071"
-        run: cargo nextest run --test e2e_regtest --run-ignored all --test-threads=1 --no-capture --fail-fast
+        run: >-
+          cargo nextest run
+          --test e2e_regtest
+          --run-ignored all
+          --test-threads=1
+          --no-capture
+          --fail-fast
+          --partition hash:${{ matrix.shard }}/3
 
       - name: Run integration tests
+        if: matrix.shard == 1
         env:
           INTEGRATION_TEST: "1"
           BITCOIN_RPC_URL: "http://admin1:123@localhost:18443"
@@ -206,16 +212,10 @@ jobs:
 
       - uses: dtolnay/rust-toolchain@stable
 
-      - uses: actions/cache@v4
+      - uses: Swatinem/rust-cache@v2
         with:
-          path: |
-            ~/.cargo/registry/index
-            ~/.cargo/registry/cache
-            ~/.cargo/git/db
-          key: ${{ runner.os }}-cargo-go-e2e-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ runner.os }}-cargo-go-e2e-
-            ${{ runner.os }}-cargo-
+          shared-key: e2e-rust
+          cache-on-failure: true
 
       - name: Build dark
         run: cargo build --bin dark

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -183,9 +183,24 @@ jobs:
         run: kill $(cat /tmp/dark.pid) 2>/dev/null || true
 
   go-e2e:
-    name: E2E tests (arkd Go)
+    name: E2E tests (arkd Go) [shard ${{ matrix.shard }}/3]
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Shards balanced by runtime measured on run 24590943659.
+          # If tests are added/renamed, the "Verify shard coverage" step will fail the job.
+          - shard: 1
+            # ~372s: TestBan(219) + TestAsset(131) + TestSendToCLTV(12) + TestSendToCond(10)
+            run_pattern: '^(TestBan|TestAsset|TestSendToCLTVMultisigClosure|TestSendToConditionMultisigClosure|TestBatchSettleMultipleClients|TestCollisionBetweenInRoundAndRedeemVtxo)$'
+          - shard: 2
+            # ~350s: TestSweep(205) + TestUnilateralExit(54) + TestCollaborativeExit(51) + TestFee(21) + TestDelegateRefresh(19)
+            run_pattern: '^(TestSweep|TestUnilateralExit|TestCollaborativeExit|TestFee|TestDelegateRefresh)$'
+          - shard: 3
+            # ~378s: TestReactToFraud(143) + TestEventListenerChurn(75) + TestOffchainTx(75) + TestTxListenerChurn(39) + TestBatchSession(30) + TestIntent(16)
+            run_pattern: '^(TestReactToFraud|TestEventListenerChurn|TestOffchainTx|TestTxListenerChurn|TestBatchSession|TestIntent)$'
 
     steps:
       - uses: actions/checkout@v4
@@ -364,12 +379,31 @@ jobs:
           echo "=== Dark server logs (last 30 lines) ==="
           tail -30 /tmp/dark-go-e2e.log || true
 
-      - name: Run arkade-os/arkd Go e2e tests
+      - name: Verify all Go e2e tests are assigned to a shard
+        if: matrix.shard == 1
+        working-directory: vendor/arkd
+        # Fail the job (shard 1 only) if a new test lands without being added
+        # to one of the matrix run_patterns — prevents silent skipping.
+        run: |
+          ALL=$(go test -list '^Test' github.com/arkade-os/arkd/internal/test/e2e 2>/dev/null | grep '^Test' | sort)
+          UNION='^(TestBan|TestAsset|TestSendToCLTVMultisigClosure|TestSendToConditionMultisigClosure|TestBatchSettleMultipleClients|TestCollisionBetweenInRoundAndRedeemVtxo|TestSweep|TestUnilateralExit|TestCollaborativeExit|TestFee|TestDelegateRefresh|TestReactToFraud|TestEventListenerChurn|TestOffchainTx|TestTxListenerChurn|TestBatchSession|TestIntent)$'
+          MISSING=$(echo "$ALL" | grep -Ev "$UNION" || true)
+          if [ -n "$MISSING" ]; then
+            echo "::error::The following Go e2e tests are not assigned to any shard:"
+            echo "$MISSING"
+            echo ""
+            echo "Add them to go-e2e.strategy.matrix.include[*].run_pattern in .github/workflows/e2e.yml"
+            exit 1
+          fi
+          echo "✅ All $(echo "$ALL" | wc -l) Go e2e tests are covered by a shard"
+
+      - name: Run arkade-os/arkd Go e2e tests (shard ${{ matrix.shard }}/3)
         working-directory: vendor/arkd
         # TestSweep/with_arkd_restart requires arkd to run in a Docker
         # container — our harness runs dark as a host process, so we skip it.
         run: |
           go test -v -count 1 -timeout 3600s \
+            -run '${{ matrix.run_pattern }}' \
             -skip 'TestSweep/with_arkd_restart' \
             github.com/arkade-os/arkd/internal/test/e2e
 


### PR DESCRIPTION
Phase 2 of #491. Stacked on top of #494.

## What

- Partition the 17 Go e2e tests across a 3-runner matrix using `go test -run`.
- Shard assignments are balanced using per-test timings from main run [`24590943659`](https://github.com/lobbyclawy/dark/actions/runs/24590943659):

| Shard | Tests | Total runtime |
|---|---|---|
| 1 | TestBan(219s), TestAsset(131s), TestSendToCLTV(12s), TestSendToCond(10s) + 2 skipped | ~372s |
| 2 | TestSweep(205s), TestUnilateralExit(54s), TestCollaborativeExit(51s), TestFee(21s), TestDelegateRefresh(19s) | ~350s |
| 3 | TestReactToFraud(143s), TestEventListenerChurn(75s), TestOffchainTx(75s), TestTxListenerChurn(39s), TestBatchSession(30s), TestIntent(16s) | ~378s |

- Each shard keeps its own nigiri + dark server, preserving the shared-state assumption `TestMain` depends on.
- Reduce `timeout-minutes` 90 → 45.

## Brittleness safeguard

Hard-coded test names mean a new test could land and silently skip across all shards. To prevent this, **shard 1 runs a coverage check** that lists every `Test*` in the package via `go test -list` and fails if any aren't matched by the union of the three `run_pattern`s.

## Expected impact

| Before | After (est.) |
|---|---|
| Go: 17m 03s serial | ~9m / shard (6m test + 3m setup) |
| Wall time (with #494 Rust shards): ~13m | **~10m** ← hits issue target |

## Risks

- Sharding ≠ parallel execution within a shard — tests within a shard still share a dark server, so no test-coupling changes.
- 3× docker + dark setup per Go run; runner minutes cost ~3×.
- If the coverage check ever fires on a legit new test, CI blocks until a human updates the shard assignments. That's the point.

## Test plan

- [ ] All 3 Go shards green
- [ ] Coverage check passes on shard 1
- [ ] Total workflow wall time ≤ 12m (with warm rust-cache)