### PR TITLE
docs(conventions): establish workspace conventions and add poll_until helper (#492)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,6 +111,10 @@ cargo clippy --all-targets --all-features -- -D warnings
 4. **No unsafe code** - Unless absolutely necessary and well-documented
 5. **Tests** - New features should include tests
 
+See [`docs/conventions/`](docs/conventions/README.md) for the binding workspace
+conventions (errors, tracing, repositories, null-objects, async/polling). A
+fuller refresh of this document is tracked under issue #511.
+
 ### Commit Messages
 
 Follow [Conventional Commits](https://www.conventionalcommits.org/):

--- a/docs/conventions/README.md
+++ b/docs/conventions/README.md
@@ -1,0 +1,29 @@
+# Workspace conventions
+
+This directory holds the conventions that every crate in the dark workspace
+follows. They are **binding** — new code is expected to conform, and existing
+code is being migrated crate-by-crate under the M1–M4 refactor milestones.
+
+Each document is short, prescriptive, and contains at least one reference
+example. When a convention is ambiguous or a new case is not covered, file an
+issue linking this directory so the convention can be extended rather than
+silently diverged from.
+
+## Index
+
+- [`errors.md`](errors.md) — when to use `anyhow` vs `thiserror`, canonical
+  error enum shape, `#[from]` and `#[non_exhaustive]` policy.
+- [`tracing.md`](tracing.md) — span naming, required structured fields,
+  level policy.
+- [`repositories.md`](repositories.md) — `Repository` trait shape, method
+  naming, pagination, transaction boundaries.
+- [`null-objects.md`](null-objects.md) — `Noop{Trait}` / `InMemory{Trait}` /
+  `Stub{Trait}` naming and when each is permitted.
+- [`async.md`](async.md) — polling (`poll_until`), cancellation-safety,
+  `spawn_blocking` rules.
+
+## Status
+
+These conventions were introduced by #492 as part of the M0 refactor
+milestone. The per-crate refactors (#495, #496, #497, #498, #499, #500,
+#501, #502, #503, #504) apply them.

--- a/docs/conventions/async.md
+++ b/docs/conventions/async.md
@@ -1,0 +1,116 @@
+# Async & polling
+
+## Rules
+
+1. **No `tokio::time::sleep` in test assertion paths.** Tests that wait
+   for state to appear must use `poll_until` so a transient timing
+   difference on CI doesn't flake the suite.
+2. **No `spawn_blocking` for non-blocking work.** Only wrap work that is
+   genuinely CPU-bound or uses a synchronous blocking API.
+3. **Every long-running task is cancellation-safe.** If shutdown fires
+   mid-`await`, no database row is left half-written, no Redis key
+   half-deleted, no partial message sent.
+4. **`tokio::select!` branches that take cancellation tokens are listed
+   last** so the happy-path branch is visually prominent.
+
+## Polling helper
+
+The canonical helper lives at
+[`tests/support/poll.rs`](../../tests/support/poll.rs) and has this
+signature:
+
+```rust
+pub async fn poll_until<F, Fut>(
+    deadline: Duration,
+    interval: Duration,
+    mut predicate: F,
+) -> Result<(), PollError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{ … }
+```
+
+Use it like:
+
+```rust
+use crate::support::poll::poll_until;
+use std::time::Duration;
+
+poll_until(
+    Duration::from_secs(10),
+    Duration::from_millis(100),
+    || async {
+        std::net::TcpStream::connect(("127.0.0.1", port)).is_ok()
+    },
+)
+.await
+.expect("dark server did not accept connections within 10s");
+```
+
+On timeout, `PollError::Timeout` is returned — callers decide whether
+to `.expect` with a message or propagate.
+
+When the test needs richer diagnostics on timeout (e.g. "what was the
+last observed round state?"), prefer a specialised helper that wraps
+`poll_until` and records observations as it polls.
+
+`poll_until` is currently under `tests/support/` because it is
+test-only. It migrates to `crates/dark-testkit` when #505 lands, at
+which point it becomes the canonical shared harness helper.
+
+## Cancellation safety checklist
+
+When writing a long-running task, ensure each of the following:
+
+- [ ] Every `await` point either completes quickly (< ~100 ms worst
+      case) or is inside a `tokio::select!` with a cancellation branch.
+- [ ] Transactions (DB, Redis) commit or roll back fully inside a single
+      `select!` arm — never split across cancellation points.
+- [ ] Work done with a `Drop` guard assumes the `Drop` may run during
+      unwind (panic or cancellation); the `Drop` is best-effort and
+      idempotent.
+- [ ] The task returns a `Result` from its outermost function, so
+      supervisors can log and restart or shut down cleanly.
+
+## `spawn_blocking` rules
+
+- **Allowed**: synchronous filesystem I/O with no async alternative
+  (`std::fs` inside a hot loop), CPU-bound work (regex over large
+  strings, crypto without an async API).
+- **Not allowed**: network I/O (use tokio IO types), `reqwest::blocking`
+  (use the async client), database clients that have async versions.
+
+If you reach for `spawn_blocking`, leave a one-line comment explaining
+why no async alternative works — reviewers will push back otherwise.
+
+## `tokio::select!` layout
+
+```rust
+loop {
+    tokio::select! {
+        biased;
+        _ = shutdown.cancelled() => break,
+        _ = ticker.tick() => self.tick_once().await?,
+    }
+}
+```
+
+- `biased;` documents that branch order matters (here: shutdown wins
+  ties).
+- The cancellation branch does not call `await` inside the arm — just
+  flips control flow.
+- The work branch propagates its `Result` via `?` so the supervisor
+  sees failures.
+
+## Forbidden patterns
+
+- `tokio::time::sleep(Duration::from_secs(N)).await` inside a test
+  assertion block. (A `sleep` inside *setup* — e.g. waiting 200 ms after
+  spawning a child process before trying to connect — is fine *if* it's
+  followed by a poll-until-ready check that is the actual readiness
+  gate.)
+- `spawn_blocking` wrapping a tokio IO call.
+- `std::thread::sleep` in async code.
+- `futures::executor::block_on` inside async code.
+- `tokio::select!` with no cancellation branch in a supervised task.

--- a/docs/conventions/errors.md
+++ b/docs/conventions/errors.md
@@ -1,0 +1,111 @@
+# Error handling
+
+## Rules
+
+1. **`anyhow::Error` is allowed in exactly three places**:
+   - Test code (`#[cfg(test)]`, `tests/`, `*/tests/*`).
+   - Binary `main` functions and their immediate `run()` wrappers
+     (`src/main.rs`, `dark-signer` bin, `dark-wallet-bin`, `ark-cli`).
+   - Internal glue *inside a single module* where a function is not `pub`
+     and never exposed across crate boundaries.
+2. **Every `pub` function at a crate's public surface returns
+   `Result<T, CrateError>`** where `CrateError` (or a more specific
+   per-module enum) is defined with `thiserror`.
+3. **Errors flow upward unchanged across crate boundaries.** No
+   `.map_err(|e| e.to_string())`. No `anyhow::Context` at the boundary.
+   If an outer crate needs extra context, it adds a variant to its own
+   error enum and `#[from]`-wraps the inner error.
+4. **Do not re-export another crate's error type as your crate's canonical
+   error.** Wrap it via `#[from]` instead.
+
+## Canonical enum shape
+
+```rust
+use thiserror::Error;
+
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum WalletError {
+    #[error("wallet is disabled; construct with a non-noop implementation")]
+    Disabled,
+
+    #[error("insufficient funds: need {needed} sats, have {available} sats")]
+    InsufficientFunds { needed: u64, available: u64 },
+
+    #[error("UTXO {0} is already reserved for a pending round")]
+    UtxoReserved(String),
+
+    #[error("BDK wallet failed")]
+    Bdk(#[from] bdk_wallet::error::Error),
+
+    #[error("database error")]
+    Db(#[from] dark_db::DbError),
+}
+```
+
+### Notes on the example above
+
+- **Use per-variant structured fields** (`{ needed, available }`), not
+  opaque `String`s. Stringly-typed variants (e.g. `DatabaseError(String)`)
+  are a code smell — they preserve no structured information for callers
+  that want to match.
+- **`#[from]` is for wrapping**, never for flattening. If the wrapped
+  error already carries the context the caller needs, `#[from]` is
+  correct. If the caller needs additional context, create a named variant
+  with named fields.
+- **`#[non_exhaustive]`** applies when new variants are likely over the
+  crate's lifetime and you want downstream callers to handle `_ => …`.
+  Do not apply it reflexively.
+- **Display strings are lowercase and sentence-form**, not capitalised or
+  ending in a period. This matches the `anyhow` / `thiserror`
+  convention and reads cleanly when chained via `{:#}`.
+
+## Per-module error enums
+
+For crates with multiple independent domains (e.g. `dark-core` with
+registration, confirmation, finalization), prefer a module-local error
+enum that is `#[from]`-wrapped by the crate-level enum:
+
+```rust
+// crates/dark-core/src/registration/error.rs
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RegistrationError {
+    #[error("intent {0} has expired")]
+    IntentExpired(String),
+    #[error("participant {0} is banned")]
+    ParticipantBanned(String),
+}
+
+// crates/dark-core/src/error.rs
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum DomainError {
+    #[error(transparent)]
+    Registration(#[from] crate::registration::RegistrationError),
+    // …
+}
+```
+
+This lets reviewers reason about a single phase in isolation while the
+top-level enum stays a single dispatch point for transport crates.
+
+## Forbidden patterns
+
+- `.expect("this should never happen")` on input-derived data — every
+  `expect` either documents a proven invariant (e.g. `expect("len is
+  non-zero by construction above")`) or is a bug.
+- `unwrap()` outside tests and proven-invariant paths.
+- `Box<dyn std::error::Error>` at a public surface.
+- `panic!` on untrusted input.
+- Returning `anyhow::Result` from a `pub` function in a library crate.
+- Stringifying an error (`e.to_string()`) and then re-wrapping it in a
+  `String` variant of another enum.
+
+## Migration note
+
+Several existing enums in the workspace (notably `dark_core::ArkError`)
+carry stringly-typed variants like `DatabaseError(String)` and
+`WalletError(String)`. These are a historical artefact and are replaced
+with typed, `#[from]`-wrapped variants as part of the per-crate refactors
+(#495, #496, #497).

--- a/docs/conventions/null-objects.md
+++ b/docs/conventions/null-objects.md
@@ -1,0 +1,96 @@
+# Null objects
+
+Three naming patterns — each with a different meaning. Using the wrong
+name makes the intent of the construction site unclear.
+
+| Name             | Meaning                                                                                               | Allowed in `main`?                 |
+| ---------------- | ----------------------------------------------------------------------------------------------------- | ---------------------------------- |
+| `Noop{Trait}`    | Trait methods are no-ops. Used when the integration is **explicitly opted-out** via config.           | Yes, when config opts out.         |
+| `InMemory{Trait}`| Full behavioural implementation backed by in-memory state. Used in tests and light-mode deployments.  | Yes, in light mode.                |
+| `Stub{Trait}`    | Incomplete / placeholder. Returns a specific error on every non-trivial call.                         | **No after M1 completes** (#497). |
+
+## `Noop{Trait}`
+
+A Noop is the right answer when a feature is optional and an operator
+has chosen to turn it off. Calls succeed silently; nothing is emitted.
+
+```rust
+pub struct NoopAlerts;
+
+#[async_trait]
+impl Alerts for NoopAlerts {
+    async fn publish(&self, _topic: AlertTopic, _payload: Payload) -> Result<(), AlertsError> {
+        Ok(())
+    }
+}
+```
+
+Wired in construction like:
+
+```rust
+let alerts: Arc<dyn Alerts> = if config.alerts.enabled {
+    Arc::new(PrometheusAlertsManager::new(&config.alerts)?)
+} else {
+    Arc::new(NoopAlerts)
+};
+```
+
+## `InMemory{Trait}`
+
+A full implementation used in tests and light-mode deployments where no
+external storage is available.
+
+```rust
+pub struct InMemoryRoundRepository {
+    rounds: tokio::sync::RwLock<HashMap<RoundId, Round>>,
+}
+
+#[async_trait]
+impl RoundRepository for InMemoryRoundRepository {
+    async fn get_round(&self, id: &RoundId) -> Result<Round, RepoError> { … }
+}
+```
+
+`InMemory*` must fully satisfy the trait contract including edge cases
+(`NotFound`, `Conflict`, pagination). A partial `InMemory*` is a `Stub*`
+in disguise — rename accordingly.
+
+## `Stub{Trait}`
+
+Only permitted during active implementation PRs, as a scaffolding that
+compiles while the real implementation lands. Must fail loudly on every
+non-trivial call:
+
+```rust
+pub struct StubSweepService;
+
+#[async_trait]
+impl SweepService for StubSweepService {
+    async fn sweep(&self, _batch: SweepBatch) -> Result<SweepResult, SweepError> {
+        Err(SweepError::NotImplemented("stub wired in, production path pending"))
+    }
+}
+```
+
+**After M1 completes (#497), no `Stub*` type may be constructed in
+`main.rs` or wired through the `App` builder.** A reachable `Stub*` in
+production is a release blocker.
+
+## Construction
+
+- Prefer `impl Default` for Noops (zero state) and some `InMemory*`
+  (clean state) variants.
+- Use an explicit `::new()` constructor when the type carries
+  configuration (seed, capacity).
+- Do not provide a `new()` that takes invented defaults; if a parameter
+  has no sensible default, require it.
+
+## Forbidden patterns
+
+- `StubWallet` or similar constructed unconditionally in `main`. If the
+  wallet is optional, use `NoopWallet` and make the opt-out visible in
+  config.
+- A Noop that logs on every call. Silent no-ops are the point; if you
+  want visibility, use a real implementation backed by `tracing`.
+- An `InMemory*` that silently drops data past a capacity limit without
+  surfacing the drop through an error or a metric.

--- a/docs/conventions/repositories.md
+++ b/docs/conventions/repositories.md
@@ -1,0 +1,104 @@
+# Repository traits
+
+## Rules
+
+1. **Repository traits live with the domain**, not the storage
+   implementation. They are defined in `dark_core::ports` (or a
+   crate-local `ports` module) and implemented in `dark-db`,
+   `dark-live-store`, or in-memory test doubles.
+2. **Trait shape**: `#[async_trait]`, methods take `&self` (interior
+   mutability is the implementation's problem), return
+   `Result<T, RepoError>`.
+3. **No SQL types, no `sqlx::Row`, no `sqlx::Error` in trait
+   surfaces.** The trait speaks in domain types only.
+4. **Method naming** follows CRUDQ prefixes so grepping is cheap:
+
+   | Prefix     | Return                       | Semantics                                      |
+   | ---------- | ---------------------------- | ---------------------------------------------- |
+   | `get_*`    | `Result<T, RepoError>`       | Single row; `NotFound` when absent.            |
+   | `find_*`   | `Result<Option<T>, RepoError>` | Single row or `None`; absence is not an error. |
+   | `insert_*` | `Result<(), RepoError>`      | Fails with `Conflict` on duplicate key.        |
+   | `update_*` | `Result<(), RepoError>`      | Fails with `NotFound` when row is missing.     |
+   | `upsert_*` | `Result<(), RepoError>`      | Insert or update.                              |
+   | `delete_*` | `Result<(), RepoError>`      | Idempotent; absence is not an error.           |
+   | `list_*`   | `Result<Page<T>, RepoError>` | Paginated; see below.                          |
+   | `count_*`  | `Result<u64, RepoError>`     | Count with the same filter as `list_*`.        |
+
+## Pagination
+
+```rust
+pub struct Page<T> {
+    pub items: Vec<T>,
+    pub next_cursor: Option<Cursor>,
+}
+
+#[async_trait]
+impl RoundRepository for SqliteRoundRepository {
+    async fn list_rounds(
+        &self,
+        filter: RoundFilter,
+        cursor: Option<Cursor>,
+        limit: u32,
+    ) -> Result<Page<Round>, RepoError> { … }
+}
+```
+
+- `cursor` is opaque (serialized keyset pointer, not an offset). Offsets
+  drift under concurrent writes; cursors don't.
+- `limit` is bounded at the trait layer, not at the SQL layer. A default
+  max of 1000 is reasonable; enforce with a `debug_assert!` or a clamp.
+- `Page<T>` is always returned — even when there is no next page, callers
+  should not have to distinguish "last page" from "empty result."
+
+## Transaction boundaries
+
+- One `Transaction` / `UnitOfWork` type per repository group.
+- Transactions are started on an explicit `&self` handle, not implicitly
+  via method ordering.
+- **Cross-repository transactions are not expressed through the trait
+  surfaces.** They are expressed at the implementation layer (e.g. a
+  single `sqlx::Transaction` passed to multiple repository adapters
+  inside the same crate). The domain does not reach into transaction
+  handles.
+
+## Error surface
+
+```rust
+#[derive(Debug, thiserror::Error)]
+#[non_exhaustive]
+pub enum RepoError {
+    #[error("{entity} {id} not found")]
+    NotFound { entity: &'static str, id: String },
+
+    #[error("{entity} {id} already exists")]
+    Conflict { entity: &'static str, id: String },
+
+    #[error("transaction aborted")]
+    Aborted,
+
+    #[error("backend error")]
+    Backend(#[source] Box<dyn std::error::Error + Send + Sync>),
+}
+```
+
+`Backend` is the only opaque variant — it exists so sqlx, redis, or any
+other concrete error can be wrapped without the trait surface growing a
+generic `E` parameter.
+
+## Forbidden patterns
+
+- Methods that return `Vec<T>` for a listing without pagination.
+- Methods taking a `sqlx::Pool`, `sqlx::Transaction`, or
+  `redis::Connection` as a parameter at the trait surface.
+- `Ok(())` as a signal for "nothing happened" where `NotFound` would be
+  correct. `delete_*` is the only idempotent variant.
+- Async traits without `#[async_trait]` (only safe with Rust 1.75+ AFIT,
+  but we keep the macro for uniformity until a workspace-wide migration
+  happens).
+
+## Migration note
+
+Per-crate refactor #497 applies these rules across `dark-db`,
+`dark-wallet`, and `dark-live-store`. Existing SQL-leaking methods
+(queries that return `sqlx::Row`, transactions threaded through the
+trait) move to concrete adapters.

--- a/docs/conventions/tracing.md
+++ b/docs/conventions/tracing.md
@@ -1,0 +1,80 @@
+# Tracing & logging
+
+## Rules
+
+1. **Every async function that represents a meaningful unit of work is
+   instrumented** with a `tracing` span. Use `#[tracing::instrument]` on
+   the function, not a manual `span!` inside the body, unless you need
+   conditional span construction.
+2. **Span name = `crate::module::function`** in snake_case. The
+   `#[instrument]` attribute already produces this; do not override the
+   span name unless you have a specific disambiguation reason
+   (e.g. two generic instantiations).
+3. **Structured fields, not string concatenation.** Log events use named
+   fields the log aggregator can index.
+4. **No ad-hoc `println!` / `eprintln!` in library code.** The binary
+   entry points may use them before the subscriber is installed, and
+   only then.
+
+## Required fields
+
+When any of these identifiers is in scope, include them as span fields so
+logs can be pivoted by round / VTXO / intent / request:
+
+| Field        | Type               | When                                                  |
+| ------------ | ------------------ | ----------------------------------------------------- |
+| `round_id`   | `&str` / `Display` | Every function inside a round-lifecycle call path.    |
+| `vtxo_id`    | `&str` / `Display` | Every function operating on a specific VTXO.          |
+| `intent_id`  | `&str` / `Display` | Every function operating on a registered intent.     |
+| `request_id` | `&str`             | Every gRPC/REST handler entry point.                 |
+| `height`     | `u32`              | Every scanner function keyed to a block height.       |
+
+Example:
+
+```rust
+#[tracing::instrument(
+    skip(self, request),
+    fields(round_id = %request.round_id, vtxo_id = %request.vtxo_id),
+)]
+async fn confirm_vtxo(&self, request: ConfirmVtxoRequest) -> Result<(), DomainError> {
+    tracing::debug!(amount = request.amount_sat, "validating confirmation");
+    // …
+    tracing::info!("vtxo confirmed");
+    Ok(())
+}
+```
+
+Use `skip` for non-`Display` arguments; `%` for `Display`; `?` for
+`Debug`. Prefer `%` — `Debug` output is noisy in production logs.
+
+## Level policy
+
+| Level   | Semantic                                                                     |
+| ------- | ---------------------------------------------------------------------------- |
+| `error` | Operator intervention required (failed round, persistent DB error, panic).   |
+| `warn`  | Degraded but functional (retry succeeded after N attempts, fallback engaged).|
+| `info`  | Lifecycle events visible to an operator (round start/end, boot, shutdown). |
+| `debug` | Control-flow detail useful when debugging a specific incident.              |
+| `trace` | Hot-path detail (every tick of a polling loop, every row read).              |
+
+**`error` and `warn` are alert-worthy.** If a line logs at `warn` or
+`error` in healthy production, either the healthy baseline is wrong or
+the log level is. Revisit.
+
+**No duplicate logging.** If a span already carries a field, don't
+re-log it in every event inside the span.
+
+## Forbidden patterns
+
+- `tracing::info!("round {} finished", round_id)` — use a structured
+  field: `tracing::info!(round_id, "round finished")`.
+- `println!` / `eprintln!` in library code.
+- `log::` macros — the workspace standardises on `tracing`.
+- Logging an error's `Debug` output when `Display` is available.
+- Logging at `info` inside a tight loop (use `debug` or `trace`).
+
+## Migration note
+
+Several modules today build log strings via `format!` before calling
+`tracing::info!`. These migrate to structured fields as part of the
+per-crate refactors.

--- a/tests/e2e_regtest.rs
+++ b/tests/e2e_regtest.rs
@@ -27,6 +27,8 @@ use std::path::PathBuf;
 use std::sync::atomic::{AtomicU16, Ordering};
 use std::time::Duration;
 
+mod support;
+
 // ═══════════════════════════════════════════════════════════════════════════════
 // Test Infrastructure
 // ═══════════════════════════════════════════════════════════════════════════════
@@ -785,29 +787,18 @@ impl DarkProcess {
             admin_port,
         };
 
-        // Wait for the gRPC port to become ready (up to 15s).
-        let _grpc_url = proc.grpc_url();
-        let deadline = tokio::time::Instant::now() + Duration::from_secs(15);
-        loop {
-            if tokio::time::Instant::now() > deadline {
-                eprintln!("⚠  dark did not become ready within 15s");
-                break;
-            }
-            let probe = reqwest::Client::builder()
-                .timeout(Duration::from_millis(500))
-                .build()
-                .ok()
-                .and_then(|_c| {
-                    // Try a TCP connect to verify port is open.
-                    None::<reqwest::Response> // placeholder
-                });
-            let _ = probe;
-
-            // Simple TCP probe
-            if std::net::TcpStream::connect(format!("127.0.0.1:{}", grpc_port)).is_ok() {
-                break;
-            }
-            tokio::time::sleep(Duration::from_millis(200)).await;
+        // Wait for the gRPC port to become ready (up to 15s). Worked example
+        // of the polling convention documented in docs/conventions/async.md —
+        // a fixed sleep would flake on a loaded CI runner.
+        if support::poll::poll_until(
+            Duration::from_secs(15),
+            Duration::from_millis(200),
+            || async { std::net::TcpStream::connect(format!("127.0.0.1:{}", grpc_port)).is_ok() },
+        )
+        .await
+        .is_err()
+        {
+            eprintln!("⚠  dark did not become ready within 15s");
         }
 
         Some(proc)

--- a/tests/support/mod.rs
+++ b/tests/support/mod.rs
@@ -1,0 +1,12 @@
+//! Shared test-support helpers.
+//!
+//! This module is included by integration tests via `mod support;`. It is
+//! not compiled as a standalone test binary — Cargo treats subdirectories
+//! containing `mod.rs` as modules rather than test targets.
+//!
+//! When #505 lands (`crates/dark-testkit`), these helpers migrate there and
+//! this module becomes a thin re-export.
+
+#![allow(dead_code)] // individual tests may not use every helper
+
+pub mod poll;

--- a/tests/support/poll.rs
+++ b/tests/support/poll.rs
@@ -1,0 +1,131 @@
+//! Polling helpers for integration tests.
+//!
+//! See [`docs/conventions/async.md`](../../docs/conventions/async.md) for the
+//! rules these helpers implement.
+//!
+//! The canonical helper is [`poll_until`]: call a predicate repeatedly at a
+//! fixed interval until it returns `true` or the deadline elapses. It
+//! replaces fixed `tokio::time::sleep` pauses in tests that are really
+//! waiting for external state to change.
+
+use std::future::Future;
+use std::time::Duration;
+
+use thiserror::Error;
+
+/// Error returned by [`poll_until`] when the deadline elapses before the
+/// predicate returns `true`.
+#[derive(Debug, Error)]
+pub enum PollError {
+    /// The deadline expired before the predicate returned `true`.
+    #[error("polling deadline of {:?} elapsed", .0)]
+    Timeout(Duration),
+}
+
+/// Poll `predicate` every `interval` until it returns `true`, or until
+/// `deadline` elapses.
+///
+/// The first call happens immediately; subsequent calls are spaced by
+/// `interval`. On timeout, returns [`PollError::Timeout`] — callers decide
+/// whether to `.expect()` with a specific diagnostic or propagate.
+///
+/// For richer diagnostics on timeout (e.g. "last observed round state was
+/// X"), prefer writing a specialised helper on top of `poll_until` that
+/// captures observations as it polls.
+///
+/// # Example
+///
+/// ```no_run
+/// # use std::time::Duration;
+/// # async fn example() {
+/// # let port: u16 = 9000;
+/// use crate::support::poll::poll_until;
+///
+/// poll_until(
+///     Duration::from_secs(10),
+///     Duration::from_millis(100),
+///     || async {
+///         std::net::TcpStream::connect(("127.0.0.1", port)).is_ok()
+///     },
+/// )
+/// .await
+/// .expect("server did not accept connections within 10s");
+/// # }
+/// ```
+pub async fn poll_until<F, Fut>(
+    deadline: Duration,
+    interval: Duration,
+    mut predicate: F,
+) -> Result<(), PollError>
+where
+    F: FnMut() -> Fut,
+    Fut: Future<Output = bool>,
+{
+    let start = tokio::time::Instant::now();
+    let deadline_instant = start + deadline;
+    loop {
+        if predicate().await {
+            return Ok(());
+        }
+        if tokio::time::Instant::now() >= deadline_instant {
+            return Err(PollError::Timeout(deadline));
+        }
+        let remaining = deadline_instant.saturating_duration_since(tokio::time::Instant::now());
+        tokio::time::sleep(interval.min(remaining)).await;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::atomic::{AtomicU32, Ordering};
+    use std::sync::Arc;
+
+    #[tokio::test]
+    async fn resolves_on_first_success() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = Arc::clone(&calls);
+        let res = poll_until(
+            Duration::from_secs(1),
+            Duration::from_millis(10),
+            move || {
+                let c = Arc::clone(&c);
+                async move {
+                    c.fetch_add(1, Ordering::SeqCst);
+                    true
+                }
+            },
+        )
+        .await;
+        assert!(res.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 1);
+    }
+
+    #[tokio::test]
+    async fn resolves_after_n_polls() {
+        let calls = Arc::new(AtomicU32::new(0));
+        let c = Arc::clone(&calls);
+        let res = poll_until(
+            Duration::from_secs(5),
+            Duration::from_millis(10),
+            move || {
+                let c = Arc::clone(&c);
+                async move { c.fetch_add(1, Ordering::SeqCst) + 1 >= 3 }
+            },
+        )
+        .await;
+        assert!(res.is_ok());
+        assert_eq!(calls.load(Ordering::SeqCst), 3);
+    }
+
+    #[tokio::test]
+    async fn returns_timeout_when_predicate_never_true() {
+        let res = poll_until(
+            Duration::from_millis(50),
+            Duration::from_millis(10),
+            || async { false },
+        )
+        .await;
+        assert!(matches!(res, Err(PollError::Timeout(_))));
+    }
+}


### PR DESCRIPTION
Closes #492.

## Summary

Introduces the binding workspace conventions that the M1–M4 per-crate refactors will apply. No production code changes; every observable behavior (logs, metrics, gRPC, on-chain output) is identical.

## What's in this PR

- **Five convention docs under `docs/conventions/`**
  - `errors.md` — when to use `anyhow` vs `thiserror`, canonical enum shape, `#[from]` and `#[non_exhaustive]` policy, forbidden patterns.
  - `tracing.md` — span naming (`crate::module::function`), required fields (`round_id`, `vtxo_id`, `intent_id`, `request_id`), level policy.
  - `repositories.md` — trait shape, CRUDQ method naming, pagination (cursor-based), transaction-boundary rules, canonical `RepoError` enum.
  - `null-objects.md` — `Noop{Trait}` / `InMemory{Trait}` / `Stub{Trait}` semantics and lifetime rules.
  - `async.md` — `poll_until` requirement in tests, cancellation-safety checklist, `tokio::select!` layout, `spawn_blocking` rules.
- **`tests/support/poll.rs`** — `poll_until(deadline, interval, predicate)` helper with its own unit tests. Lives under `tests/support/` because it is test-only; migrates to `crates/dark-testkit` when #505 lands.
- **Worked example in `tests/e2e_regtest.rs`** — the TCP-readiness loop (a fixed 200 ms sleep) is converted to a `poll_until` call. Demonstrates the convention in real code.
- **Brief pointer in `CONTRIBUTING.md`** to `docs/conventions/`. Full `CONTRIBUTING.md` refresh is tracked separately under #511.

## What's *not* in this PR

- No changes to any production `pub` function signature.
- No changes to `ArkError` or any other existing error enum. Those migrate under #495, #496, #497.
- No new dependencies.
- No CI workflow changes.

## Test plan

- [ ] `cargo fmt --all -- --check` green (verified locally).
- [ ] `cargo clippy --workspace --all-targets -- -D warnings` green (CI).
- [ ] `cargo test --workspace` green — includes new unit tests in `tests/support/poll.rs` (CI).
- [ ] E2E suites green on CI: `e2e.yml` and `go-e2e.yml`. The `tests/e2e_regtest.rs` edit replaces a fixed sleep with `poll_until`; the timing envelope is identical.
- [ ] No new `TODO` / `FIXME` in the diff.
- [ ] No behavior change observable via logs, metrics, gRPC, or on-chain output.

## Follow-ups referenced by this PR

- #495 — `dark-core` refactor applies the error/tracing conventions to the domain crate.
- #497 — storage refactor applies the repository conventions.
- #505 — `dark-testkit` harness, at which point `tests/support/poll.rs` moves there.
- #511 — full `CONTRIBUTING.md` refresh linking every ADR and convention.