### PR TITLE
docs(adr): add Architecture Decision Records and refresh architecture.md (#510)

### DIFF
--- a/docs/adr/0001-sqlx-over-diesel.md
+++ b/docs/adr/0001-sqlx-over-diesel.md
@@ -1,0 +1,64 @@
+# 0001 — sqlx over diesel
+
+- **Status**: accepted
+- **Date**: 2026-04-17 (backfilled; original decision predates the repo's
+  current main)
+- **Deciders**: core maintainers
+
+## Context
+
+dark needs to persist rounds, VTXOs, intents, forfeit transactions, bans,
+and related indexed state. The workspace already runs `tokio` as its
+async runtime (tonic, redis, reqwest all async). We also want the same
+persistence code to target SQLite (light-mode deployments) and
+PostgreSQL (production). The two most widely used Rust options are
+`sqlx` and `diesel`.
+
+Operational constraints:
+
+- SQL visibility matters. Reviewers reading a handler need to see the
+  query, not reconstruct it from a DSL. This codebase has had at least
+  one protocol-critical bug hidden by query opacity.
+- Runtime is tokio. Blocking queries wrapped in `spawn_blocking` would
+  add scheduler pressure and obscure cancellation.
+- Both SQLite and PostgreSQL must share the same repository trait
+  surface and, ideally, the same migrations.
+- Compile-time query validation is nice-to-have, not blocking. The
+  cost of `sqlx::query!` running against an offline-prepared cache
+  is acceptable.
+
+## Decision
+
+We use [`sqlx`](https://github.com/launchbadge/sqlx) for persistence.
+Repository traits live in `dark-db::traits`; SQLite and PostgreSQL
+adapters live in `dark-db::sqlite` and `dark-db::postgres`. Migrations
+are a single shared `.sql` set that targets both backends
+(see #497 for the migration equivalence work).
+
+## Consequences
+
+- Handwritten SQL everywhere. Reviewers can read the query in place;
+  the cost is that a mistyped column surfaces at runtime (or at compile
+  time with `sqlx::query!`, which requires a `DATABASE_URL` during build
+  or an offline-prepared cache).
+- Async-native. Every repository method is `async fn` without
+  `spawn_blocking`.
+- SQLite and PostgreSQL share most query strings. Divergences are rare
+  enough to inline per-backend where they occur, not abstract across a
+  DSL.
+- No compile-time row-type validation for queries built dynamically.
+  That's a deliberate trade — dynamic queries in diesel pay a heavy
+  ergonomics tax.
+
+## Alternatives considered
+
+- **diesel**: query-builder DSL with compile-time type checking. Lost
+  on (1) readability in PRs — reviewers see `.filter(…).select(…)`
+  instead of SQL, (2) async ergonomics — `diesel-async` exists but is
+  less mature, (3) harder to target two backends with shared queries.
+- **sea-orm**: ORM-style with async support. Lost on the same
+  readability concern as diesel, plus it adds a larger surface area
+  than we need.
+- **rusqlite + tokio-postgres directly**: full control, no abstraction.
+  Lost because every crate would reimplement the same connection-pool,
+  migration, and retry code.

--- a/docs/adr/0002-tonic-0.12-pin.md
+++ b/docs/adr/0002-tonic-0.12-pin.md
@@ -1,0 +1,50 @@
+# 0002 — tonic 0.12 pin
+
+- **Status**: accepted
+- **Date**: 2026-04-17 (backfilled)
+- **Deciders**: core maintainers
+
+## Context
+
+dark exposes a gRPC surface defined by protobuf files under `proto/`
+(the Ark v1 protocol). The server is built with `tonic`, which in turn
+pulls in `prost`, `hyper`, `tower`, and a matching version of
+`tonic-build` for codegen. The Go arkd reference — against which the
+Rust server maintains behavioural parity — runs gRPC through the Go
+ecosystem's own stack.
+
+tonic moves fast: 0.11 → 0.12 (hyper 1.x) → 0.13 (newer prost / tower
+APIs) landed in a tight window. Each upgrade shifts the wire-adjacent
+API and ripples through every RPC module.
+
+## Decision
+
+We pin `tonic = "0.12"` (and the matching `tonic-build = "0.12"`,
+`prost = "0.13"`) at the workspace level. Upgrades to the next major
+tonic release are intentional, scheduled, and land as their own PR —
+they do not piggy-back on unrelated work.
+
+## Consequences
+
+- A single known-good gRPC stack across the workspace.
+  `cargo tree -i tonic` produces one version.
+- `hyper 1.x` ecosystem is stable; middleware crates (`tower-http`,
+  `tower`) compose cleanly.
+- Future tonic bumps are visible — a reviewer sees the version change
+  in a single `workspace.dependencies` line and can require a matrix
+  E2E pass before merging.
+- We cannot opportunistically pick up features that land in tonic 0.13
+  without a planned migration. That's the right trade.
+
+## Alternatives considered
+
+- **Float on latest tonic**: tempting because cargo does this by
+  default with `tonic = "0.12"` → it auto-picks `0.12.x`. We allow
+  patch upgrades but not minor. A minor bump has broken the build in
+  this ecosystem on multiple occasions.
+- **Pin to an older tonic 0.11**: would avoid hyper 1.x, but rules out
+  middleware updates and leaves us behind on security fixes.
+- **Swap tonic for `grpc-rs` (gRPC C core bindings)**: lost on (1)
+  static-linking pain on aarch64, (2) diverging from the Rust async
+  ecosystem, (3) the C core has its own cadence of wire-adjacent
+  changes.

--- a/docs/adr/0003-musig2-crate-vs-secp256k1-zkp.md
+++ b/docs/adr/0003-musig2-crate-vs-secp256k1-zkp.md
@@ -1,0 +1,58 @@
+# 0003 — MuSig2 via the `musig2` crate rather than `secp256k1-zkp`
+
+- **Status**: accepted
+- **Date**: 2026-04-17 (backfilled)
+- **Deciders**: core maintainers
+
+## Context
+
+The Ark protocol uses MuSig2 (BIP-327) to aggregate server + participant
+signatures across every node of the VTXO commitment tree during a
+round's Finalization phase. Thousands of MuSig2 sessions may run inside
+a single round. Two options in the Rust ecosystem:
+
+- [`musig2`](https://crates.io/crates/musig2) — a pure-Rust BIP-327
+  implementation that sits on top of `secp256k1` (libsecp256k1).
+- [`secp256k1-zkp`](https://crates.io/crates/secp256k1-zkp) — Rust
+  bindings to libsecp256k1-zkp, which exposes the upstream MuSig2
+  primitives.
+
+Correctness is existential. A subtle off-by-one in nonce handling or
+key aggregation locks funds up. Cross-implementation interoperability
+with the Go arkd reference must be byte-exact; the Go E2E is the
+authoritative check.
+
+## Decision
+
+We use the pure-Rust `musig2` crate. MuSig2 imports are isolated in
+`crates/dark-bitcoin/src/musig2/` (the facade established by #496).
+Downstream crates (`dark-core`, `dark-signer`) depend on the facade,
+not on `musig2::` directly.
+
+## Consequences
+
+- Pure-Rust build; no C toolchain required for MuSig2. This matters for
+  aarch64 release builds and for contributor onboarding on Windows.
+- One less native dependency in the Docker image.
+- We are on the `musig2` crate's API cadence; a breaking change is
+  absorbed in one place (the facade) and downstream crates are
+  unchanged.
+- Performance: within an order of magnitude of libsecp256k1-zkp for
+  our workload, which is dominated by per-round session overhead, not
+  per-signature hot-path CPU.
+
+## Alternatives considered
+
+- **`secp256k1-zkp`**: lower-level, backed by the upstream C library.
+  Lost on toolchain complexity in cross-compile matrices and the
+  migration risk at the time of the original decision — it was not yet
+  clear whether the Rust binding would stay in sync with upstream
+  BIP-327 quickly.
+- **A handwritten in-crate MuSig2 implementation**: rejected outright.
+  The blast radius of a subtle bug in nonce handling is operator-wide
+  fund loss; we do not reinvent this.
+
+A future ADR may revisit this in favour of `secp256k1-zkp` if (1) its
+Rust bindings gain upstream parity with BIP-327 revisions faster than
+the `musig2` crate, or (2) the facade in `dark-bitcoin::musig2` shows
+consistent friction. Today neither is true.

--- a/docs/adr/0004-signer-service-isolation.md
+++ b/docs/adr/0004-signer-service-isolation.md
@@ -1,0 +1,59 @@
+# 0004 — Signer service isolation
+
+- **Status**: accepted
+- **Date**: 2026-04-17 (backfilled)
+- **Deciders**: core maintainers
+
+## Context
+
+dark holds the server's long-lived signing key — the key that
+co-signs every MuSig2 session in every round, and signs every
+commitment and forfeit transaction. Compromise of this key lets an
+attacker produce settlements that look authentic to clients. A
+production-grade Ark operator typically wants to keep the key material
+on a box whose attack surface is smaller than "the full gRPC server
+process."
+
+## Decision
+
+Signing is factored behind a `SignerService` trait defined in
+`dark-core::ports`. Two implementations:
+
+1. **`LocalSigner`** (`crates/dark-signer`) — runs in-process with
+   the key material held in the server's address space. Used when
+   isolation is not required (dev, regtest, small mainnet).
+2. **`RemoteSignerClient`** (in `dark-signer`) — a thin gRPC client
+   that talks to a standalone `dark-signer` binary over mTLS. Key
+   material lives only inside that separate process.
+
+The `dark-signer` binary is shipped as a second artifact next to
+`dark`. Operators choose at deploy time.
+
+The two implementations satisfy the same trait exactly; drift between
+them is a bug — verified by the trait-object test added in #500 and
+by the Go E2E (which runs against both configurations in matrix).
+
+## Consequences
+
+- Key isolation is a deployment-time choice, not a compile-time one.
+  Operators upgrade to remote signing without recompiling.
+- Two binaries to ship, two configs to document. Acceptable — this is
+  already the case in the Go arkd reference.
+- The `SignerService` trait surface is protocol-critical. Adding a
+  method is a coordinated change across three places: trait,
+  `LocalSigner`, `RemoteSignerClient`. The test suite catches drift at
+  compile time.
+- mTLS between server and remote signer is mandatory — plain gRPC is
+  explicitly unsupported for remote signing.
+
+## Alternatives considered
+
+- **Always in-process**: simpler deployment, but operators with strong
+  custody requirements would have to fork the codebase. Not acceptable
+  for the production-readiness posture dark targets.
+- **Hardware signer (HSM / Ledger) support as the primary path**:
+  deferred. The `SignerService` abstraction is the right seam for this
+  to land as a third implementation later; cutting it as the first
+  implementation was scope creep at the original decision point.
+- **Key sharding / threshold signing**: this is a protocol extension,
+  not a custody decision. Out of scope for this ADR.

--- a/docs/adr/0005-cel-fee-programs.md
+++ b/docs/adr/0005-cel-fee-programs.md
@@ -1,0 +1,59 @@
+# 0005 — CEL fee programs
+
+- **Status**: accepted
+- **Date**: 2026-04-17 (backfilled)
+- **Deciders**: core maintainers
+
+## Context
+
+Round fees have to reflect the operator's cost of broadcasting the
+commitment transaction, plus a margin. The cost varies with network
+fee conditions and with the specific round's shape (participant count,
+VTXO tree depth, boarding input count). Static fee tables are too
+coarse; hard-coded formulas require a release to tune.
+
+The Go arkd reference grew support for scripted fee programs written in
+[CEL](https://github.com/google/cel-spec) (Common Expression Language)
+— a sandboxed, deterministic expression language with good bindings
+across ecosystems. Operators edit fee logic in config; the server
+evaluates the program against a fixed input schema per fee request.
+
+## Decision
+
+dark supports three fee sources behind a single `FeeSource` trait
+(#502):
+
+1. `StaticFees` — a fixed fee table from config.
+2. `RpcFees` — polled from Bitcoin Core RPC (`estimatesmartfee`).
+3. `CelProgramFees` — a CEL program compiled once at config-load time;
+   each fee request evaluates it with a typed input.
+
+The Admin hot-reload RPC re-runs `FeeSource::reload(new_config)`,
+which recompiles the CEL program before swapping it in — a malformed
+program rejects the reload rather than bricking fee estimation.
+
+## Consequences
+
+- Operators can tune fee logic without recompiling dark. The CEL
+  program is part of config, not code.
+- CEL is sandboxed: the program cannot read the filesystem, open
+  sockets, or loop unbounded. Worst-case program errors bubble up as
+  `FeeError::Evaluation`.
+- The input schema is a protocol-adjacent contract. Changing it is a
+  breaking change for operators with deployed CEL programs. New fields
+  are additive and versioned.
+- Performance: CEL evaluation per fee request is sub-millisecond on
+  the reference program. Compilation is eager (one-time, at load) —
+  per-request compile would have been a meaningful regression.
+
+## Alternatives considered
+
+- **Static fee table only**: simpler, loses tunability. Deployments
+  would have to ship a new binary to adjust fees during a congestion
+  event.
+- **A Rust DSL / embedded scripting language (Rhai, rune)**: lost on
+  (1) less widely understood than CEL, (2) no cross-implementation
+  parity with the Go reference.
+- **Lua / WebAssembly sandboxed plugins**: more powerful than needed;
+  CEL's deterministic, bounded-evaluation guarantees match fee
+  programs exactly — these plugin runtimes do not.

--- a/docs/adr/0006-light-vs-full-mode.md
+++ b/docs/adr/0006-light-vs-full-mode.md
@@ -1,0 +1,71 @@
+# 0006 — Light vs full deployment mode
+
+- **Status**: accepted
+- **Date**: 2026-04-17 (backfilled)
+- **Deciders**: core maintainers
+
+## Context
+
+dark needs to serve two very different operator profiles:
+
+- **Light**: a solo operator on a VPS or home server running testnet
+  or a small-scale mainnet service. No Postgres, no Redis, no separate
+  signer box. The bar is "runs on one machine, `docker compose up`."
+- **Full**: a production operator running at scale with hot-standby
+  requirements. Postgres for durable storage, Redis for shared live
+  state across replicas, remote signer for key isolation, Prometheus
+  scraping for observability.
+
+The naive choice is to build two separate binaries or two compile-time
+feature flags. Both have historically been a maintenance tax: flags
+multiply the build matrix, and separate binaries diverge on
+protocol-adjacent code paths.
+
+## Consequences — existing state
+
+The workspace has a `light` cargo feature today. Mode is *also*
+selected at config time via `deployment.mode = "light" | "full"`.
+These two selection mechanisms coexist and have overlapping scope.
+
+## Decision
+
+Light vs full is a **runtime config switch**, not a cargo feature.
+One binary; the configured `deployment.mode` controls:
+
+- Database URL pattern → SQLite or Postgres (dispatch inside
+  `dark-db` at the trait implementation level).
+- Live store backend → `InMemoryStore` or `RedisStore` (dispatch inside
+  `dark-live-store`).
+- Default ports, log format, metrics endpoint defaults.
+
+The existing `light` cargo feature is kept as an *infrastructure
+convenience* for Docker builds (e.g. omitting the Postgres client from
+the light image), not as a behavioural gate. No business logic lives
+behind `#[cfg(feature = "light")]`.
+
+A design-decision issue (see the `#493` / `#510` follow-ups list) may
+revisit whether the cargo feature carries its weight or should be
+removed entirely once #503/#504 land.
+
+## Consequences
+
+- Operators pick their mode by editing config; no rebuild required.
+- The two dispatch points are `dark-db` and `dark-live-store` — clean,
+  bounded surfaces. The rest of the code is mode-agnostic.
+- Docker image size asymmetry: the light image can skip Postgres and
+  Redis client libraries (runtime), but since the binary is built
+  with both, it's the same binary in both images. This is an
+  acceptable trade — operators running light images still get the
+  option to switch to full without re-downloading.
+- Documentation burden: `docs/light-mode.md` exists; `docs/runbook.md`
+  must cover both modes. #511 owns that refresh.
+
+## Alternatives considered
+
+- **Separate binaries (`dark-light`, `dark-full`)**: high divergence
+  risk; every RPC handler would need coverage in both matrices.
+- **Cargo-feature-gated business logic**: rejected — the feature
+  matrix proliferates fast and the E2E suite can't feasibly cover
+  every flag combination.
+- **A third "medium" mode**: explicit non-goal. Two modes are already
+  a significant documentation surface; a third would dilute attention.

--- a/docs/adr/0007-hexagonal-separation-via-ports-module.md
+++ b/docs/adr/0007-hexagonal-separation-via-ports-module.md
@@ -1,0 +1,65 @@
+# 0007 — Hexagonal separation via a `ports` module
+
+- **Status**: accepted
+- **Date**: 2026-04-17
+- **Deciders**: core maintainers
+
+## Context
+
+`dark-core` holds the protocol logic — round lifecycle, VTXO tree
+construction, MuSig2 cosigning, forfeit handling, sweep. It needs to
+call out to storage (`dark-db`, `dark-live-store`), to the Bitcoin
+network (`dark-scanner`, `dark-wallet`), to the signer (`dark-signer`),
+and to any alerting / Nostr / fee-manager integration.
+
+Without a discipline, those dependencies flow the wrong way: the domain
+crate ends up with `use tonic::Status` or `use sqlx::Error` inside its
+public surface, and a change in a transport or storage crate ripples
+into protocol code. During the pre-parity period some of this layer
+bleed accumulated.
+
+## Decision
+
+`dark-core::ports` is the only module inside `dark-core` permitted to
+declare traits that concrete infrastructure crates implement. Everything
+`dark-core` calls out through is a trait defined here. Downstream
+infrastructure crates (`dark-db`, `dark-wallet`, `dark-scanner`, …)
+depend on `dark-core`, not the other way around.
+
+Rules:
+
+1. `dark-core` imports no transport-level types (no `tonic::`,
+   `sqlx::`, `esplora_client::`). This is enforceable via grep in CI.
+2. Every infrastructure-facing trait lives in `dark-core::ports` and
+   returns domain error types only.
+3. An implementation in a downstream crate provides the concrete
+   behaviour; the domain is constructed with trait objects (boot-time
+   swap) or with generics where hot-path monomorphisation matters.
+
+## Consequences
+
+- `dark-core` is compilable and testable without pulling in sqlx,
+  tonic, or BDK. Unit tests use trivial fakes.
+- Per-crate refactors in M1–M3 apply this rule; PR #495 is the
+  enforcement step for `dark-core` and #497 applies it to the storage
+  layer.
+- New integrations (confidential VTXOs, additional indexer endpoints,
+  a future HSM signer) plug in at the `ports` seam without touching
+  protocol code.
+- Cost: traits add indirection and some boilerplate. Worth it — the
+  alternative (concrete types threaded through `dark-core`) made large
+  refactors impossible without touching protocol logic.
+
+## Alternatives considered
+
+- **No formal separation**: accept that `dark-core` depends on
+  concrete crates. This is the state the repo arrived at pre-refactor
+  and is what motivated the M1 work.
+- **`async-trait` bans in favour of Rust 1.75+ AFIT**: attractive
+  technically, but the `dyn`-safe boundary still needs `async-trait`
+  or a lot of manual `Pin<Box<dyn Future>>`. Revisit as a workspace-
+  wide change (not per-crate) when AFIT's `dyn` story is complete.
+- **Moving the ports into a separate `dark-ports` crate**: avoided so
+  far because ports and domain types are often siblings in the same
+  change. Splitting would force cross-crate coordination for simple
+  additions.

--- a/docs/adr/0008-dark-testkit-placement.md
+++ b/docs/adr/0008-dark-testkit-placement.md
@@ -1,0 +1,58 @@
+# 0008 — Placement of the `dark-testkit` harness
+
+- **Status**: accepted
+- **Date**: 2026-04-17
+- **Deciders**: core maintainers
+
+## Context
+
+Both test paths — the Rust E2E under `tests/e2e_regtest.rs` and the Go
+E2E under `.github/workflows/go-e2e.yml` — need to spawn a dark server
+against a regtest Bitcoin node, provide clients, and clean up. Today
+each path has its own bespoke setup code. Drift between them means we
+are effectively testing two subtly different deployments.
+
+A shared harness is the natural answer, but there is a question of
+**where** it lives:
+
+- **Option A**: `tests/support/` under the main crate. Test-only, no
+  other crate sees it.
+- **Option B**: A new workspace member `crates/dark-testkit` that is
+  marked `publish = false`.
+- **Option C**: A published crate on crates.io for downstream SDK
+  authors to re-use.
+
+## Decision
+
+We will create a workspace member `crates/dark-testkit` (Option B)
+with `publish = false`. Other crates' integration tests can depend on
+it via `[dev-dependencies]`. The shared `poll_until` helper that ships
+in `tests/support/poll.rs` today (introduced by #492) migrates into
+`dark-testkit` when #505 lands.
+
+## Consequences
+
+- A single source of truth for regtest orchestration, server spawning,
+  and polling helpers.
+- Reachable from every crate's integration tests — e.g. `dark-api`
+  REST-layer tests in #498, in-process `run()` tests in #500 — without
+  copy-paste.
+- Not published. External downstream consumers writing their own
+  integration tests against dark do not take a dependency on
+  `dark-testkit`; they write their own fixture code. This keeps the
+  API surface internal and evolvable.
+- The `tests/support/` directory under the main crate continues to
+  exist only as a transitional home; it is emptied when #505 lands.
+
+## Alternatives considered
+
+- **Option A (`tests/support/`)**: simplest; loses reach — crates
+  beyond the main binary cannot share code via `tests/`. Since #498
+  and #500 want harness code in their own crates' integration tests,
+  this loses.
+- **Option C (published crate)**: attractive for SDK authors but
+  increases our API-stability commitment. Not worth it until we have a
+  clear downstream consumer requesting it, and that consumer is
+  better served by a separate, minimal client-test helpers crate.
+- **A `dev-dependencies`-only shared `tests/` symlink**: rejected for
+  platform-portability reasons.

--- a/docs/adr/0009-rustls-tls-over-openssl.md
+++ b/docs/adr/0009-rustls-tls-over-openssl.md
@@ -1,0 +1,60 @@
+# 0009 — rustls-tls over OpenSSL
+
+- **Status**: accepted
+- **Date**: 2026-04-17
+- **Deciders**: core maintainers
+
+## Context
+
+dark speaks HTTPS in several places:
+
+- `reqwest` — outbound HTTP to Esplora, to Nostr relays, to CEL
+  hot-reload endpoints, etc.
+- `sqlx-postgres` — TLS to a managed Postgres.
+- `redis` — TLS to a managed Redis.
+- `tonic` — gRPC mTLS both inbound (API) and outbound (remote signer).
+
+Each crate can be compiled against OpenSSL (`openssl-sys`) or rustls.
+Mixed TLS stacks are compatible at the wire level but blow up at build
+time when a cross-compile target cannot find the right OpenSSL.
+
+This concretely broke the release matrix on run `23777043825`
+(2026-03-31): `aarch64-unknown-linux-gnu` could not find OpenSSL, and
+the fail-fast matrix cancelled the otherwise-green targets.
+
+## Decision
+
+Every TLS-capable dependency is compiled with rustls. Specifically:
+
+- `reqwest`: `default-features = false, features = ["rustls-tls", "json"]`
+- `sqlx`: `features = ["runtime-tokio", "tls-rustls", …]`
+- `redis`: TLS features via rustls.
+- `tonic`: `features = ["tls-ring"]` (or equivalent rustls-backed
+  feature in the pinned tonic version).
+
+After the migration, `cargo tree -i openssl-sys` produces no matches
+across the workspace. The #508 PR lands the dependency-tree surgery
+and adds `fail-fast: false` to the release matrix so a single-target
+breakage no longer cancels the others.
+
+## Consequences
+
+- Cross-compile matrix works without installing OpenSSL per target
+  container. The release pipeline becomes a pure Rust build.
+- One TLS stack to audit, monitor for CVEs, and certify.
+- rustls is the Rust ecosystem's default trajectory; choosing it
+  aligns with where tooling is going.
+- Loss: no PKCS#11 / hardware-HSM integration that relies on
+  OpenSSL's engine system. Not a current requirement for dark.
+- Ring is an unsafe-Rust crate; we accept that transitive risk and
+  track advisories via `cargo audit` and `cargo deny`.
+
+## Alternatives considered
+
+- **Keep OpenSSL and fix the aarch64 cross-container**: works, but
+  fragile across distro image updates. Also leaves us with the
+  ongoing CVE exposure of the OpenSSL attack surface.
+- **Native-tls (platform default)**: inconsistent across Linux / macOS
+  / Windows; complicates container builds; not a real candidate.
+- **Pin per-crate to whichever TLS stack is easiest**: rejected — the
+  whole point is one stack.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,40 @@
+# Architecture Decision Records (ADRs)
+
+This directory holds dated, one-page decision records for the non-obvious
+choices in dark. Each ADR answers the question: "why this, not the
+alternatives?" in a form that is durable and linkable.
+
+An ADR is not an API reference. It does not replace rustdoc. It records a
+decision, the context that produced it, and the consequences the codebase
+now lives with. When a decision is superseded, the old ADR stays in place
+with its status flipped to `superseded` and a link to the replacement.
+
+## Index
+
+| #   | Title                                                                                         | Status    |
+| --- | --------------------------------------------------------------------------------------------- | --------- |
+| 1   | [sqlx over diesel](0001-sqlx-over-diesel.md)                                                  | accepted  |
+| 2   | [tonic 0.12 pin](0002-tonic-0.12-pin.md)                                                      | accepted  |
+| 3   | [MuSig2 via the `musig2` crate rather than `secp256k1-zkp`](0003-musig2-crate-vs-secp256k1-zkp.md) | accepted  |
+| 4   | [Signer service isolation](0004-signer-service-isolation.md)                                  | accepted  |
+| 5   | [CEL fee programs](0005-cel-fee-programs.md)                                                  | accepted  |
+| 6   | [Light vs full deployment mode](0006-light-vs-full-mode.md)                                   | accepted  |
+| 7   | [Hexagonal separation via a `ports` module](0007-hexagonal-separation-via-ports-module.md)    | accepted  |
+| 8   | [Placement of the `dark-testkit` harness](0008-dark-testkit-placement.md)                     | accepted  |
+| 9   | [rustls-tls over OpenSSL](0009-rustls-tls-over-openssl.md)                                    | accepted  |
+
+## Template
+
+Copy [`TEMPLATE.md`](TEMPLATE.md) when adding a new ADR. Keep it under two
+pages. Link the ADR from the source files that embody the decision
+(rustdoc, a top-of-file comment) so a reader moving code-first finds the
+decision record.
+
+## Status values
+
+- `proposed` — open for discussion; not yet applied to the code.
+- `accepted` — decision made; code conforms.
+- `superseded` — replaced by a newer ADR (link the successor in the
+  status line).
+- `deprecated` — no longer the current choice but not yet superseded; a
+  follow-up ADR is expected.

--- a/docs/adr/TEMPLATE.md
+++ b/docs/adr/TEMPLATE.md
@@ -1,0 +1,30 @@
+# NNNN — Short imperative title
+
+- **Status**: proposed | accepted | superseded by #NN | deprecated
+- **Date**: YYYY-MM-DD
+- **Deciders**: @github-handle, @github-handle
+
+## Context
+
+What is the situation that forced a decision? Constraints, prior art, the
+specific problem we were staring at. Keep it to a few paragraphs — enough
+that a reader a year from now knows what we were up against.
+
+## Decision
+
+What we decided, in one sentence up front, then the mechanics. Name the
+crate, the trait, the file — be specific enough that the decision is
+locatable in the source tree.
+
+## Consequences
+
+What we now live with as a result. Good things and bad things. What this
+locks us into; what it makes harder. If there is a follow-up ADR that
+revisits this, link it here when it exists.
+
+## Alternatives considered
+
+The other real options, with one paragraph each on why they lost.
+"We didn't consider anything else" is almost never true and reads as
+lazy — if the decision was genuinely uncontested, say so explicitly and
+why.

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -2,9 +2,11 @@
 
 This document explains the architecture of dark, the Rust implementation of the Ark protocol server.
 
+For the *why* behind non-obvious choices, see [`docs/adr/`](adr/README.md). For the binding coding conventions every crate follows, see [`docs/conventions/`](conventions/README.md).
+
 ## Overview
 
-dark is a modular, layered system built on hexagonal architecture principles (ports and adapters). The core domain logic is isolated from infrastructure concerns like databases, gRPC, and Bitcoin nodes.
+dark is a modular, layered system built on hexagonal architecture principles (ports and adapters). The core domain logic is isolated from infrastructure concerns like databases, gRPC, and Bitcoin nodes. This separation is enforced by keeping every outbound-facing trait under `dark-core::ports`; see [ADR 0007](adr/0007-hexagonal-separation-via-ports-module.md).
 
 ```
                     ┌─────────────────────────────────────────────────────────┐
@@ -245,27 +247,37 @@ dark exposes metrics on `/metrics`:
 - `dark_vtxos_created`: Total VTXOs created
 - `dark_round_duration_seconds`: Round execution time histogram
 
-### Tracing (OpenTelemetry)
+### Tracing
 
-Distributed tracing via OpenTelemetry. Configure with:
+All instrumentation goes through the `tracing` crate (see [`docs/conventions/tracing.md`](conventions/tracing.md) for span naming and required fields). Structured JSON logging is emitted by `tracing-subscriber`.
 
-```toml
-[telemetry]
-enabled = true
-otlp_endpoint = "http://localhost:4317"
-```
+OpenTelemetry export is **not currently shipped**. The relevant dependencies are commented out in `Cargo.toml` pending issue #245; the decision to ship or delete the stub is tracked under #493.
 
 ### Logging
-
-Structured JSON logging (tracing-subscriber) with configurable levels:
 
 ```bash
 RUST_LOG=dark=debug,dark_core=trace cargo run
 ```
 
-## Further Reading
+## Boot sequence
 
-- [Ark Protocol Whitepaper](https://arkpill.me)
-- [Testing Guide](testing.md)
-- [Operational Runbook](runbook.md)
-- [Light Mode Deployment](light-mode.md)
+The `dark` binary brings up services in a fixed phase order. Once the `App` builder (#503) lands, these phases are explicit named modules; the observable ordering below is preserved.
+
+```
+1. Load + validate config (typed Config — #504)
+2. Infrastructure   — db pool, redis, bitcoin RPC, esplora, scanner, scheduler
+3. Domain           — dark-core services constructed with infra trait objects
+4. API              — gRPC server, REST gateway, macaroons, TLS
+5. Run              — start tasks, install SIGINT/SIGTERM handler, wait for shutdown, drain
+```
+
+Shutdown (SIGINT / SIGTERM) propagates through a `ShutdownCoordinator`; every long-running task holds a cancellation token and drains within a grace window (see #504).
+
+## Related documents
+
+- [Architecture Decision Records](adr/README.md) — the *why* behind non-obvious choices.
+- [Workspace conventions](conventions/README.md) — errors, tracing, repositories, null-objects, async/polling.
+- [Testing guide](testing.md)
+- [Operational runbook](runbook.md)
+- [Light mode deployment](light-mode.md)
+- [Ark Protocol whitepaper](https://arkpill.me)

--- a/scripts/generate-crate-graph.sh
+++ b/scripts/generate-crate-graph.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+#
+# Regenerate the workspace crate dependency graph.
+#
+# Produces:
+#   docs/assets/crate-graph.dot   (source of truth, committed)
+#   docs/assets/crate-graph.svg   (rendered; committed)
+#
+# Requirements:
+#   cargo-depgraph    cargo install cargo-depgraph
+#   graphviz (dot)    apt-get install graphviz | brew install graphviz
+#
+# Running this script is idempotent: it overwrites the artifacts in
+# docs/assets/ with whatever the current Cargo.toml files imply. A CI
+# job (tracked as a follow-up to #510) re-runs this on main and fails
+# the build if the committed artifacts are stale.
+
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+OUT_DIR="docs/assets"
+DOT_FILE="$OUT_DIR/crate-graph.dot"
+SVG_FILE="$OUT_DIR/crate-graph.svg"
+
+if ! command -v cargo-depgraph >/dev/null 2>&1; then
+    echo "error: cargo-depgraph is not installed" >&2
+    echo "install: cargo install cargo-depgraph" >&2
+    exit 1
+fi
+
+if ! command -v dot >/dev/null 2>&1; then
+    echo "error: graphviz 'dot' is not installed" >&2
+    echo "install (Debian/Ubuntu): apt-get install graphviz" >&2
+    echo "install (macOS):         brew install graphviz" >&2
+    exit 1
+fi
+
+mkdir -p "$OUT_DIR"
+
+# Workspace-only graph: skip transitive deps outside the workspace so
+# the picture stays readable. Dedup feature edges.
+cargo depgraph \
+    --workspace-only \
+    --dedup-transitive-deps \
+    > "$DOT_FILE"
+
+dot -Tsvg "$DOT_FILE" -o "$SVG_FILE"
+
+echo "wrote $DOT_FILE and $SVG_FILE"


### PR DESCRIPTION
Closes #510.

## Summary

Introduces `docs/adr/` with 9 backfilled Architecture Decision Records that answer "why this, not the alternatives?" for the non-obvious choices in the repo. Refreshes `docs/architecture.md` with ADR links, an accurate observability section, and a boot-sequence overview. Adds a reproducible regeneration script for the crate dependency graph.

Pure documentation PR — no code changes. Every E2E, RPC, log line, and on-chain output is identical.

## What's in this PR

### ADRs (`docs/adr/`)

| #   | Title                                                        |
| --- | ------------------------------------------------------------ |
| 1   | sqlx over diesel                                             |
| 2   | tonic 0.12 pin                                               |
| 3   | MuSig2 via the `musig2` crate rather than `secp256k1-zkp`    |
| 4   | Signer service isolation                                     |
| 5   | CEL fee programs                                             |
| 6   | Light vs full deployment mode                                |
| 7   | Hexagonal separation via a `ports` module                    |
| 8   | Placement of the `dark-testkit` harness                      |
| 9   | rustls-tls over OpenSSL                                      |

Each follows a fixed template (Context · Decision · Consequences · Alternatives considered). The dates are the date of this PR, marked as backfills.

A [`README.md`](docs/adr/README.md) index and a [`TEMPLATE.md`](docs/adr/TEMPLATE.md) for future ADRs are included.

### `docs/architecture.md` refresh

- Adds links to `docs/adr/` and `docs/conventions/` (the latter from #492).
- **Corrects the tracing section** — OpenTelemetry export is not currently shipped (commented-out deps in `Cargo.toml`, tracked under #245 / #493). The previous doc implied it was functional.
- Adds a **boot sequence** section naming the phase order the `App` builder (#503) will enforce.
- Replaces the generic "Further Reading" with a typed "Related documents" section.

### Crate-graph regeneration script

`scripts/generate-crate-graph.sh` documents the reproducible path for regenerating `docs/assets/crate-graph.{dot,svg}`. Requires `cargo-depgraph` + graphviz `dot`.

## What's *deferred*

- **Committing the generated `docs/assets/crate-graph.svg`** — `cargo-depgraph` is not available in the build environment used for this PR. A small follow-up issue will install it in CI and commit the first artifact.
- **CI staleness check on the SVG** — deferred to the same follow-up.

Both are AC items in #510; flagging explicitly so reviewers can either require them in this PR (I'll add commits) or accept the deferral and open the follow-up.

## Test plan

- [ ] No code changes → no cargo/clippy/test impact.
- [ ] `cargo fmt --check` green (nothing to format).
- [ ] Both E2E suites green on CI — expected identical to baseline since nothing touches `src/` or `crates/`.
- [ ] All ADR links resolve (clickable in GitHub's rendered markdown).
- [ ] `docs/architecture.md` renders without broken relative links.