### PR TITLE
ci(coverage): add cargo-llvm-cov with per-crate floors (#506)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,10 @@ on:
     branches: [main, develop]
   pull_request:
     branches: [main]
+    types: [opened, synchronize, reopened, labeled]
+  schedule:
+    - cron: "0 4 * * *"  # 4 AM UTC nightly (coverage job)
+  workflow_dispatch:
 
 concurrency:
   group: ci-${{ github.ref }}
@@ -187,3 +191,79 @@ jobs:
         with:
           name: dark
           path: target/release/dark
+
+  coverage:
+    name: Coverage (cargo-llvm-cov)
+    runs-on: ubuntu-latest
+    needs: check
+    timeout-minutes: 45
+    # Coverage is instrumented — compilation roughly doubles vs a plain build,
+    # so we don't run on every PR. Opt-in channels:
+    #   * push to main or develop
+    #   * the nightly schedule
+    #   * a manual workflow_dispatch
+    #   * PRs carrying the `run-coverage` label
+    # See issue #506 for the rationale.
+    if: >
+      github.event_name == 'push' ||
+      github.event_name == 'schedule' ||
+      github.event_name == 'workflow_dispatch' ||
+      (github.event_name == 'pull_request' &&
+       contains(github.event.pull_request.labels.*.name, 'run-coverage'))
+    env:
+      # Report-only while per-crate sub-issues (#506 checkboxes) land.
+      # Flip to "true" once every crate is at or above its declared floor.
+      COVERAGE_ENFORCE: "false"
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust stable + llvm-tools-preview
+        run: |
+          rustup update stable
+          rustup default stable
+          rustup component add llvm-tools-preview
+
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-llvm-cov
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-coverage-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-coverage-
+
+      - name: Generate lcov.info
+        # Instrumented build of the whole workspace + full unit/integration
+        # suite. E2E tests are intentionally excluded — they live in a
+        # separate workflow (e2e.yml) and their coverage is a bonus, not
+        # part of the floor mechanism. See issue #506 ("What must not change").
+        run: cargo llvm-cov --workspace --lcov --output-path lcov.info
+
+      - name: Print summary to log
+        run: cargo llvm-cov report --summary-only
+
+      - name: Enforce per-crate floors
+        run: |
+          args=(lcov.info coverage-thresholds.toml --github-summary)
+          if [ "${COVERAGE_ENFORCE}" = "true" ]; then
+            args+=(--enforce)
+          fi
+          python3 scripts/check-coverage.py "${args[@]}"
+
+      - name: Upload lcov.info as artifact
+        uses: actions/upload-artifact@v4
+        if: always()
+        with:
+          name: lcov
+          path: lcov.info
+          retention-days: 14

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,10 @@ Thumbs.db
 
 # Logs
 *.log
+
+# Coverage (cargo-llvm-cov, see coverage-thresholds.toml)
+lcov.info
+/coverage
+
+# Python bytecode (from scripts/*.py)
+__pycache__/

--- a/Justfile
+++ b/Justfile
@@ -21,9 +21,18 @@ test:
 test-verbose:
     cargo test --all-features --workspace -- --nocapture
 
-# Run test coverage (requires cargo-tarpaulin: cargo install cargo-tarpaulin)
+# Run test coverage (requires cargo-llvm-cov: cargo install cargo-llvm-cov --locked).
+# Generates both an lcov.info (for CI + editor integrations) and an HTML report.
+# See issue #506 / coverage-thresholds.toml for per-crate floors.
 test-coverage:
-    cargo tarpaulin --all-features --workspace --out Html --output-dir coverage
+    cargo llvm-cov --workspace --lcov --output-path lcov.info
+    cargo llvm-cov report --html --output-dir coverage
+
+# Check per-crate coverage floors locally (same script CI runs).
+# Runs the llvm-cov pass first if lcov.info is missing.
+coverage-check:
+    test -f lcov.info || cargo llvm-cov --workspace --lcov --output-path lcov.info
+    python3 scripts/check-coverage.py lcov.info coverage-thresholds.toml
 
 # Run clippy linter
 lint:

--- a/coverage-thresholds.toml
+++ b/coverage-thresholds.toml
@@ -1,0 +1,39 @@
+# Per-crate coverage floors (line coverage, %).
+#
+# This file is the single source of truth for the per-crate coverage floor
+# enforced by the `coverage` CI job. CI runs `cargo llvm-cov` over the
+# workspace and fails if any listed crate drops below its floor.
+#
+# Rules:
+#   * Floors are a ratchet — they may move UP without ceremony but never down
+#     without a linked issue explaining why. See GitHub issue #506.
+#   * A crate listed here that produces no lines (e.g. a re-export-only crate)
+#     is reported as 100% by llvm-cov and is harmless.
+#   * Crates not listed here are ignored by the threshold check (but still
+#     show up in the generated lcov.info uploaded as an artifact).
+#
+# The floors below are the INITIAL targets from issue #506. They are set
+# aspirationally: until the per-crate sub-issues (#506 checkboxes) land,
+# the infrastructure PR runs the coverage job in *report-only* mode — see
+# `.github/workflows/coverage.yml` for how the `enforce` flag is wired.
+#
+# To measure coverage locally:
+#   cargo install cargo-llvm-cov --locked
+#   cargo llvm-cov --workspace --lcov --output-path lcov.info
+#   ./scripts/check-coverage.sh lcov.info coverage-thresholds.toml
+
+[crates]
+dark-core        = 70
+dark-bitcoin     = 70
+dark-db          = 60
+dark-live-store  = 60
+dark-wallet      = 60
+dark-api         = 60
+dark-client      = 60
+"ark-cli"        = 50
+dark-signer      = 60
+dark-wallet-bin  = 50
+dark-scanner     = 60
+dark-scheduler   = 60
+dark-fee-manager = 60
+dark-nostr       = 50

--- a/scripts/check-coverage.py
+++ b/scripts/check-coverage.py
@@ -1,0 +1,202 @@
+#!/usr/bin/env python3
+"""Enforce per-crate coverage floors declared in coverage-thresholds.toml.
+
+Usage:
+    scripts/check-coverage.py LCOV_FILE THRESHOLDS_TOML [--enforce]
+
+Parses an lcov.info file emitted by `cargo llvm-cov --workspace --lcov` and
+computes per-crate line coverage by attributing each `SF:<source_file>` block
+to the crate whose `crates/<crate>/src/` prefix appears in the path. A crate's
+coverage is total lines hit over total instrumented lines across all its
+source files.
+
+Without --enforce, prints a report and exits 0 regardless of floor violations
+(report-only mode, useful while per-crate test-backfill PRs land; see #506).
+With --enforce, exits 1 if any crate listed in the thresholds file falls below
+its declared floor.
+
+The TOML schema is:
+
+    [crates]
+    dark-core    = 70        # integer percent
+    dark-bitcoin = 70.0      # float percent also accepted
+
+Crates listed but absent from the lcov report are treated as 0% (missing
+instrumentation is a failure, not a silent pass). Crates present in lcov but
+not listed in the TOML are ignored by the enforcement check but still shown
+in the report.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import re
+import sys
+from collections import defaultdict
+
+try:
+    import tomllib  # Python 3.11+
+except ModuleNotFoundError:  # pragma: no cover - fallback for older runners
+    import tomli as tomllib  # type: ignore
+
+
+# Matches ".../crates/<name>/..." anywhere in a source file path. Works for
+# both absolute paths (GitHub runners) and relative ones.
+CRATE_RE = re.compile(r"(?:^|/)crates/([^/]+)/")
+
+
+def parse_lcov(path: pathlib.Path) -> dict[str, tuple[int, int]]:
+    """Return {crate_name: (lines_hit, lines_found)} aggregated from lcov."""
+    per_crate: dict[str, list[int]] = defaultdict(lambda: [0, 0])  # [hit, found]
+
+    current_crate: str | None = None
+    with path.open() as fp:
+        for raw_line in fp:
+            line = raw_line.rstrip("\n")
+            if line.startswith("SF:"):
+                source = line[3:]
+                match = CRATE_RE.search(source)
+                current_crate = match.group(1) if match else None
+            elif current_crate is None:
+                continue
+            elif line.startswith("LH:"):
+                per_crate[current_crate][0] += int(line[3:])
+            elif line.startswith("LF:"):
+                per_crate[current_crate][1] += int(line[3:])
+            elif line == "end_of_record":
+                current_crate = None
+
+    return {k: (v[0], v[1]) for k, v in per_crate.items()}
+
+
+def load_thresholds(path: pathlib.Path) -> dict[str, float]:
+    with path.open("rb") as fp:
+        data = tomllib.load(fp)
+    crates = data.get("crates", {})
+    if not isinstance(crates, dict) or not crates:
+        raise SystemExit(f"no [crates] table in {path}")
+    return {name: float(pct) for name, pct in crates.items()}
+
+
+def pct(hit: int, found: int) -> float:
+    if found == 0:
+        return 100.0
+    return 100.0 * hit / found
+
+
+def main(argv: list[str]) -> int:
+    parser = argparse.ArgumentParser(description=__doc__.splitlines()[0])
+    parser.add_argument("lcov", type=pathlib.Path)
+    parser.add_argument("thresholds", type=pathlib.Path)
+    parser.add_argument(
+        "--enforce",
+        action="store_true",
+        help="Exit non-zero when any listed crate is below its floor.",
+    )
+    parser.add_argument(
+        "--github-summary",
+        action="store_true",
+        help=(
+            "Write a markdown table to $GITHUB_STEP_SUMMARY in addition to "
+            "stdout. No-op when the env var is unset."
+        ),
+    )
+    args = parser.parse_args(argv)
+
+    coverage = parse_lcov(args.lcov)
+    thresholds = load_thresholds(args.thresholds)
+
+    # Build the unified report: every crate that is listed OR that appears in
+    # lcov. Listed crates come first so the report has a stable ordering.
+    names: list[str] = list(thresholds.keys())
+    for name in sorted(coverage):
+        if name not in thresholds:
+            names.append(name)
+
+    violations: list[tuple[str, float, float]] = []
+    lines: list[str] = []
+    header = f"{'crate':<22}{'coverage':>12}{'floor':>10}  status"
+    lines.append(header)
+    lines.append("-" * len(header))
+    for name in names:
+        missing = name not in coverage
+        hit, found = coverage.get(name, (0, 0))
+        actual = pct(hit, found)
+        floor = thresholds.get(name)
+        if floor is None:
+            status = "(unlisted)"
+        elif missing:
+            # Crate is listed as mandatory but absent from lcov: treat as 0%.
+            # Otherwise a typo in the toml or a crate accidentally dropped
+            # from the build would silently disable its floor.
+            status = "FAIL"
+            actual = 0.0
+            violations.append((name, actual, floor))
+        elif actual + 1e-9 >= floor:
+            status = "ok"
+        else:
+            status = "FAIL"
+            violations.append((name, actual, floor))
+        floor_s = "—" if floor is None else f"{floor:>6.1f}%"
+        if missing:
+            suffix = "   (no coverage data — crate not in lcov)"
+        elif not found:
+            suffix = "   (no instrumented lines)"
+        else:
+            suffix = ""
+        lines.append(
+            f"{name:<22}{actual:>11.2f}%{floor_s:>10}  {status}{suffix}"
+        )
+
+    report = "\n".join(lines)
+    print(report)
+
+    if args.github_summary:
+        summary_path = os.environ.get("GITHUB_STEP_SUMMARY")
+        if summary_path:
+            md: list[str] = [
+                "## Per-crate coverage",
+                "",
+                "| crate | coverage | floor | status |",
+                "| --- | ---: | ---: | :--- |",
+            ]
+            for name in names:
+                missing = name not in coverage
+                hit, found = coverage.get(name, (0, 0))
+                actual = pct(hit, found)
+                floor = thresholds.get(name)
+                if floor is None:
+                    status = "_unlisted_"
+                elif missing:
+                    status = "**FAIL** (no data)"
+                    actual = 0.0
+                elif actual + 1e-9 >= floor:
+                    status = "ok"
+                else:
+                    status = "**FAIL**"
+                floor_cell = "—" if floor is None else f"{floor:.1f}%"
+                md.append(
+                    f"| `{name}` | {actual:.2f}% | {floor_cell} | {status} |"
+                )
+            with open(summary_path, "a") as fp:
+                fp.write("\n".join(md) + "\n")
+
+    if violations:
+        print("", file=sys.stderr)
+        print(
+            f"{len(violations)} crate(s) below floor:", file=sys.stderr
+        )
+        for name, actual, floor in violations:
+            print(
+                f"  {name}: {actual:.2f}% < {floor:.1f}%", file=sys.stderr
+            )
+        if args.enforce:
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))


### PR DESCRIPTION
## Summary

Lands the coverage infrastructure requested in #506:

- New `coverage` job in `.github/workflows/ci.yml` running `cargo llvm-cov --workspace --lcov`.
- `coverage-thresholds.toml` at repo root as the single source of truth for per-crate floors (values taken verbatim from #506).
- `scripts/check-coverage.py` — parses lcov.info, aggregates per crate by `crates/<name>/` path prefix, and fails CI (in `--enforce` mode) if any listed crate drops below its floor. A listed crate missing from lcov is treated as 0% so a typo or a dropped build can't silently disable a floor.
- `Justfile` swaps `test-coverage` from `cargo-tarpaulin` to `cargo-llvm-cov` (matches the issue's design decision) and adds a `coverage-check` recipe that mirrors CI locally.
- `.gitignore` gains `lcov.info`, `/coverage`, `__pycache__/`.

## Why llvm-cov and not tarpaulin

Per the issue's week-1 design decision: llvm-cov is source-based (more accurate on async-heavy Rust) vs tarpaulin's ptrace approach.

## Gating

Coverage is instrumented so compilation roughly doubles. To avoid doubling CI on every PR, the job runs only on:
- push to `main` / `develop`
- nightly schedule (04:00 UTC)
- `workflow_dispatch`
- PRs carrying the `run-coverage` label (ci.yml listens for the `labeled` pull_request type so adding the label retriggers CI)

## Why this PR ships in report-only mode

`COVERAGE_ENFORCE: "false"` env var on the `coverage` job means the script prints the per-crate table but exits 0 even when crates are below floor. This is deliberate: locally measured coverage today shows 7 crates below their #506 targets, which is exactly what the issue's sub-checkboxes are for. Flipping the env var to `true` is a one-line change for the PR that closes the last sub-issue.

Measured on this branch (`cargo llvm-cov --workspace` locally):

| crate            | current | floor | status |
|------------------|--------:|------:|:-------|
| dark-core        | 56.60%  | 70%   | FAIL (tracked) |
| dark-bitcoin     | 87.01%  | 70%   | ok |
| dark-db          | 84.54%  | 60%   | ok |
| dark-live-store  | 100.00% | 60%   | ok (no instrumented lines — glue crate) |
| dark-wallet      | 52.28%  | 60%   | FAIL (tracked) |
| dark-api         |  0.00%  | 60%   | FAIL (tracked — no unit tests yet) |
| dark-client      |  0.00%  | 60%   | FAIL (tracked — no unit tests yet) |
| ark-cli          |  0.00%  | 50%   | FAIL (tracked — bin-only crate) |
| dark-signer      | 56.20%  | 60%   | FAIL (tracked) |
| dark-wallet-bin  | 52.54%  | 50%   | ok |
| dark-scanner     | 75.95%  | 60%   | ok |
| dark-scheduler   | 42.50%  | 60%   | FAIL (tracked) |
| dark-fee-manager | 70.90%  | 60%   | ok |
| dark-nostr       | 78.78%  | 50%   | ok |

## Validation

- `cargo-llvm-cov 0.8.5` installed locally (`cargo install cargo-llvm-cov --locked`) and `cargo llvm-cov --workspace --lcov --output-path lcov.info` run end-to-end — 2 MB lcov, 45k lines, 130 instrumented source files.
- `scripts/check-coverage.py` exercised against the real lcov plus a synthetic lcov covering the missing-crate path; both modes (with and without `--enforce`) return the expected exit codes.
- `ci.yml` parses under PyYAML; job list: `check, test, clippy, fmt, doc, build, coverage`.
- No Rust touched — `cargo fmt --all -- --check` still green.

## Closes

Closes #506 (infrastructure portion). Sub-issue checkboxes in #506 remain open and will be ticked as per-crate backfill PRs land. The last one to land should also flip `COVERAGE_ENFORCE` to `"true"`.

## Test plan

- [ ] Merge this PR; confirm nightly coverage run produces the report artifact and markdown summary
- [ ] Open a dummy PR with the `run-coverage` label; confirm the `coverage` job fires and the rest of CI is unchanged
- [ ] After a per-crate backfill PR, confirm the per-crate number moves up in the CI summary
- [ ] When all crates are above floor, flip `COVERAGE_ENFORCE: "true"` and confirm CI fails on a synthetic regression