### PR TITLE
test(poll): guard deadline clamp with timing assertion

### DIFF
--- a/tests/support/poll.rs
+++ b/tests/support/poll.rs
@@ -128,4 +128,24 @@ mod tests {
         .await;
         assert!(matches!(res, Err(PollError::Timeout(_))));
     }
+
+    /// Guards the `interval.min(remaining)` clamp on the tail sleep: a
+    /// short deadline must not be exceeded by nearly a full interval.
+    /// If someone simplifies the sleep to just `sleep(interval)`, this
+    /// test fails.
+    #[tokio::test]
+    async fn timeout_respects_deadline_not_interval() {
+        let start = tokio::time::Instant::now();
+        let _ = poll_until(
+            Duration::from_millis(50),
+            Duration::from_millis(500),
+            || async { false },
+        )
+        .await;
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed < Duration::from_millis(200),
+            "poll_until overran deadline: elapsed={elapsed:?}"
+        );
+    }
 }


### PR DESCRIPTION
Tiny follow-up to the review on #513 (merged before my inline reply landed).

The `poll_until` helper (`tests/support/poll.rs`) uses `interval.min(remaining)` on the tail sleep so a short deadline with a long interval still returns `Timeout` within the deadline — not after a full interval. The existing `returns_timeout_when_predicate_never_true` test asserts the error shape but not the timing bound, so a future cleanup could remove the clamp without the test noticing.

This PR adds `timeout_respects_deadline_not_interval`: a 50 ms deadline + 500 ms interval must complete within 200 ms. Removing the clamp breaks the test.

## Test plan

- [ ] `cargo test --test e2e_regtest -- support::poll::tests::timeout_respects_deadline_not_interval` passes locally (CI will verify).
- [ ] Both E2E suites remain green.
- [ ] No behavior change to `poll_until` itself — purely a tightened test.