### PR TITLE
fix(deps): migrate TLS stack to rustls-tls across the workspace (#508)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,8 +64,8 @@ prost = "0.13"
 tonic-build = "0.12"  # For proto compilation
 
 # Database
-sqlx = { version = "0.8", features = ["postgres", "sqlite", "runtime-tokio", "macros"] }
-redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
+sqlx = { version = "0.8", features = ["postgres", "sqlite", "runtime-tokio", "tls-rustls-ring", "macros"] }
+redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager"] }
 
 # Configuration
 config = "0.14"
@@ -105,7 +105,7 @@ hex = "0.4"
 tokio = { version = "1.42", features = ["full"] }
 uuid = { version = "1", features = ["v4"] }
 serde_json = "1.0"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 url = "2"
 
 [[bin]]

--- a/crates/dark-api/Cargo.toml
+++ b/crates/dark-api/Cargo.toml
@@ -45,7 +45,7 @@ sha2 = "0.10"
 bitcoin = { version = "0.32", features = ["serde"] }
 
 # HTTP client (package broadcast)
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 # Internal crates
 dark-core = { path = "../dark-core" }
@@ -58,7 +58,7 @@ profiling = []
 
 [dev-dependencies]
 async-trait = "0.1"
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 serde_json = "1.0"
 tokio = { version = "1.42", features = ["rt-multi-thread", "macros", "net", "time"] }
 tokio-stream = { version = "0.1", features = ["net"] }

--- a/crates/dark-client/Cargo.toml
+++ b/crates/dark-client/Cargo.toml
@@ -24,7 +24,7 @@ sha2 = "0.10"
 rand = "0.8"
 
 # HTTP client for Esplora
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 # Utilities
 base64 = "0.22"

--- a/crates/dark-core/Cargo.toml
+++ b/crates/dark-core/Cargo.toml
@@ -39,7 +39,7 @@ hex = "0.4"
 base64 = "0.22"
 
 # HTTP client (Alertmanager integration)
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 # Metrics
 prometheus = "0.13"

--- a/crates/dark-db/Cargo.toml
+++ b/crates/dark-db/Cargo.toml
@@ -12,10 +12,10 @@ postgres = ["sqlx/postgres"]
 
 [dependencies]
 # Database
-sqlx = { version = "0.8", features = ["runtime-tokio", "macros", "uuid", "chrono"] }
+sqlx = { version = "0.8", features = ["runtime-tokio", "tls-rustls-ring", "macros", "uuid", "chrono"] }
 
 # Cache
-redis = { version = "0.27", features = ["tokio-comp", "connection-manager"] }
+redis = { version = "0.27", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager"] }
 
 # Async runtime
 tokio = { version = "1.42", features = ["sync"] }

--- a/crates/dark-fee-manager/Cargo.toml
+++ b/crates/dark-fee-manager/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 dark-core = { path = "../dark-core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/dark-live-store/Cargo.toml
+++ b/crates/dark-live-store/Cargo.toml
@@ -15,7 +15,7 @@ etcd = ["dep:etcd-client"]
 dark-core = { path = "../dark-core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync"] }
-redis = { version = "0.25", features = ["tokio-comp", "connection-manager"], optional = true }
+redis = { version = "0.25", features = ["tokio-comp", "tokio-rustls-comp", "connection-manager"], optional = true }
 etcd-client = { version = "0.14", optional = true }
 
 [dev-dependencies]

--- a/crates/dark-scanner/Cargo.toml
+++ b/crates/dark-scanner/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 dark-core = { path = "../dark-core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync", "time"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tracing = "0.1"

--- a/crates/dark-scheduler/Cargo.toml
+++ b/crates/dark-scheduler/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 dark-core = { path = "../dark-core" }
 async-trait = "0.1"
 tokio = { version = "1", features = ["sync", "time"] }
-reqwest = { version = "0.11", features = ["json"] }
+reqwest = { version = "0.11", default-features = false, features = ["rustls-tls", "json"] }
 tracing = "0.1"
 thiserror = "1"
 

--- a/crates/dark-wallet/Cargo.toml
+++ b/crates/dark-wallet/Cargo.toml
@@ -9,7 +9,7 @@ license = "MIT"
 # Bitcoin Development Kit (BDK 1.0+)
 # NOTE: Using 1.2 series with matching chain/file_store versions
 bdk_wallet = { version = "1.2", features = ["keys-bip39", "file_store"] }
-bdk_esplora = { version = "0.20", features = ["async-https", "tokio"] }
+bdk_esplora = { version = "0.20", features = ["async-https-rustls", "tokio"] }
 
 # Bitcoin core primitives
 bitcoin = { version = "0.32", features = ["serde", "rand"] }
@@ -31,7 +31,7 @@ base64 = "0.22"
 hex = "0.4"
 
 # HTTP client (for package broadcast)
-reqwest = { version = "0.12", features = ["json"] }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 
 # Logging
 tracing = "0.1"


### PR DESCRIPTION
Partial scope for #508 — the Cargo.toml half. Workflow changes (release.yml \`fail-fast: false\`, Swatinem cache migration in ci.yml, modern release-asset upload) are split into a follow-up because this PR's OAuth token lacks \`workflow\` scope.

## What this PR does

Removes \`openssl-sys\` from the default feature graph by switching every TLS-capable dependency to a rustls-backed feature set. This addresses the root cause of the aarch64-unknown-linux-gnu cross-compile failure observed on release run \`23777043825\` (2026-03-31), where the cross container could not locate OpenSSL.

### Dependency changes

| Crate        | Change                                                                         |
| ------------ | ------------------------------------------------------------------------------ |
| reqwest (x8) | \`default-features = false, features = [\"rustls-tls\", \"json\"]\`                |
| sqlx         | \`features += [\"tls-rustls-ring\"]\`                                            |
| redis        | \`features += [\"tokio-rustls-comp\"]\`                                          |
| bdk_esplora  | \`async-https\` → \`async-https-rustls\`                                         |

No wire-level behavior change — rustls speaks the same TLS as the previous OpenSSL-backed stack. Every outbound HTTPS call (Esplora, Nostr, CEL hot-reload, Bitcoin Core RPC over TLS) continues to work against the same endpoints.

## What's deferred to the workflow follow-up

- \`.github/workflows/release.yml\` — \`fail-fast: false\`, Swatinem/rust-cache per-target key, replacing the deprecated \`actions/upload-release-asset@v1\` with \`gh release upload\`, adding \`contents: write\` permission.
- \`.github/workflows/ci.yml\` — replacing manual \`actions/cache\` blocks with \`Swatinem/rust-cache@v2\`, making the Format job independent of Check, using \`dtolnay/rust-toolchain@stable\` instead of manual \`rustup update\`.

These changes are ready locally and will ship as soon as a token with \`workflow\` scope is used to push them. They are orthogonal to the TLS migration — the migration alone is sufficient to unblock the release matrix once \`fail-fast: false\` is also landed.

## Test plan

- [ ] \`cargo tree -i openssl-sys\` on this branch returns no matches (CI will verify indirectly via the release matrix once the workflow follow-up lands; the TLS migration alone may not completely remove openssl-sys if a transitive \`--all-features\` path still enables it. Confirm with \`cargo tree\` locally.)
- [ ] Both E2E suites green on CI: \`e2e.yml\` (native Rust) + \`e2e.yml\` (Go arkd).
- [ ] \`cargo clippy --workspace --all-targets -- -D warnings\` green.
- [ ] \`cargo fmt --check\` green.
- [ ] No behavior change observable via logs, metrics, gRPC, or on-chain output.

Refs #508.