### PR TITLE
ci(e2e): set fraud reaction delay in Go workflow config

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -271,6 +271,11 @@ jobs:
           utxo_max_amount = 100000000
           unilateral_exit_delay = 30
           boarding_exit_delay = 30
+          # TEST-ENV-ONLY: hold the forfeit tx in the mempool for 5 s before
+          # broadcasting, to keep a just-reacted-to fraud unconfirmed across the
+          # 5 s mempool-propagation window reserved by the upstream Go E2E.
+          # Production deployments leave this unset so fraud response is immediate.
+          fraud_reaction_delay_secs = 5
           EOF
 
       - name: Start dark server


### PR DESCRIPTION
## Summary
- add `fraud_reaction_delay_secs = 5` to the Go e2e config written by `.github/workflows/e2e.yml`
- align the GitHub Actions path with the existing dark e2e config used elsewhere
- keep the fix entirely inside `dark`

## Why
Dark already supports a test-only fraud reaction delay for Go e2e. That setting was already present in other dark test paths, but the GitHub Actions Go workflow was writing its own config without it.

This PR makes the workflow use the same setting, so CI runs the same fraud timing behavior as the rest of dark's e2e setup.

## Scope
- no upstream `arkd` changes
- no vendored `arkd` patch
- workflow/config only
