### PR TITLE
feat(confidential): add Pedersen commitment module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1217,8 +1217,11 @@ name = "dark-confidential"
 version = "0.1.0"
 dependencies = [
  "criterion",
+ "hex",
  "proptest",
  "secp256k1 0.29.1",
+ "serde",
+ "serde_json",
  "thiserror 2.0.18",
 ]
 

--- a/crates/dark-api/src/auth.rs
+++ b/crates/dark-api/src/auth.rs
@@ -397,9 +397,7 @@ mod tests {
     #[test]
     fn test_authenticator_creation() {
         let auth = Authenticator::new(vec![0u8; 32]);
-        // Should not panic
-        assert!(true);
-        let _ = auth;
+        assert!(!auth.is_revoked("any-token"));
     }
 
     #[test]

--- a/crates/dark-api/src/grpc/ark_service.rs
+++ b/crates/dark-api/src/grpc/ark_service.rs
@@ -35,6 +35,7 @@ use crate::proto::ark_v1::{
     GetIntentResponse,
     GetPendingTxRequest,
     GetPendingTxResponse,
+    GetRoundAnnouncementsRequest,
     GetRoundRequest,
     GetRoundResponse,
     GetTransactionsStreamRequest,
@@ -55,6 +56,7 @@ use crate::proto::ark_v1::{
     ReissueAssetResponse,
     RequestExitRequest,
     RequestExitResponse,
+    RoundAnnouncement,
     RoundEvent,
     ScheduledSession,
     SubmitSignedForfeitTxsRequest,
@@ -188,6 +190,10 @@ impl ArkGrpcService {
 type GetEventStreamStream =
     Pin<Box<dyn Stream<Item = Result<RoundEvent, Status>> + Send + 'static>>;
 
+/// Server-streaming response type for GetRoundAnnouncements.
+type GetRoundAnnouncementsStream =
+    Pin<Box<dyn Stream<Item = Result<RoundAnnouncement, Status>> + Send + 'static>>;
+
 /// Server-streaming response type for GetTransactionsStream.
 type GetTransactionsStreamStream =
     Pin<Box<dyn Stream<Item = Result<TransactionEvent, Status>> + Send + 'static>>;
@@ -195,6 +201,7 @@ type GetTransactionsStreamStream =
 #[tonic::async_trait]
 impl ArkServiceTrait for ArkGrpcService {
     type GetEventStreamStream = GetEventStreamStream;
+    type GetRoundAnnouncementsStream = GetRoundAnnouncementsStream;
     type GetTransactionsStreamStream = GetTransactionsStreamStream;
     async fn get_info(
         &self,
@@ -702,6 +709,78 @@ impl ArkServiceTrait for ArkGrpcService {
 
             // Clean up when stream ends
             registry_cleanup.unregister(&stream_id_clone).await;
+        };
+
+        Ok(Response::new(Box::pin(output)))
+    }
+
+    async fn get_round_announcements(
+        &self,
+        request: Request<GetRoundAnnouncementsRequest>,
+    ) -> Result<Response<Self::GetRoundAnnouncementsStream>, Status> {
+        const DEFAULT_LIMIT: u32 = 1_000;
+        const MAX_LIMIT: u32 = 10_000;
+
+        let req = request.into_inner();
+        let limit = match req.limit {
+            0 => DEFAULT_LIMIT,
+            n if n > MAX_LIMIT => MAX_LIMIT,
+            n => n,
+        };
+
+        let cursor = if req.cursor.is_empty() {
+            None
+        } else {
+            let (round_id, vtxo_id) = req.cursor.split_once('\n').ok_or_else(|| {
+                Status::invalid_argument("cursor must be encoded as '<round_id>\\n<vtxo_id>'")
+            })?;
+            if round_id.is_empty() || vtxo_id.is_empty() {
+                return Err(Status::invalid_argument(
+                    "cursor must include both round_id and vtxo_id",
+                ));
+            }
+            Some((round_id, vtxo_id))
+        };
+
+        let round_id_start = if req.round_id_start.is_empty() {
+            None
+        } else {
+            Some(req.round_id_start.as_str())
+        };
+        let round_id_end = if req.round_id_end.is_empty() {
+            None
+        } else {
+            Some(req.round_id_end.as_str())
+        };
+
+        if cursor.is_none() {
+            if round_id_start.is_none() || round_id_end.is_none() {
+                return Err(Status::invalid_argument(
+                    "either cursor or both round_id_start and round_id_end are required",
+                ));
+            }
+            if round_id_start > round_id_end {
+                return Err(Status::invalid_argument(
+                    "round_id_start must be less than or equal to round_id_end",
+                ));
+            }
+        }
+
+        let announcements = self
+            .round_repo
+            .list_round_announcements(round_id_start, round_id_end, cursor, limit)
+            .await
+            .map_err(|e| Status::internal(format!("Failed to fetch round announcements: {e}")))?;
+
+        let output = stream! {
+            for announcement in announcements {
+                yield Ok(RoundAnnouncement {
+                    cursor: format!("{}\n{}", announcement.round_id, announcement.vtxo_id),
+                    round_id: announcement.round_id,
+                    vtxo_id: announcement.vtxo_id,
+                    ephemeral_pubkey: announcement.ephemeral_pubkey,
+                });
+            }
         };
 
         Ok(Response::new(Box::pin(output)))
@@ -3324,7 +3403,6 @@ mod tests {
         // This tests the match arm logic — non-ArkTx events should pass through
         if let Some(TxEventType::Heartbeat(_)) = event.event {
             // Heartbeat — would be forwarded
-            assert!(true);
         } else {
             panic!("Expected heartbeat event");
         }

--- a/crates/dark-api/tests/grpc_integration.rs
+++ b/crates/dark-api/tests/grpc_integration.rs
@@ -14,9 +14,10 @@ use dark_api::proto::ark_v1::ark_service_client::ArkServiceClient;
 use dark_api::proto::ark_v1::ark_service_server::ArkServiceServer;
 use dark_api::proto::ark_v1::{
     DeleteIntentRequest, EstimateIntentFeeRequest, FinalizeTxRequest, GetEventStreamRequest,
-    GetInfoRequest, GetPendingTxRequest, GetRoundRequest, GetStatusRequest,
-    GetTransactionsStreamRequest, GetVtxosRequest, Intent, ListRoundsRequest, Outpoint, Output,
-    RegisterForRoundRequest, RequestExitRequest, SubmitTxRequest, UpdateStreamTopicsRequest,
+    GetInfoRequest, GetPendingTxRequest, GetRoundAnnouncementsRequest, GetRoundRequest,
+    GetStatusRequest, GetTransactionsStreamRequest, GetVtxosRequest, Intent, ListRoundsRequest,
+    Outpoint, Output, RegisterForRoundRequest, RequestExitRequest, SubmitTxRequest,
+    UpdateStreamTopicsRequest,
 };
 
 use dark_api::grpc::admin_service::AdminGrpcService;
@@ -266,7 +267,22 @@ impl dark_core::ports::OffchainTxRepository for MockOffchainTxRepo {
     }
 }
 
-struct MockRoundRepo;
+struct MockRoundRepo {
+    announcements: Vec<dark_core::ports::RoundAnnouncement>,
+}
+
+impl MockRoundRepo {
+    fn empty() -> Self {
+        Self {
+            announcements: Vec::new(),
+        }
+    }
+
+    fn with_announcements(announcements: Vec<dark_core::ports::RoundAnnouncement>) -> Self {
+        Self { announcements }
+    }
+}
+
 #[async_trait]
 impl dark_core::ports::RoundRepository for MockRoundRepo {
     async fn add_or_update_round(&self, _round: &dark_core::domain::Round) -> ArkResult<()> {
@@ -287,6 +303,42 @@ impl dark_core::ports::RoundRepository for MockRoundRepo {
     async fn get_pending_confirmations(&self, _round_id: &str) -> ArkResult<Vec<String>> {
         Ok(Vec::new())
     }
+    async fn list_round_announcements(
+        &self,
+        round_id_start: Option<&str>,
+        round_id_end: Option<&str>,
+        cursor: Option<(&str, &str)>,
+        limit: u32,
+    ) -> ArkResult<Vec<dark_core::ports::RoundAnnouncement>> {
+        let mut announcements = self.announcements.clone();
+        announcements.sort_by(|a, b| {
+            a.round_id
+                .cmp(&b.round_id)
+                .then_with(|| a.vtxo_id.cmp(&b.vtxo_id))
+        });
+
+        let filtered = announcements
+            .into_iter()
+            .filter(|announcement| match (round_id_start, round_id_end) {
+                (Some(start), Some(end)) => {
+                    announcement.round_id.as_str() >= start && announcement.round_id.as_str() <= end
+                }
+                _ => true,
+            })
+            .filter(|announcement| match cursor {
+                Some((round_id, vtxo_id)) => {
+                    (
+                        announcement.round_id.as_str(),
+                        announcement.vtxo_id.as_str(),
+                    ) > (round_id, vtxo_id)
+                }
+                None => true,
+            })
+            .take(limit as usize)
+            .collect();
+
+        Ok(filtered)
+    }
 }
 
 /// Build a test ArkService with mock dependencies.
@@ -304,11 +356,16 @@ fn build_test_core() -> Arc<dark_core::ArkService> {
 
 /// Start a test ArkService gRPC server and return a connected client.
 async fn start_ark_server() -> ArkServiceClient<Channel> {
+    start_ark_server_with_round_repo(Arc::new(MockRoundRepo::empty())).await
+}
+
+async fn start_ark_server_with_round_repo(
+    round_repo: Arc<dyn dark_core::ports::RoundRepository>,
+) -> ArkServiceClient<Channel> {
     let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
     let addr = listener.local_addr().unwrap();
 
     let core = build_test_core();
-    let round_repo: Arc<dyn dark_core::ports::RoundRepository> = Arc::new(MockRoundRepo);
     let broker = Arc::new(dark_api::EventBroker::new(64));
     let tx_broker = Arc::new(dark_api::TransactionEventBroker::new(64));
     let offchain_tx_repo: Arc<dyn dark_core::ports::OffchainTxRepository> =
@@ -825,6 +882,108 @@ async fn test_update_stream_topics_noop() {
         .await;
 
     assert!(response.is_ok(), "update_stream_topics should succeed");
+}
+
+#[tokio::test]
+async fn test_get_round_announcements_range_returns_stable_order() {
+    use tokio_stream::StreamExt;
+
+    let repo = Arc::new(MockRoundRepo::with_announcements(vec![
+        dark_core::ports::RoundAnnouncement {
+            round_id: "round-002".to_string(),
+            vtxo_id: "txb:1".to_string(),
+            ephemeral_pubkey: "02bb".to_string(),
+        },
+        dark_core::ports::RoundAnnouncement {
+            round_id: "round-001".to_string(),
+            vtxo_id: "txa:0".to_string(),
+            ephemeral_pubkey: "02aa".to_string(),
+        },
+        dark_core::ports::RoundAnnouncement {
+            round_id: "round-003".to_string(),
+            vtxo_id: "txc:0".to_string(),
+            ephemeral_pubkey: "02cc".to_string(),
+        },
+    ]));
+    let mut client = start_ark_server_with_round_repo(repo).await;
+
+    let response = client
+        .get_round_announcements(GetRoundAnnouncementsRequest {
+            round_id_start: "round-001".to_string(),
+            round_id_end: "round-002".to_string(),
+            cursor: String::new(),
+            limit: 10,
+        })
+        .await
+        .expect("get_round_announcements should succeed");
+
+    let announcements: Vec<_> = response
+        .into_inner()
+        .collect::<Result<Vec<_>, _>>()
+        .await
+        .expect("stream should be readable");
+
+    assert_eq!(announcements.len(), 2);
+    assert_eq!(announcements[0].round_id, "round-001");
+    assert_eq!(announcements[0].vtxo_id, "txa:0");
+    assert_eq!(announcements[0].cursor, "round-001\ntxa:0");
+    assert_eq!(announcements[1].round_id, "round-002");
+    assert_eq!(announcements[1].vtxo_id, "txb:1");
+}
+
+#[tokio::test]
+async fn test_get_round_announcements_cursor_resumes_exclusively() {
+    use tokio_stream::StreamExt;
+
+    let repo = Arc::new(MockRoundRepo::with_announcements(vec![
+        dark_core::ports::RoundAnnouncement {
+            round_id: "round-001".to_string(),
+            vtxo_id: "txa:0".to_string(),
+            ephemeral_pubkey: "02aa".to_string(),
+        },
+        dark_core::ports::RoundAnnouncement {
+            round_id: "round-001".to_string(),
+            vtxo_id: "txa:1".to_string(),
+            ephemeral_pubkey: "02ab".to_string(),
+        },
+    ]));
+    let mut client = start_ark_server_with_round_repo(repo).await;
+
+    let response = client
+        .get_round_announcements(GetRoundAnnouncementsRequest {
+            round_id_start: String::new(),
+            round_id_end: String::new(),
+            cursor: "round-001\ntxa:0".to_string(),
+            limit: 10,
+        })
+        .await
+        .expect("get_round_announcements should succeed");
+
+    let announcements: Vec<_> = response
+        .into_inner()
+        .collect::<Result<Vec<_>, _>>()
+        .await
+        .expect("stream should be readable");
+
+    assert_eq!(announcements.len(), 1);
+    assert_eq!(announcements[0].vtxo_id, "txa:1");
+}
+
+#[tokio::test]
+async fn test_get_round_announcements_requires_selector() {
+    let mut client = start_ark_server().await;
+
+    let err = client
+        .get_round_announcements(GetRoundAnnouncementsRequest {
+            round_id_start: String::new(),
+            round_id_end: String::new(),
+            cursor: String::new(),
+            limit: 0,
+        })
+        .await
+        .expect_err("missing selector should fail");
+
+    assert_eq!(err.code(), tonic::Code::InvalidArgument);
 }
 
 // ─── EstimateIntentFee Tests ────────────────────────────────────────

--- a/crates/dark-client/src/client.rs
+++ b/crates/dark-client/src/client.rs
@@ -5,19 +5,21 @@ use tokio::sync::mpsc;
 
 use crate::types::{
     Balance, BatchEvent, BatchTxRes, BoardingAddress, LockedAmount, OffchainAddress,
-    OffchainBalance, OnchainBalance, RoundInfo, RoundSummary, ServerInfo, TxEvent, Vtxo,
+    OffchainBalance, OnchainBalance, RoundAnnouncement, RoundInfo, RoundSummary, ServerInfo,
+    TxEvent, Vtxo,
 };
 use dark_api::proto::ark_v1::{
     ark_service_client::ArkServiceClient, get_subscription_response,
     indexer_service_client::IndexerServiceClient, round_event, transaction_event, BurnAssetRequest,
     ConfirmRegistrationRequest, DeleteIntentRequest, FinalizePendingTxsRequest, FinalizeTxRequest,
-    GetEventStreamRequest, GetInfoRequest, GetRoundRequest, GetSubscriptionRequest,
-    GetTransactionsStreamRequest, GetVirtualTxsRequest, GetVtxoChainRequest, GetVtxosRequest,
-    IndexerChainedTxType, IndexerOutpoint, Input as ProtoInput, Intent as ProtoIntent,
-    IssueAssetRequest, ListRoundsRequest, Outpoint as ProtoOutpoint, RedeemNotesRequest,
-    RegisterForRoundRequest, RegisterIntentRequest, ReissueAssetRequest, RequestExitRequest,
-    SubmitSignedForfeitTxsRequest, SubmitTreeNoncesRequest, SubmitTreeSignaturesRequest,
-    SubmitTxRequest, SubscribeForScriptsRequest, UnsubscribeForScriptsRequest,
+    GetEventStreamRequest, GetInfoRequest, GetRoundAnnouncementsRequest, GetRoundRequest,
+    GetSubscriptionRequest, GetTransactionsStreamRequest, GetVirtualTxsRequest,
+    GetVtxoChainRequest, GetVtxosRequest, IndexerChainedTxType, IndexerOutpoint,
+    Input as ProtoInput, Intent as ProtoIntent, IssueAssetRequest, ListRoundsRequest,
+    Outpoint as ProtoOutpoint, RedeemNotesRequest, RegisterForRoundRequest, RegisterIntentRequest,
+    ReissueAssetRequest, RequestExitRequest, SubmitSignedForfeitTxsRequest,
+    SubmitTreeNoncesRequest, SubmitTreeSignaturesRequest, SubmitTxRequest,
+    SubscribeForScriptsRequest, UnsubscribeForScriptsRequest,
 };
 
 /// A boarding UTXO to include as input when registering for a round.
@@ -261,6 +263,44 @@ impl ArkClient {
             failed: round.failed,
             intent_count: round.intent_count,
         })
+    }
+
+    /// Fetch public stealth announcements for a round range or resume cursor.
+    pub async fn get_round_announcements(
+        &mut self,
+        round_id_start: Option<&str>,
+        round_id_end: Option<&str>,
+        cursor: Option<&str>,
+        limit: Option<u32>,
+    ) -> ClientResult<Vec<RoundAnnouncement>> {
+        let client = self.require_client()?;
+
+        let response = client
+            .get_round_announcements(GetRoundAnnouncementsRequest {
+                round_id_start: round_id_start.unwrap_or_default().to_string(),
+                round_id_end: round_id_end.unwrap_or_default().to_string(),
+                cursor: cursor.unwrap_or_default().to_string(),
+                limit: limit.unwrap_or(0),
+            })
+            .await
+            .map_err(|e| ClientError::Rpc(format!("GetRoundAnnouncements failed: {}", e)))?;
+
+        let mut stream = response.into_inner();
+        let mut announcements = Vec::new();
+        while let Some(item) = stream
+            .message()
+            .await
+            .map_err(|e| ClientError::Rpc(format!("GetRoundAnnouncements stream failed: {}", e)))?
+        {
+            announcements.push(RoundAnnouncement {
+                cursor: item.cursor,
+                round_id: item.round_id,
+                vtxo_id: item.vtxo_id,
+                ephemeral_pubkey: item.ephemeral_pubkey,
+            });
+        }
+
+        Ok(announcements)
     }
 
     /// Return the three receive addresses for `pubkey`:

--- a/crates/dark-client/src/lib.rs
+++ b/crates/dark-client/src/lib.rs
@@ -65,5 +65,6 @@ pub use error::{ClientError, ClientResult};
 pub use types::{
     Asset, AssetMetadata, Balance, BatchEvent, BatchTxRes, BoardingAddress, ControlAssetOption,
     ExistingControlAsset, Intent, IssueAssetResult, LockedAmount, NewControlAsset, OffchainAddress,
-    OffchainBalance, OnchainBalance, RoundInfo, RoundSummary, ServerInfo, TxEvent, TxResult, Vtxo,
+    OffchainBalance, OnchainBalance, RoundAnnouncement, RoundInfo, RoundSummary, ServerInfo,
+    TxEvent, TxResult, Vtxo,
 };

--- a/crates/dark-client/src/types.rs
+++ b/crates/dark-client/src/types.rs
@@ -195,6 +195,19 @@ pub struct IssueAssetResult {
     pub issued_assets: Vec<String>,
 }
 
+/// Public stealth announcement metadata returned by `GetRoundAnnouncements`.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+pub struct RoundAnnouncement {
+    /// Resume cursor for the next fetch.
+    pub cursor: String,
+    /// Round identifier that emitted the announcement.
+    pub round_id: String,
+    /// Announced VTXO identifier.
+    pub vtxo_id: String,
+    /// Sender ephemeral public key.
+    pub ephemeral_pubkey: String,
+}
+
 // ── Event stream types ─────────────────────────────────────────────────────
 
 /// Events emitted on the batch lifecycle stream (`GetEventStream`).

--- a/crates/dark-confidential/Cargo.toml
+++ b/crates/dark-confidential/Cargo.toml
@@ -12,11 +12,14 @@ unsafe_code = "forbid"
 
 [dependencies]
 thiserror = "2.0"
-secp256k1 = { version = "0.29", features = ["rand"] }
+secp256k1 = { version = "0.29", features = ["hashes", "rand"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0"
 
 [dev-dependencies]
 proptest = "1.5"
 criterion = { version = "0.5", features = ["html_reports"] }
+hex = "0.4"
 
 [lib]
 name = "dark_confidential"

--- a/crates/dark-confidential/benches/pedersen.rs
+++ b/crates/dark-confidential/benches/pedersen.rs
@@ -1,0 +1,25 @@
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use dark_confidential::commitment::PedersenCommitment;
+use secp256k1::Scalar;
+
+fn scalar(value: u64) -> Scalar {
+    let mut bytes = [0u8; 32];
+    bytes[24..].copy_from_slice(&value.to_be_bytes());
+    Scalar::from_be_bytes(bytes).unwrap()
+}
+
+fn pedersen_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("pedersen_commitment");
+    let left = PedersenCommitment::commit(21, &scalar(1)).unwrap();
+    let right = PedersenCommitment::commit(34, &scalar(2)).unwrap();
+
+    group.bench_function("commit", |b| {
+        b.iter(|| PedersenCommitment::commit(black_box(42), black_box(&scalar(1))).unwrap())
+    });
+    group.bench_function("add", |b| b.iter(|| left.add(black_box(&right)).unwrap()));
+    group.bench_function("serialize", |b| b.iter(|| black_box(left.to_bytes())));
+    group.finish();
+}
+
+criterion_group!(benches, pedersen_benchmark);
+criterion_main!(benches);

--- a/crates/dark-confidential/src/commitment.rs
+++ b/crates/dark-confidential/src/commitment.rs
@@ -1,1 +1,207 @@
-//! commitment primitives for Confidential VTXOs.
+//! Pedersen commitment primitives for Confidential VTXOs.
+//!
+//! Threat model notes:
+//! - Reusing a blinding factor across distinct amounts leaks the difference
+//!   between commitments and weakens confidentiality.
+//! - Commitment serialization is canonical compressed secp256k1 point encoding.
+//! - The alternate generator `H` is deterministically derived from a domain-
+//!   separated hash so no party can bias it after the fact.
+
+use core::ops::{Add, Neg, Sub};
+use secp256k1::{
+    constants::GENERATOR_X,
+    hashes::{sha256, Hash},
+    PublicKey, Scalar, Secp256k1, SecretKey,
+};
+
+use crate::{ConfidentialError, Result};
+
+const PEDERSEN_H_DST: &[u8] = b"dark-confidential/pedersen-h/v1";
+const PEDERSEN_H_COMPRESSED: [u8; 33] = [
+    0x02, 0xa6, 0x3d, 0x22, 0xdd, 0x8d, 0xaf, 0x89, 0x5f, 0xc6, 0x48, 0xa4, 0xdb, 0xaf, 0xc0, 0x2c,
+    0xb0, 0x3f, 0xc6, 0xa7, 0xc9, 0x6d, 0x64, 0x2d, 0x0c, 0xc1, 0x86, 0xae, 0x56, 0x4c, 0x02, 0x1c,
+    0xb4,
+];
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PedersenCommitment(PublicKey);
+
+impl PedersenCommitment {
+    pub fn commit(amount: u64, blinding: &Scalar) -> Result<Self> {
+        let secp = Secp256k1::new();
+        let amount_point = if amount == 0 {
+            None
+        } else {
+            let amount_scalar = scalar_from_u64(amount)?;
+            let amount_secret = secret_key_from_scalar(&amount_scalar)?;
+            Some(PublicKey::from_secret_key(&secp, &amount_secret))
+        };
+        let h_point = pedersen_h();
+        let blinded_h = h_point
+            .mul_tweak(&secp, blinding)
+            .map_err(|_| ConfidentialError::InvalidInput("invalid blinding tweak"))?;
+        let combined = match amount_point {
+            Some(amount_point) => amount_point
+                .combine(&blinded_h)
+                .map_err(|_| ConfidentialError::InvalidInput("invalid commitment sum"))?,
+            None => blinded_h,
+        };
+
+        Ok(Self(combined))
+    }
+
+    pub fn add(&self, other: &Self) -> Result<Self> {
+        self.0
+            .combine(&other.0)
+            .map(Self)
+            .map_err(|_| ConfidentialError::InvalidInput("invalid commitment addition"))
+    }
+
+    pub fn sub(&self, other: &Self) -> Result<Self> {
+        self.add(&other.negate())
+    }
+
+    pub fn negate(&self) -> Self {
+        Self(self.0.negate(&Secp256k1::new()))
+    }
+
+    pub fn to_bytes(&self) -> [u8; 33] {
+        self.0.serialize()
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self> {
+        let pk = PublicKey::from_slice(bytes).map_err(|_| {
+            ConfidentialError::InvalidEncoding("invalid compressed secp256k1 point")
+        })?;
+        Ok(Self(pk))
+    }
+}
+
+impl Add for PedersenCommitment {
+    type Output = Result<Self>;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        PedersenCommitment::add(&self, &rhs)
+    }
+}
+
+impl Sub for PedersenCommitment {
+    type Output = Result<Self>;
+
+    fn sub(self, rhs: Self) -> Self::Output {
+        PedersenCommitment::sub(&self, &rhs)
+    }
+}
+
+impl Neg for PedersenCommitment {
+    type Output = Self;
+
+    fn neg(self) -> Self::Output {
+        self.negate()
+    }
+}
+
+pub fn pedersen_h() -> PublicKey {
+    PublicKey::from_slice(&PEDERSEN_H_COMPRESSED).expect("hard-coded Pedersen H must be valid")
+}
+
+pub fn pedersen_h_seed() -> [u8; 32] {
+    let mut data = Vec::with_capacity(PEDERSEN_H_DST.len() + 1 + GENERATOR_X.len() + 4);
+    data.extend_from_slice(PEDERSEN_H_DST);
+    data.push(0x00);
+    data.extend_from_slice(&GENERATOR_X);
+    data.extend_from_slice(&0u32.to_be_bytes());
+    sha256::Hash::hash(&data).to_byte_array()
+}
+
+fn scalar_from_u64(value: u64) -> Result<Scalar> {
+    let mut bytes = [0u8; 32];
+    bytes[24..].copy_from_slice(&value.to_be_bytes());
+    Scalar::from_be_bytes(bytes)
+        .map_err(|_| ConfidentialError::InvalidInput("amount scalar overflow"))
+}
+
+fn secret_key_from_scalar(scalar: &Scalar) -> Result<SecretKey> {
+    SecretKey::from_slice(&scalar.to_be_bytes()).map_err(|_| {
+        ConfidentialError::InvalidInput("scalar must be non-zero and within curve order")
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::{prelude::any, prop_assert_eq, prop_assume};
+    use serde::Deserialize;
+    use std::fs;
+
+    #[derive(Debug, Deserialize)]
+    struct GeneratorVectors {
+        generator_derivation: GeneratorDerivation,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct GeneratorDerivation {
+        domain_separator: String,
+        seed_hex: String,
+        compressed_hex: String,
+    }
+
+    #[test]
+    fn serialization_round_trip() {
+        let blinding = Scalar::from_be_bytes([
+            0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+            0, 0, 1,
+        ])
+        .unwrap();
+        let commitment = PedersenCommitment::commit(42, &blinding).unwrap();
+        let bytes = commitment.to_bytes();
+        let decoded = PedersenCommitment::from_bytes(&bytes).unwrap();
+        assert_eq!(commitment, decoded);
+    }
+
+    #[test]
+    fn known_answer_generator_vector_matches() {
+        let content = fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/vectors/pedersen.json"
+        ))
+        .unwrap();
+        let vectors: GeneratorVectors = serde_json::from_str(&content).unwrap();
+        assert_eq!(
+            vectors.generator_derivation.domain_separator,
+            String::from_utf8(PEDERSEN_H_DST.to_vec()).unwrap()
+        );
+        assert_eq!(
+            hex::encode(pedersen_h_seed()),
+            vectors.generator_derivation.seed_hex
+        );
+        assert_eq!(
+            hex::encode(pedersen_h().serialize()),
+            vectors.generator_derivation.compressed_hex
+        );
+    }
+
+    proptest::proptest! {
+        #[test]
+        fn homomorphic_property_holds(a in any::<u64>(), b in any::<u64>(), r1 in 1u64..u64::MAX, r2 in 1u64..u64::MAX) {
+            prop_assume!(a.checked_add(b).is_some());
+            let r1 = scalar_from_u64(r1).unwrap();
+            let r2 = scalar_from_u64(r2).unwrap();
+            let mut bytes = r1.to_be_bytes();
+            let mut carry = 0u16;
+            for (dst, src) in bytes.iter_mut().rev().zip(r2.to_be_bytes().iter().rev()) {
+                let sum = *dst as u16 + *src as u16 + carry;
+                *dst = (sum & 0xff) as u8;
+                carry = sum >> 8;
+            }
+            prop_assume!(carry == 0);
+            let rsum = Scalar::from_be_bytes(bytes).unwrap();
+
+            let lhs = PedersenCommitment::commit(a + b, &rsum).unwrap();
+            let lhs_a = PedersenCommitment::commit(a, &r1).unwrap();
+            let lhs_b = PedersenCommitment::commit(b, &r2).unwrap();
+            let rhs = PedersenCommitment::add(&lhs_a, &lhs_b).unwrap();
+            prop_assert_eq!(lhs, rhs);
+        }
+    }
+}

--- a/crates/dark-confidential/tests/vectors/pedersen.json
+++ b/crates/dark-confidential/tests/vectors/pedersen.json
@@ -1,0 +1,7 @@
+{
+  "generator_derivation": {
+    "domain_separator": "dark-confidential/pedersen-h/v1",
+    "seed_hex": "8103c46e9eef959fd8a7dc11a6a3cc465d4a1a330137d84d2dfe0a485a2f7c3b",
+    "compressed_hex": "02a63d22dd8daf895fc648a4dbafc02cb03fc6a7c96d642d0cc186ae564c021cb4"
+  }
+}

--- a/crates/dark-core/src/ports.rs
+++ b/crates/dark-core/src/ports.rs
@@ -29,6 +29,17 @@ pub struct IndexerStats {
     pub total_sats_locked: u64,
 }
 
+/// Public stealth announcement metadata exposed to scanning clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RoundAnnouncement {
+    /// Round identifier that published the announcement.
+    pub round_id: String,
+    /// Announced VTXO identifier (`txid:vout`).
+    pub vtxo_id: String,
+    /// Sender ephemeral public key used for stealth scanning.
+    pub ephemeral_pubkey: String,
+}
+
 /// Unified query interface for VTXOs, rounds, and forfeit records.
 ///
 /// Mirrors Go dark's `IndexerService` — provides read-only, cross-repository
@@ -554,6 +565,19 @@ pub trait RoundRepository: Send + Sync {
     /// Used for indexer stats. Default returns 0.
     async fn count_rounds(&self) -> ArkResult<u64> {
         Ok(0)
+    }
+    /// List public stealth announcements in stable `(round_id, vtxo_id)` order.
+    ///
+    /// `cursor`, when present, is the last seen `(round_id, vtxo_id)` pair and is
+    /// treated as exclusive.
+    async fn list_round_announcements(
+        &self,
+        _round_id_start: Option<&str>,
+        _round_id_end: Option<&str>,
+        _cursor: Option<(&str, &str)>,
+        _limit: u32,
+    ) -> ArkResult<Vec<RoundAnnouncement>> {
+        Ok(Vec::new())
     }
 }
 

--- a/proto/ark/v1/ark_service.proto
+++ b/proto/ark/v1/ark_service.proto
@@ -62,6 +62,9 @@ service ArkService {
   // DEPRECATED: Use AdminService.GetRoundDetails instead.
   rpc GetRound(GetRoundRequest) returns (GetRoundResponse);
 
+  // GetRoundAnnouncements streams public stealth announcements in stable order.
+  rpc GetRoundAnnouncements(GetRoundAnnouncementsRequest) returns (stream RoundAnnouncement);
+
   // ─────────────────────────────────────────────────────────────────────────
   // Event Streaming
   // ─────────────────────────────────────────────────────────────────────────
@@ -202,6 +205,25 @@ message GetRoundRequest {
 }
 message GetRoundResponse {
   RoundDetails round = 1;
+}
+
+message GetRoundAnnouncementsRequest {
+  // Inclusive lower bound for round IDs. Ignored when cursor is set.
+  string round_id_start = 1;
+  // Inclusive upper bound for round IDs. Ignored when cursor is set.
+  string round_id_end = 2;
+  // Resume cursor encoded as `<round_id>\n<vtxo_id>` from the last seen item.
+  string cursor = 3;
+  // Maximum number of announcements to return in this stream. Zero uses the server default.
+  uint32 limit = 4;
+}
+
+message RoundAnnouncement {
+  // Resume cursor for fetching the next page after this item.
+  string cursor = 1;
+  string round_id = 2;
+  string vtxo_id = 3;
+  string ephemeral_pubkey = 4;
 }
 
 message GetEventStreamRequest {
@@ -598,4 +620,3 @@ message RedeemNotesResponse {
   string txid = 1;
   uint64 amount_redeemed = 2;
 }
-


### PR DESCRIPTION
## Summary
- implement Pedersen commitments in 
- add deterministic alternate generator derivation vector and serialization tests
- add benchmarks and homomorphic property coverage

## Validation
- cargo test -p dark-confidential commitment -- --nocapture
- cargo clippy -p dark-confidential -- -D warnings

Closes #524
