### PR TITLE
feat(confidential): add nullifier derivation (#527)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1218,11 +1218,15 @@ version = "0.1.0"
 dependencies = [
  "criterion",
  "hex",
+ "hmac",
  "proptest",
+ "rand 0.8.6",
  "secp256k1 0.29.1",
  "serde",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
+ "zeroize",
 ]
 
 [[package]]
@@ -6398,6 +6402,20 @@ name = "zeroize"
 version = "1.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+dependencies = [
+ "zeroize_derive",
+]
+
+[[package]]
+name = "zeroize_derive"
+version = "1.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85a5b4158499876c763cb03bc4e49185d3cccbabb15b33c627f7884f43db852e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "zerotrie"

--- a/crates/dark-confidential/Cargo.toml
+++ b/crates/dark-confidential/Cargo.toml
@@ -13,6 +13,9 @@ unsafe_code = "forbid"
 [dependencies]
 thiserror = "2.0"
 secp256k1 = { version = "0.29", features = ["hashes", "rand"] }
+hmac = "0.12"
+sha2 = "0.10"
+zeroize = { version = "1.7", features = ["zeroize_derive"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 
@@ -20,6 +23,7 @@ serde_json = "1.0"
 proptest = "1.5"
 criterion = { version = "0.5", features = ["html_reports"] }
 hex = "0.4"
+rand = { version = "0.8", features = ["small_rng"] }
 
 [lib]
 name = "dark_confidential"

--- a/crates/dark-confidential/src/nullifier.rs
+++ b/crates/dark-confidential/src/nullifier.rs
@@ -1,1 +1,292 @@
-//! nullifier primitives for Confidential VTXOs.
+//! Nullifier derivation for Confidential VTXOs.
+//!
+//! Implements the scheme fixed by ADR-0002
+//! (`docs/adr/0002-nullifier-derivation.md`):
+//!
+//! ```text
+//!     nullifier = HMAC-SHA256(
+//!         key = secret_key_bytes,
+//!         msg = b"dark-confidential/nullifier" || 0x00 || version || vtxo_id_bytes,
+//!     )
+//! ```
+//!
+//! - `secret_key_bytes` — 32 bytes, the confidential spend secret.
+//! - The `0x00` byte is a hard separator so no future DST suffix can
+//!   collide with a version-prefixed encoding.
+//! - `version` is the byte [`NULLIFIER_VERSION_V1`]. Versioning lives
+//!   *inside* the HMAC input, not on the wire output, so migrating to a
+//!   new primitive does not widen stored nullifier columns.
+//! - `vtxo_id_bytes` is the canonical 36-byte encoding
+//!   `32-byte txid || 4-byte big-endian vout` defined by the ADR.
+//!   Callers MUST NOT invent ad-hoc encodings; use [`VtxoId`] or
+//!   [`encode_vtxo_id`].
+//!
+//! # Note on the issue text
+//!
+//! Issue #527's task description types `vtxo_id` as `&[u8; 32]`. That
+//! pre-dates ADR-0002, which canonicalises the identifier at 36 bytes
+//! (txid + vout). The ADR is the controlling document — mismatched
+//! lengths would silently change which nullifier maps to which VTXO, so
+//! we take `&[u8; 36]` here and offer [`VtxoId`] as the ergonomic
+//! constructor. Downstream issues (#530, #538, #539) are all scoped to
+//! opaque 32-byte nullifier outputs and do not care about the input
+//! length.
+//!
+//! # Zeroization
+//!
+//! The spend secret enters this module only via `&SecretKey`. We extract
+//! its byte view into a [`zeroize::Zeroizing`] buffer that wipes on
+//! drop, feed it into HMAC, and release the MAC engine immediately.
+//! `secp256k1::SecretKey` itself is `Copy` + `Drop`-zeroizing upstream
+//! — that choice is upstream's to defend; we do not introduce any new
+//! `Copy` type that carries secret bytes in this path. [`VtxoId`] is
+//! `Copy` on purpose: it holds public identifier bytes only.
+//!
+//! The output 32-byte nullifier is **public**. We do not zeroize it.
+
+use hmac::{Hmac, Mac};
+use secp256k1::SecretKey;
+use sha2::Sha256;
+use zeroize::Zeroizing;
+
+/// Domain separator, exactly as specified in ADR-0002.
+pub const NULLIFIER_DST: &[u8] = b"dark-confidential/nullifier";
+
+/// Hard separator byte between DST and version.
+pub const NULLIFIER_SEPARATOR: u8 = 0x00;
+
+/// Current nullifier derivation version.
+///
+/// ADR-0002: "any future primitive change must mint a new version byte,
+/// not reinterpret v1".
+pub const NULLIFIER_VERSION_V1: u8 = 0x01;
+
+/// Length of the canonical VTXO identifier bytes, per ADR-0002:
+/// `32-byte txid || 4-byte big-endian vout`.
+pub const VTXO_ID_LEN: usize = 36;
+
+/// Length of a nullifier in bytes. HMAC-SHA256 output width.
+pub const NULLIFIER_LEN: usize = 32;
+
+/// Returns the current nullifier version byte so on-wire formats can
+/// evolve without reading the constant directly.
+pub const fn nullifier_version() -> u8 {
+    NULLIFIER_VERSION_V1
+}
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Derive the 32-byte nullifier for `vtxo_id` under `secret_key`.
+///
+/// Deterministic, collision-resistant, and one-way w.r.t. the secret
+/// key. See the module docs for transcript and zeroization specifics.
+pub fn compute_nullifier(
+    secret_key: &SecretKey,
+    vtxo_id: &[u8; VTXO_ID_LEN],
+) -> [u8; NULLIFIER_LEN] {
+    let sk_bytes = Zeroizing::new(secret_key.secret_bytes());
+    let mut mac = HmacSha256::new_from_slice(sk_bytes.as_ref())
+        .expect("HMAC-SHA256 accepts keys of any length");
+    mac.update(NULLIFIER_DST);
+    mac.update(&[NULLIFIER_SEPARATOR]);
+    mac.update(&[NULLIFIER_VERSION_V1]);
+    mac.update(vtxo_id);
+    let tag = mac.finalize().into_bytes();
+    let mut out = [0u8; NULLIFIER_LEN];
+    out.copy_from_slice(&tag);
+    out
+}
+
+/// Canonical VTXO identifier for nullifier derivation.
+///
+/// The ADR pins the on-the-wire encoding as `txid || vout_be`; this
+/// struct is the one-and-only sanctioned constructor so nothing
+/// downstream re-invents the layout. Hold it by value where convenient
+/// — it carries no secret material.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct VtxoId {
+    pub txid: [u8; 32],
+    pub vout: u32,
+}
+
+impl VtxoId {
+    pub const fn new(txid: [u8; 32], vout: u32) -> Self {
+        Self { txid, vout }
+    }
+
+    pub fn to_bytes(&self) -> [u8; VTXO_ID_LEN] {
+        encode_vtxo_id(&self.txid, self.vout)
+    }
+}
+
+/// Encode `(txid, vout)` into the ADR-0002 canonical 36-byte layout.
+pub fn encode_vtxo_id(txid: &[u8; 32], vout: u32) -> [u8; VTXO_ID_LEN] {
+    let mut out = [0u8; VTXO_ID_LEN];
+    out[..32].copy_from_slice(txid);
+    out[32..].copy_from_slice(&vout.to_be_bytes());
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+    use serde::Deserialize;
+    use std::collections::HashSet;
+    use std::fs;
+
+    fn sk_from_hex(hex: &str) -> SecretKey {
+        let bytes = hex::decode(hex).unwrap();
+        SecretKey::from_slice(&bytes).unwrap()
+    }
+
+    fn id_from_hex(hex: &str) -> [u8; VTXO_ID_LEN] {
+        let bytes = hex::decode(hex).unwrap();
+        let mut out = [0u8; VTXO_ID_LEN];
+        out.copy_from_slice(&bytes);
+        out
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Vectors {
+        version: u8,
+        dst: String,
+        vectors: Vec<Vector>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Vector {
+        name: String,
+        secret_key_hex: String,
+        vtxo_id_hex: String,
+        nullifier_hex: String,
+    }
+
+    #[test]
+    fn version_is_one() {
+        assert_eq!(nullifier_version(), 0x01);
+    }
+
+    #[test]
+    fn encode_vtxo_id_layout() {
+        let txid = [0xaau8; 32];
+        let vout = 0x1234_5678u32;
+        let bytes = encode_vtxo_id(&txid, vout);
+        assert_eq!(&bytes[..32], &txid);
+        assert_eq!(&bytes[32..], &[0x12, 0x34, 0x56, 0x78]);
+    }
+
+    #[test]
+    fn vtxo_id_to_bytes_matches_encoder() {
+        let txid = [0x11u8; 32];
+        let id = VtxoId::new(txid, 7);
+        assert_eq!(id.to_bytes(), encode_vtxo_id(&txid, 7));
+    }
+
+    #[test]
+    fn adr_0002_vector_c_secret_key_is_invalid() {
+        // Document the ADR-0002 bug: Vector C's secret_key_hex
+        // `ffffffffffffffffffffffffffffffff00000000000000000000000000000001`
+        // is above the secp256k1 group order n, so SecretKey::from_slice
+        // rejects it. This test exists so the discrepancy stays visible
+        // in CI and is not silently worked around. ADR-0002 needs an
+        // amendment substituting a valid scalar (e.g. n−1 for the same
+        // "near upper bound" stress intent).
+        let bytes = hex::decode("ffffffffffffffffffffffffffffffff00000000000000000000000000000001")
+            .unwrap();
+        assert!(SecretKey::from_slice(&bytes).is_err());
+    }
+
+    #[test]
+    fn adr_0002_known_answer_vectors_match() {
+        let content = fs::read_to_string(concat!(
+            env!("CARGO_MANIFEST_DIR"),
+            "/tests/vectors/nullifier.json"
+        ))
+        .unwrap();
+        let vectors: Vectors = serde_json::from_str(&content).unwrap();
+        assert_eq!(vectors.version, NULLIFIER_VERSION_V1);
+        assert_eq!(vectors.dst.as_bytes(), NULLIFIER_DST);
+        for v in &vectors.vectors {
+            let sk = sk_from_hex(&v.secret_key_hex);
+            let id = id_from_hex(&v.vtxo_id_hex);
+            let got = compute_nullifier(&sk, &id);
+            assert_eq!(
+                hex::encode(got),
+                v.nullifier_hex,
+                "ADR-0002 vector {} mismatch",
+                v.name
+            );
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(10_000))]
+
+        #[test]
+        fn determinism(
+            sk_bytes in proptest::array::uniform32(any::<u8>()),
+            txid in proptest::array::uniform32(any::<u8>()),
+            vout in any::<u32>(),
+        ) {
+            prop_assume!(sk_bytes != [0u8; 32]);
+            let Ok(sk) = SecretKey::from_slice(&sk_bytes) else { return Ok(()); };
+            let id = encode_vtxo_id(&txid, vout);
+            let a = compute_nullifier(&sk, &id);
+            let b = compute_nullifier(&sk, &id);
+            prop_assert_eq!(a, b);
+        }
+    }
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(1024))]
+
+        #[test]
+        fn distinct_inputs_produce_distinct_outputs(
+            sk_bytes_a in proptest::array::uniform32(any::<u8>()),
+            sk_bytes_b in proptest::array::uniform32(any::<u8>()),
+            id_a in proptest::array::uniform32(any::<u8>()),
+            id_b in proptest::array::uniform32(any::<u8>()),
+            vout_a in any::<u32>(),
+            vout_b in any::<u32>(),
+        ) {
+            prop_assume!(sk_bytes_a != sk_bytes_b || id_a != id_b || vout_a != vout_b);
+            prop_assume!(sk_bytes_a != [0u8; 32] && sk_bytes_b != [0u8; 32]);
+            let Ok(sk_a) = SecretKey::from_slice(&sk_bytes_a) else { return Ok(()); };
+            let Ok(sk_b) = SecretKey::from_slice(&sk_bytes_b) else { return Ok(()); };
+            let id_a_full = encode_vtxo_id(&id_a, vout_a);
+            let id_b_full = encode_vtxo_id(&id_b, vout_b);
+            let n_a = compute_nullifier(&sk_a, &id_a_full);
+            let n_b = compute_nullifier(&sk_b, &id_b_full);
+            prop_assert_ne!(n_a, n_b);
+        }
+    }
+
+    /// Collision-resistance smoke test: 1M random inputs, zero observed
+    /// collisions (AC: "1M random inputs, no collisions").
+    ///
+    /// Gated behind `--ignored` because 1M HMAC-SHA256 operations in
+    /// debug mode is ~40s on a laptop; release brings it under 5s. Run
+    /// via `cargo test -p dark-confidential --release collision_resistance -- --ignored --nocapture`.
+    #[test]
+    #[ignore = "1M HMAC iterations — run with --release and --ignored"]
+    fn collision_resistance_one_million() {
+        use rand::{rngs::SmallRng, Rng, SeedableRng};
+        const N: usize = 1_000_000;
+        let mut rng = SmallRng::seed_from_u64(0xc0ffee_u64);
+        let mut seen: HashSet<[u8; NULLIFIER_LEN]> = HashSet::with_capacity(N);
+        let mut sk_buf = [0u8; 32];
+        let mut id_buf = [0u8; VTXO_ID_LEN];
+        for _ in 0..N {
+            let sk = loop {
+                rng.fill(&mut sk_buf[..]);
+                if let Ok(sk) = SecretKey::from_slice(&sk_buf) {
+                    break sk;
+                }
+            };
+            rng.fill(&mut id_buf[..]);
+            let n = compute_nullifier(&sk, &id_buf);
+            assert!(seen.insert(n), "unexpected nullifier collision");
+        }
+    }
+}

--- a/crates/dark-confidential/tests/vectors/nullifier.json
+++ b/crates/dark-confidential/tests/vectors/nullifier.json
@@ -1,0 +1,19 @@
+{
+  "_comment": "Known-answer vectors for nullifier derivation per ADR-0002. Transcript format: HMAC-SHA256(sk_bytes, dst || 0x00 || 0x01 || vtxo_id). ADR-0002 Vector C is intentionally omitted: its secret_key_hex `ffff...ff00...01` exceeds the secp256k1 curve order n and is rejected by SecretKey::from_slice. This is tracked by the adr_0002_vector_c_secret_key_is_invalid test; the ADR needs a follow-up to substitute a valid scalar.",
+  "version": 1,
+  "dst": "dark-confidential/nullifier",
+  "vectors": [
+    {
+      "name": "A",
+      "secret_key_hex": "000102030405060708090a0b0c0d0e0f101112131415161718191a1b1c1d1e1f",
+      "vtxo_id_hex": "111111111111111111111111111111111111111111111111111111111111111100000001",
+      "nullifier_hex": "861dd26af26743cc28d21c53a0d1d7f1262f12ede2cf4b0b89487cfc00de9b23"
+    },
+    {
+      "name": "B",
+      "secret_key_hex": "1f1e1d1c1b1a191817161514131211100f0e0d0c0b0a09080706050403020100",
+      "vtxo_id_hex": "22222222222222222222222222222222222222222222222222222222222222220000000a",
+      "nullifier_hex": "544b94484e85393bc71b7d188c5b6a51e3cb4b82e2374b1acb31ba40ad917969"
+    }
+  ]
+}


### PR DESCRIPTION
HMAC-SHA256(sk_bytes, dst || 0x00 || 0x01 || vtxo_id) per ADR-0002. Intermediate sk bytes zeroized on drop via Zeroizing. Canonical 36-byte VtxoId encoder (txid || vout_be) exposed as the single sanctioned constructor so downstream crates cannot reinvent the layout.

Tests cover AC: 10k-case determinism proptest, 1024-case distinctness proptest, 1M-sample collision-resistance sweep (gated behind --ignored --release, ~0.85s), ADR-0002 known-answer vectors A and B materialised under tests/vectors/nullifier.json. Vector C in the ADR has a secret key byte string above the secp256k1 group order — documented via the adr_0002_vector_c_secret_key_is_invalid test; ADR needs an amendment before vector C can be materialised.

vtxo_id is typed &[u8; 36] (not the &[u8; 32] in the issue text) — ADR-0002 canonicalises the identifier as txid||vout_be and supersedes the issue's pre-ADR signature.

closes #527 