### PR TITLE
fix(fraud-reaction): trim broadcast critical-path latency to fit Go E…

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -4925,16 +4925,30 @@ impl ArkService {
             {
                 Ok(txid) => {
                     info!(connector_idx = i, txid = %txid, "Connector TX broadcast (CPFP)");
-                    // Wait for confirmation before proceeding (matches Go's waitForConfirmation).
-                    // broadcast_forfeit_with_anchor already mines a regtest block on success,
-                    // but the Esplora index may lag. Poll until confirmed.
+                    // `broadcast_forfeit_with_anchor` mines a regtest block before
+                    // returning, so Bitcoin Core has already confirmed the
+                    // connector by this point. The poll exists only to give
+                    // chopsticks/electrs a moment to index that confirmation
+                    // — the *next* broadcast (the forfeit package) is validated
+                    // by Bitcoin Core's `submitpackage` against Bitcoin Core's
+                    // mempool, not against the chopsticks index, so missing the
+                    // index here is not a correctness problem; it's only
+                    // surfaced as a slower poll attempt on the next iteration.
+                    //
+                    // Check eagerly first (no initial sleep) since
+                    // `is_tx_confirmed` falls back to Bitcoin Core RPC, which
+                    // sees the just-mined block immediately. Cap the wait at
+                    // ~3 s with 100 ms intervals so the
+                    // `TestReactToFraud/.../with_batch_output` 8 s phase-2
+                    // budget — already 5 s consumed by `fraud_reaction_delay`
+                    // — is not exhausted by per-connector index latency.
                     if let Some(ref ctxid) = connector_txid {
-                        for _attempt in 0..10 {
-                            tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+                        for _attempt in 0..30 {
                             if self.scanner.is_tx_confirmed(ctxid).await.unwrap_or(false) {
                                 info!(connector_idx = i, "Connector confirmed");
                                 break;
                             }
+                            tokio::time::sleep(std::time::Duration::from_millis(100)).await;
                         }
                     }
                 }

--- a/crates/dark-scanner/src/esplora.rs
+++ b/crates/dark-scanner/src/esplora.rs
@@ -199,15 +199,24 @@ impl EsploraScanner {
         });
 
         // Spawn a lightweight block-tip polling loop.
-        // Checks for new blocks every 3 seconds (a single small HTTP call)
-        // and emits NewBlockEvent when the tip advances. This lets consumers
-        // react to new blocks promptly without waiting for the heavier
-        // script-spend poll cycle.
+        //
+        // Emits `NewBlockEvent` when the chain tip advances so consumers
+        // can react without waiting for the heavier script-spend cycle.
+        // The cadence tracks `poll_interval` capped at 3 s: production
+        // still polls every 3 s (the prior default), while regtest —
+        // where the auto-miner advances the tip every 2 s and the Go
+        // E2E suite gives the server a few seconds to react to a fraud
+        // unroll — gets the same fast 1 s rhythm as the script-spend
+        // poller. Without this, block events arrived every ~6 s under
+        // CI load (request latency stacked on top of the fixed 3 s
+        // sleep), pushing fraud detection past the test budget at
+        // `vendor/arkd/internal/test/e2e/e2e_test.go:2119`.
+        let block_poll = std::cmp::min(self.poll_interval, Duration::from_secs(3));
         tokio::spawn(async move {
             debug!("EsploraScanner: block-tip polling loop started");
             loop {
                 self.check_new_block().await;
-                tokio::time::sleep(Duration::from_secs(3)).await;
+                tokio::time::sleep(block_poll).await;
             }
         });
     }


### PR DESCRIPTION
…2E budget

Two surgical timing fixes that bring the post-detection window for TestReactToFraud/react_to_unroll_of_forfeited_vtxos/with_batch_output back inside the upstream test's 8 s phase-2 budget at vendor/arkd/internal/test/e2e/e2e_test.go:2119:

1. crates/dark-core/src/application.rs: The poll between connector broadcast and forfeit broadcast slept 500 ms before the first check, then up to 10× 500 ms = 5 s, every round-trip. The wallet has already mined a regtest block before `broadcast_forfeit_with_anchor` returns, so Bitcoin Core has the confirmation immediately and `is_tx_confirmed` falls back to the RPC path on the first call. Check eagerly with no initial sleep and tighten retries to 30 × 100 ms (~3 s cap). Typical run drops from ~2.3 s to <100 ms — observed CI logs show this slot fully consumed the test's slack.

2. crates/dark-scanner/src/esplora.rs: The block-tip poller slept 3 s between checks. Under CI load each HTTP round-trip stretched the actual cadence to ~6 s, so block- driven maintenance — and therefore fraud detection — ran at roughly the same cadence. Cap the sleep at `poll_interval`, so regtest tracks its 1 s rhythm (matching the script-spend poller) while production's 30 s `poll_interval_secs` still resolves to the prior 3 s ceiling.

Both changes are no-ops for the dark-confidential / range-proof work landing in #525 / #590; they only touch the fraud-reaction broadcast path that was already on `main` and exhibiting the same shard-3/3 failure (e.g. run 24905768080 on b930894).