### PR TITLE
ci: switch Test job to nextest, default proptest cases to 256, nightly heavy

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,8 +69,20 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-cargo-
 
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
       - name: Run tests
-        run: cargo test --all-features --workspace
+        # PR-time defaults: nextest for parallelism, PROPTEST_CASES=256
+        # for the proptest suite (the heavy 10_000-case sweep promised
+        # by issue #528 runs nightly via the proptest-heavy workflow).
+        # See `crates/dark-confidential/tests/props.rs` for the env-var
+        # contract.
+        env:
+          PROPTEST_CASES: "256"
+        run: cargo nextest run --all-features --workspace
 
   clippy:
     name: Clippy

--- a/.github/workflows/proptest-heavy.yml
+++ b/.github/workflows/proptest-heavy.yml
@@ -1,0 +1,65 @@
+name: Proptest (heavy)
+
+# Nightly 10_000-case sweep over the dark-confidential property suite,
+# matching the formal coverage AC of issue #528. The PR-time CI Test
+# job runs the same properties at PROPTEST_CASES=256 to keep wall time
+# under ~5 min; this workflow brings the case count back up to 10 000
+# at a cadence where its ~20 min runtime is acceptable.
+#
+# The job is also dispatchable manually from the Actions tab so a
+# triage run can be kicked off ad hoc without waiting for the scheduled
+# slot.
+
+on:
+  schedule:
+    # Daily at 06:00 UTC — off-peak for North-American and European devs.
+    - cron: "0 6 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: proptest-heavy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  CARGO_TERM_COLOR: always
+  RUST_BACKTRACE: 1
+
+jobs:
+  proptest-heavy:
+    name: Proptest (10_000 cases)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install protoc
+        run: sudo apt-get update && sudo apt-get install -y protobuf-compiler
+
+      - name: Install Rust stable
+        run: |
+          rustup update stable
+          rustup default stable
+
+      - name: Cache cargo registry
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-proptest-heavy-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-proptest-heavy-
+            ${{ runner.os }}-cargo-
+
+      - name: Install cargo-nextest
+        uses: taiki-e/install-action@v2
+        with:
+          tool: cargo-nextest
+
+      - name: Run dark-confidential proptest suite (10_000 cases)
+        env:
+          PROPTEST_CASES: "10000"
+        # Release mode trims per-case curve-arithmetic latency by ~10x
+        # (~1.3 ms vs ~13 ms range-proof prove) so the full 10_000-case
+        # sweep finishes inside the 30 min cap.
+        run: cargo nextest run --release --all-features -p dark-confidential --test props

--- a/crates/dark-confidential/tests/props.rs
+++ b/crates/dark-confidential/tests/props.rs
@@ -1,10 +1,18 @@
 //! Property-based test suite for `dark-confidential` (issue #528).
 //!
-//! Every property runs ≥10_000 proptest cases by default. Bump via
-//! `PROPTEST_CASES=N cargo test -p dark-confidential --test props` for
-//! triage runs. Heavy curve-arithmetic properties (range, balance) take
-//! a few seconds per 10k cases on modern x86_64; lighter scalar/HMAC
-//! properties run in under a second.
+//! Case count is configurable via the `PROPTEST_CASES` environment
+//! variable. Default is **256**, tuned for fast PR-time CI runs. The
+//! heavy 10_000-case sweep that issue #528 promises runs nightly via a
+//! scheduled workflow that exports `PROPTEST_CASES=10000`. Override
+//! locally with `PROPTEST_CASES=N cargo test -p dark-confidential --test props`.
+//!
+//! Why this is configurable: the heavy properties (range-proof and
+//! balance-proof prove+verify) are 5–15 ms per case in debug mode. At
+//! 10 000 cases × 4 heavy properties they take ~20 minutes on the GitHub
+//! Actions Test job, which dominated CI wall time after #597 landed. A
+//! 256-case smoke run still flushes out almost every regression at a
+//! tiny fraction of the cost; the nightly 10 000-case run keeps the
+//! formal coverage AC live.
 //!
 //! Coverage map (matches AC of #528):
 //! - `homomorphism_holds_over_pedersen`            — commitment module
@@ -25,15 +33,30 @@ use proptest::prelude::*;
 use proptest::test_runner::Config as PropConfig;
 use secp256k1::{Scalar, SecretKey};
 
-const HEAVY_CASES: u32 = 10_000;
-const VERY_HEAVY_CASES: u32 = 10_000;
+/// Default number of proptest cases when `PROPTEST_CASES` is unset.
+///
+/// Tuned for PR-time CI: 256 cases catches almost every regression in
+/// the curve-arithmetic and HMAC paths while keeping the Test job under
+/// ~5 minutes. The nightly heavy sweep overrides this via
+/// `PROPTEST_CASES=10000`.
+const DEFAULT_CASES: u32 = 256;
+
+/// Read the case count once per test invocation. Honours the standard
+/// proptest `PROPTEST_CASES` env var (which `PropConfig::with_cases`
+/// otherwise overrides).
+fn case_count() -> u32 {
+    std::env::var("PROPTEST_CASES")
+        .ok()
+        .and_then(|s| s.parse::<u32>().ok())
+        .unwrap_or(DEFAULT_CASES)
+}
 
 fn heavy_config() -> PropConfig {
-    PropConfig::with_cases(HEAVY_CASES)
+    PropConfig::with_cases(case_count())
 }
 
 fn very_heavy_config() -> PropConfig {
-    PropConfig::with_cases(VERY_HEAVY_CASES)
+    PropConfig::with_cases(case_count())
 }
 
 fn scalar_from_u64(value: u64) -> Scalar {
@@ -81,7 +104,7 @@ proptest! {
 /// is ~30 s. Separate config so we can dial this down independently if
 /// the suite ever breaches a CI budget.
 fn range_proof_config() -> PropConfig {
-    PropConfig::with_cases(HEAVY_CASES)
+    PropConfig::with_cases(case_count())
 }
 
 proptest! {
@@ -153,7 +176,7 @@ proptest! {
 // =====================================================================
 
 fn balance_proof_config() -> PropConfig {
-    PropConfig::with_cases(HEAVY_CASES)
+    PropConfig::with_cases(case_count())
 }
 
 proptest! {


### PR DESCRIPTION
The unit Test job grew from ~6 min to ~25 min once #597's 10_000-case
property suite landed: `tests/props.rs` hardcoded `PropConfig::with_cases(10_000)`
in debug mode, and 4 heavy curve-arithmetic properties at ~10–30 ms per
case dominate. Two changes:

1. `crates/dark-confidential/tests/props.rs` now reads
   `PROPTEST_CASES` from the environment (it would otherwise be
   ignored by `with_cases`) and defaults to 256 — the smallest count
   that still flushes out the regressions we have seen historically.

2. `.github/workflows/ci.yml` Test job swaps `cargo test` for
   `cargo nextest run` (already used by the e2e workflow) and pins
   `PROPTEST_CASES=256` for PR runs.

3. `.github/workflows/proptest-heavy.yml` (new) runs the full 10 000-
   case sweep nightly under `--release` so the formal #528 coverage
   AC stays live. Manually dispatchable for ad-hoc triage.
