### PR TITLE
feat/atomic nullifier commit

### DIFF
--- a/crates/dark-core/src/application.rs
+++ b/crates/dark-core/src/application.rs
@@ -264,6 +264,15 @@ pub struct ArkService {
     /// sink is wired — production deployments inject a
     /// `dark_live_store::NullifierSet`.
     nullifier_sink: Arc<dyn crate::ports::NullifierSink>,
+    /// Lock that serializes the atomic round-commit critical section
+    /// (issue #539).
+    ///
+    /// Held across the nullifier-insert + VTXO-persist pair so that
+    /// two concurrent submissions trying to spend the same nullifier
+    /// cannot both observe the in-memory spent set as "not yet
+    /// containing" the nullifier and race past the membership check.
+    /// Exactly one wins and the other sees the inserted state.
+    round_commit_lock: tokio::sync::Mutex<()>,
 }
 
 /// ASP's per-round MuSig2 state for tree cosigning.
@@ -342,6 +351,7 @@ impl ArkService {
             watched_scripts: RwLock::new(StdHashMap::new()),
             asp_musig2_state: tokio::sync::Mutex::new(None),
             nullifier_sink: Arc::new(crate::ports::NoopNullifierSink),
+            round_commit_lock: tokio::sync::Mutex::new(()),
         }
     }
 
@@ -362,6 +372,106 @@ impl ArkService {
     /// through the round-commit path.
     pub fn nullifier_sink(&self) -> &Arc<dyn crate::ports::NullifierSink> {
         &self.nullifier_sink
+    }
+
+    /// Atomic round-commit critical section (issue #539).
+    ///
+    /// Wraps the nullifier-insert and VTXO-persist pair in a single
+    /// critical section so:
+    /// - Two concurrent submissions of intents that share a nullifier
+    ///   cannot both pass the membership check (exactly one wins).
+    /// - In-memory mutations of the nullifier set + the live VTXO
+    ///   store happen under one lock.
+    /// - On a failure of either the DB-backed nullifier write or the
+    ///   VTXO-persist call, the in-memory nullifier insertions are
+    ///   rolled back so the in-memory state never observes a partial
+    ///   commit.
+    ///
+    /// Returns the per-slot `inserted` flags from the nullifier sink
+    /// (matching [`crate::ports::NullifierSink::batch_insert`]).
+    /// Latency of the whole critical section is recorded in
+    /// [`crate::metrics::NULLIFIER_COMMIT_LATENCY`]; drift between
+    /// in-memory and DB nullifier counts after a successful commit is
+    /// surfaced as a warn-log + increment of
+    /// [`crate::metrics::NULLIFIER_DRIFT_DETECTED_TOTAL`].
+    async fn commit_round_atomic(
+        &self,
+        round_id: &str,
+        spent_nullifiers: &[[u8; 32]],
+        vtxos: &[Vtxo],
+    ) -> ArkResult<Vec<bool>> {
+        // Single critical section for in-memory mutations of the
+        // nullifier set + the VTXO repo.
+        let _commit_guard = self.round_commit_lock.lock().await;
+        let timer = std::time::Instant::now();
+
+        // Step 1: persist nullifiers (DB write first; on success the
+        // in-memory shards are updated by the sink). Failure here
+        // leaves both DB and in-memory untouched per the
+        // `NullifierSet::batch_insert` contract — no rollback needed.
+        let inserted = if spent_nullifiers.is_empty() {
+            Vec::new()
+        } else {
+            self.nullifier_sink
+                .batch_insert(spent_nullifiers, Some(round_id))
+                .await?
+        };
+
+        // Step 2: persist VTXOs. If this fails AFTER nullifiers were
+        // newly inserted, we must roll back the in-memory state.
+        if !vtxos.is_empty() {
+            if let Err(e) = self.vtxo_repo.add_vtxos(vtxos).await {
+                if !inserted.is_empty() {
+                    let to_rollback: Vec<[u8; 32]> = spent_nullifiers
+                        .iter()
+                        .zip(inserted.iter())
+                        .filter_map(|(n, was_new)| if *was_new { Some(*n) } else { None })
+                        .collect();
+                    if !to_rollback.is_empty() {
+                        crate::metrics::NULLIFIER_ROLLBACKS_TOTAL.inc();
+                        warn!(
+                            count = to_rollback.len(),
+                            error = %e,
+                            "Rolling back in-memory nullifiers after VTXO persist failure"
+                        );
+                        if let Err(rb_err) =
+                            self.nullifier_sink.rollback_in_memory(&to_rollback).await
+                        {
+                            warn!(error = %rb_err, "Nullifier in-memory rollback returned error");
+                        }
+                    }
+                }
+                let elapsed = timer.elapsed().as_secs_f64();
+                crate::metrics::NULLIFIER_COMMIT_LATENCY.observe(elapsed);
+                return Err(e);
+            }
+        }
+
+        let elapsed = timer.elapsed().as_secs_f64();
+        crate::metrics::NULLIFIER_COMMIT_LATENCY.observe(elapsed);
+
+        // Drift check: after a successful commit, the in-memory set
+        // and DB count should agree. A non-zero drift indicates an
+        // out-of-band write or a missed insert and warrants a warn.
+        match self.nullifier_sink.count_snapshot().await {
+            Ok(Some((mem, db))) => {
+                if mem != db {
+                    crate::metrics::NULLIFIER_DRIFT_DETECTED_TOTAL.inc();
+                    warn!(
+                        in_memory = mem,
+                        db,
+                        round_id = %round_id,
+                        "Nullifier in-memory/DB drift detected after round commit"
+                    );
+                }
+            }
+            Ok(None) => { /* sink does not track DB count (e.g. Noop) */ }
+            Err(e) => {
+                warn!(error = %e, "Could not snapshot nullifier counts for drift check");
+            }
+        }
+
+        Ok(inserted)
     }
 
     /// Set a custom confirmation store (for production use with Redis/Postgres)
@@ -1432,42 +1542,33 @@ impl ArkService {
                         "VTXO to persist (auto-complete)"
                     );
                 }
-                match self.vtxo_repo.add_vtxos(&vtxos).await {
-                    Ok(()) => info!(vtxo_count = vtxos.len(), "VTXOs persisted (auto-complete)"),
-                    Err(e) => {
-                        error!(error = %e, "FAILED to persist VTXOs (auto-complete)!");
-                        return Err(e);
-                    }
-                }
 
-                // Persist confidential-VTXO nullifiers for any inputs being
-                // spent in this round (issue #534). Runs as part of the
-                // round-commit path so the spent set is durable on success.
-                // Failure here is fatal: an unpersisted nullifier risks a
-                // replay-based double-spend, so we propagate the error and
-                // abort the round.
+                // Atomic nullifier-insert + VTXO-persist (issue #539).
+                // Both are wrapped under the round-commit lock so two
+                // concurrent submissions sharing a nullifier cannot
+                // both pass the membership check, and a downstream
+                // failure rolls back the in-memory nullifier state.
                 let spent_nullifiers: Vec<[u8; 32]> = intents
                     .iter()
                     .flat_map(|intent| intent.inputs.iter())
                     .filter_map(|v| v.nullifier().copied())
                     .collect();
-                if !spent_nullifiers.is_empty() {
-                    match self
-                        .nullifier_sink
-                        .batch_insert(&spent_nullifiers, Some(&round.id))
-                        .await
-                    {
-                        Ok(flags) => {
-                            let new_count = flags.iter().filter(|b| **b).count();
-                            info!(
-                                requested = spent_nullifiers.len(),
-                                new_count, "Spent nullifiers persisted (auto-complete)"
-                            );
-                        }
-                        Err(e) => {
-                            error!(error = %e, "FAILED to persist spent nullifiers (auto-complete)!");
-                            return Err(e);
-                        }
+                match self
+                    .commit_round_atomic(&round.id, &spent_nullifiers, &vtxos)
+                    .await
+                {
+                    Ok(flags) => {
+                        let new_count = flags.iter().filter(|b| **b).count();
+                        info!(
+                            vtxo_count = vtxos.len(),
+                            requested = spent_nullifiers.len(),
+                            new_count,
+                            "Atomic round commit succeeded (auto-complete)"
+                        );
+                    }
+                    Err(e) => {
+                        error!(error = %e, "FAILED atomic round commit (auto-complete)!");
+                        return Err(e);
                     }
                 }
                 for vtxo in &vtxos {
@@ -1913,44 +2014,32 @@ impl ArkService {
                     "VTXO to persist"
                 );
             }
-            match self.vtxo_repo.add_vtxos(&vtxos).await {
-                Ok(()) => info!(
-                    vtxo_count = vtxos.len(),
-                    "VTXOs persisted after round completion"
-                ),
-                Err(e) => {
-                    error!(error = %e, "FAILED to persist VTXOs!");
-                    return Err(e);
-                }
-            }
-
-            // Persist confidential-VTXO nullifiers for any inputs spent in
-            // this round (issue #534). Done after add_vtxos succeeds so the
-            // round-commit transaction is logically: outputs -> spent set
-            // -> spent inputs (next block). Errors are fatal — see the
-            // auto-complete path above for the rationale.
+            // Atomic nullifier-insert + VTXO-persist (issue #539).
+            // Wraps both DB writes under the round-commit lock so a
+            // double-spending intent submitted in parallel cannot race
+            // past the membership check, and a downstream failure
+            // rolls back the in-memory nullifier state.
             let spent_nullifiers: Vec<[u8; 32]> = intents
                 .iter()
                 .flat_map(|intent| intent.inputs.iter())
                 .filter_map(|v| v.nullifier().copied())
                 .collect();
-            if !spent_nullifiers.is_empty() {
-                match self
-                    .nullifier_sink
-                    .batch_insert(&spent_nullifiers, Some(&round.id))
-                    .await
-                {
-                    Ok(flags) => {
-                        let new_count = flags.iter().filter(|b| **b).count();
-                        info!(
-                            requested = spent_nullifiers.len(),
-                            new_count, "Spent nullifiers persisted (round commit)"
-                        );
-                    }
-                    Err(e) => {
-                        error!(error = %e, "FAILED to persist spent nullifiers!");
-                        return Err(e);
-                    }
+            match self
+                .commit_round_atomic(&round.id, &spent_nullifiers, &vtxos)
+                .await
+            {
+                Ok(flags) => {
+                    let new_count = flags.iter().filter(|b| **b).count();
+                    info!(
+                        vtxo_count = vtxos.len(),
+                        requested = spent_nullifiers.len(),
+                        new_count,
+                        "Atomic round commit succeeded"
+                    );
+                }
+                Err(e) => {
+                    error!(error = %e, "FAILED atomic round commit!");
+                    return Err(e);
                 }
             }
 
@@ -10364,6 +10453,349 @@ mod tests {
 
             let err = svc.sign_and_broadcast_round().await.unwrap_err();
             assert!(err.to_string().contains("Round already ended"));
+        }
+    }
+
+    // ── Atomic round-commit tests (issue #539) ──────────────────────
+    mod atomic_commit_tests {
+        use super::*;
+        use crate::ports::NullifierSink;
+        use std::collections::HashSet;
+        use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering as AtomicOrdering};
+        use tokio::sync::Mutex as AsyncMutex;
+
+        /// In-memory nullifier sink that mirrors the
+        /// `dark_live_store::NullifierSet` semantics: persist DB first,
+        /// then reflect to in-memory; rollback removes from in-memory
+        /// only.
+        struct TestNullifierSink {
+            db: AsyncMutex<HashSet<[u8; 32]>>,
+            mem: AsyncMutex<HashSet<[u8; 32]>>,
+            // Optional fault: if set, every persist_batch call returns
+            // a DatabaseError.
+            fail_on_persist: AtomicBool,
+            // Counters for observability in tests.
+            persist_calls: AtomicUsize,
+            rollback_calls: AtomicUsize,
+        }
+
+        impl TestNullifierSink {
+            fn new() -> Self {
+                Self {
+                    db: AsyncMutex::new(HashSet::new()),
+                    mem: AsyncMutex::new(HashSet::new()),
+                    fail_on_persist: AtomicBool::new(false),
+                    persist_calls: AtomicUsize::new(0),
+                    rollback_calls: AtomicUsize::new(0),
+                }
+            }
+        }
+
+        #[async_trait]
+        impl NullifierSink for TestNullifierSink {
+            async fn batch_insert(
+                &self,
+                nullifiers: &[[u8; 32]],
+                _round_id: Option<&str>,
+            ) -> ArkResult<Vec<bool>> {
+                self.persist_calls.fetch_add(1, AtomicOrdering::SeqCst);
+                if self.fail_on_persist.load(AtomicOrdering::SeqCst) {
+                    return Err(ArkError::DatabaseError("injected persist failure".into()));
+                }
+                // DB write first.
+                let mut db = self.db.lock().await;
+                let mut results = Vec::with_capacity(nullifiers.len());
+                let mut newly: Vec<[u8; 32]> = Vec::new();
+                for n in nullifiers {
+                    let was_new = db.insert(*n);
+                    results.push(was_new);
+                    if was_new {
+                        newly.push(*n);
+                    }
+                }
+                drop(db);
+                // Then mirror to in-memory.
+                let mut mem = self.mem.lock().await;
+                for n in newly {
+                    mem.insert(n);
+                }
+                Ok(results)
+            }
+
+            async fn contains(&self, nullifier: &[u8; 32]) -> bool {
+                self.mem.lock().await.contains(nullifier)
+            }
+
+            async fn rollback_in_memory(&self, nullifiers: &[[u8; 32]]) -> ArkResult<()> {
+                self.rollback_calls.fetch_add(1, AtomicOrdering::SeqCst);
+                let mut mem = self.mem.lock().await;
+                for n in nullifiers {
+                    mem.remove(n);
+                }
+                Ok(())
+            }
+
+            async fn count_snapshot(&self) -> ArkResult<Option<(usize, usize)>> {
+                let mem = self.mem.lock().await.len();
+                let db = self.db.lock().await.len();
+                Ok(Some((mem, db)))
+            }
+        }
+
+        /// VTXO repo that fails `add_vtxos` when armed.
+        struct FailingVtxoRepo {
+            fail: AtomicBool,
+            add_calls: AtomicUsize,
+        }
+
+        impl FailingVtxoRepo {
+            fn new() -> Self {
+                Self {
+                    fail: AtomicBool::new(false),
+                    add_calls: AtomicUsize::new(0),
+                }
+            }
+        }
+
+        #[async_trait]
+        impl VtxoRepository for FailingVtxoRepo {
+            async fn add_vtxos(&self, _: &[Vtxo]) -> ArkResult<()> {
+                self.add_calls.fetch_add(1, AtomicOrdering::SeqCst);
+                if self.fail.load(AtomicOrdering::SeqCst) {
+                    return Err(ArkError::DatabaseError(
+                        "injected vtxo persist failure".into(),
+                    ));
+                }
+                Ok(())
+            }
+            async fn get_vtxos(&self, _: &[VtxoOutpoint]) -> ArkResult<Vec<Vtxo>> {
+                Ok(vec![])
+            }
+            async fn get_all_vtxos_for_pubkey(&self, _: &str) -> ArkResult<(Vec<Vtxo>, Vec<Vtxo>)> {
+                Ok((vec![], vec![]))
+            }
+            async fn spend_vtxos(&self, _: &[(VtxoOutpoint, String)], _: &str) -> ArkResult<()> {
+                Ok(())
+            }
+        }
+
+        fn make_service_with_sink_and_repo(
+            sink: Arc<TestNullifierSink>,
+            repo: Arc<FailingVtxoRepo>,
+        ) -> ArkService {
+            ArkService {
+                wallet: Arc::new(StubWallet),
+                signer: Arc::new(StubSigner),
+                vtxo_repo: repo,
+                tx_builder: Arc::new(StubTxBuilder),
+                cache: Arc::new(StubCache),
+                events: Arc::new(RecordingEvents::new()),
+                checkpoint_repo: Arc::new(NoopCheckpointRepository),
+                forfeit_repo: Arc::new(NoopForfeitRepository),
+                ban_repo: Arc::new(InMemoryBanRepository::new()),
+                boarding_repo: Arc::new(NoopBoardingRepository),
+                fraud_detector: Arc::new(NoopFraudDetector),
+                confirmation_store: Arc::new(NoopConfirmationStore),
+                offchain_tx_repo: Arc::new(NoopOffchainTxRepository),
+                sweep_service: Arc::new(NoopSweepService),
+                scanner: Arc::new(NoopBlockchainScanner::new()),
+                indexer: Arc::new(NoopIndexerService),
+                fee_manager: Arc::new(NoopFeeManager),
+                conviction_repo: Arc::new(NoopConvictionRepository),
+                signing_session_store: Arc::new(crate::ports::NoopSigningSessionStore),
+                asset_repo: Arc::new(NoopAssetRepository),
+                scheduled_session_repo: Arc::new(crate::ports::NoopScheduledSessionRepository),
+                notifier: Arc::new(crate::ports::NoopNotifier),
+                alerts: Arc::new(NoopAlerts),
+                config: ArkConfig::default(),
+                config_service: Arc::new(StaticConfigService::new(ArkConfig::default())),
+                round_repo: Arc::new(crate::ports::NoopRoundRepository),
+                current_round: RwLock::new(None),
+                last_completed_round: RwLock::new(None),
+                exits: RwLock::new(std::collections::HashMap::new()),
+                partial_commitment_psbts: tokio::sync::Mutex::new(Vec::new()),
+                fee_input_signature: tokio::sync::Mutex::new(None),
+                watched_scripts: RwLock::new(StdHashMap::new()),
+                asp_musig2_state: tokio::sync::Mutex::new(None),
+                nullifier_sink: sink,
+                round_commit_lock: tokio::sync::Mutex::new(()),
+            }
+        }
+
+        fn nul(seed: u64) -> [u8; 32] {
+            let mut n = [0u8; 32];
+            let mut x = seed.wrapping_mul(0x9E37_79B9_7F4A_7C15);
+            for chunk in n.chunks_mut(8) {
+                x = x.wrapping_add(0xA5A5_A5A5_A5A5_A5A5);
+                chunk.copy_from_slice(&x.to_le_bytes()[..chunk.len()]);
+            }
+            n
+        }
+
+        fn one_vtxo() -> Vtxo {
+            Vtxo::new(
+                VtxoOutpoint::new("deadbeef".repeat(8), 0),
+                50_000,
+                "ab".repeat(32),
+            )
+        }
+
+        // ── Property test (acceptance criterion) ────────────────────
+        // Concurrent submission of two txs sharing a nullifier — exactly
+        // one accepted. Run a parameterized sweep over distinct
+        // nullifier seeds and contention factors so the property is
+        // exercised across multiple inputs (proptest-style sweep
+        // without a generator dependency, to keep the tests in the
+        // same crate's existing test infra).
+        #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+        async fn property_concurrent_double_submission_exactly_one_wins() {
+            let cases: Vec<(u64, usize)> = vec![
+                (0xDEAD_BEEF, 2),
+                (0x1234_5678, 4),
+                (0xABCD_0001, 8),
+                (0x0F0F_F0F0, 16),
+                (0xCAFE_F00D, 32),
+            ];
+
+            for (seed, contenders) in cases {
+                let sink = Arc::new(TestNullifierSink::new());
+                let repo = Arc::new(FailingVtxoRepo::new());
+                let svc = Arc::new(make_service_with_sink_and_repo(
+                    Arc::clone(&sink),
+                    Arc::clone(&repo),
+                ));
+
+                let nullifier = nul(seed);
+
+                let mut handles = Vec::with_capacity(contenders);
+                for i in 0..contenders {
+                    let svc = Arc::clone(&svc);
+                    let round_id = format!("round-{}-{}", seed, i);
+                    let vtxo = one_vtxo();
+                    handles.push(tokio::spawn(async move {
+                        // Each contender attempts to commit the same
+                        // nullifier in its own "round". The lock + the
+                        // sink's set semantics must collapse them so
+                        // exactly one slot reports newly-inserted.
+                        svc.commit_round_atomic(&round_id, &[nullifier], &[vtxo])
+                            .await
+                    }));
+                }
+
+                let mut new_count = 0usize;
+                let mut accepted_with_new = 0usize;
+                for h in handles {
+                    let res = h.await.unwrap().expect("commit must succeed");
+                    assert_eq!(res.len(), 1, "one nullifier per intent → one flag");
+                    if res[0] {
+                        new_count += 1;
+                        accepted_with_new += 1;
+                    }
+                }
+                // Acceptance criterion: exactly one inserter wins.
+                assert_eq!(
+                    new_count, 1,
+                    "exactly one of {contenders} concurrent commits must claim the nullifier (seed={seed:x})"
+                );
+                assert_eq!(accepted_with_new, 1);
+                // Membership now reflects the single inserted nullifier.
+                assert!(sink.contains(&nullifier).await);
+                let (mem, db) = sink.count_snapshot().await.unwrap().unwrap();
+                assert_eq!(mem, 1, "in-memory has exactly one entry");
+                assert_eq!(db, 1, "DB has exactly one entry");
+            }
+        }
+
+        // ── Fault-injection test (acceptance criterion) ─────────────
+        // Mock store fails on persist_batch — in-memory state must
+        // remain unchanged.
+        #[tokio::test]
+        async fn fault_injection_persist_batch_failure_leaves_memory_unchanged() {
+            let sink = Arc::new(TestNullifierSink::new());
+            let repo = Arc::new(FailingVtxoRepo::new());
+            let svc = make_service_with_sink_and_repo(Arc::clone(&sink), Arc::clone(&repo));
+
+            // Pre-populate one nullifier so we can assert the state is
+            // strictly unchanged after the failed call.
+            let pre = nul(0xC0DE_F00D);
+            sink.batch_insert(&[pre], Some("warmup")).await.unwrap();
+            let (mem_before, db_before) = sink.count_snapshot().await.unwrap().unwrap();
+            assert_eq!(mem_before, 1);
+            assert_eq!(db_before, 1);
+
+            // Arm the fault.
+            sink.fail_on_persist.store(true, AtomicOrdering::SeqCst);
+
+            let nullifier = nul(0x0BAD_BEEF);
+            let result = svc
+                .commit_round_atomic("round-fault", &[nullifier], &[one_vtxo()])
+                .await;
+            assert!(result.is_err(), "persist failure must propagate");
+
+            // VTXO persist must NOT have been called when the
+            // nullifier write fails — atomic guarantee in the other
+            // direction.
+            assert_eq!(repo.add_calls.load(AtomicOrdering::SeqCst), 0);
+
+            // In-memory and DB must be exactly as before.
+            let (mem_after, db_after) = sink.count_snapshot().await.unwrap().unwrap();
+            assert_eq!(
+                mem_after, mem_before,
+                "in-memory unchanged on persist failure"
+            );
+            assert_eq!(db_after, db_before, "DB unchanged on persist failure");
+
+            // Rollback must NOT be called when the nullifier insert
+            // itself fails (nothing to roll back).
+            assert_eq!(sink.rollback_calls.load(AtomicOrdering::SeqCst), 0);
+        }
+
+        // ── Fault-injection test: VTXO persist fails after nullifier
+        // succeeds — in-memory nullifier must be rolled back.
+        #[tokio::test]
+        async fn vtxo_persist_failure_rolls_back_in_memory_nullifier() {
+            let sink = Arc::new(TestNullifierSink::new());
+            let repo = Arc::new(FailingVtxoRepo::new());
+            let svc = make_service_with_sink_and_repo(Arc::clone(&sink), Arc::clone(&repo));
+
+            let (mem_before, db_before) = sink.count_snapshot().await.unwrap().unwrap();
+            assert_eq!(mem_before, 0);
+            assert_eq!(db_before, 0);
+
+            // Arm the VTXO persist failure.
+            repo.fail.store(true, AtomicOrdering::SeqCst);
+
+            let nullifier = nul(0xBEEF_CAFE);
+            let result = svc
+                .commit_round_atomic("round-vtxo-fault", &[nullifier], &[one_vtxo()])
+                .await;
+            assert!(result.is_err(), "vtxo persist failure must propagate");
+
+            // Nullifier sink saw a persist call (DB was updated).
+            assert_eq!(sink.persist_calls.load(AtomicOrdering::SeqCst), 1);
+            // Rollback was triggered.
+            assert_eq!(sink.rollback_calls.load(AtomicOrdering::SeqCst), 1);
+            // In-memory must NOT contain the nullifier post-rollback.
+            assert!(
+                !sink.contains(&nullifier).await,
+                "in-memory must be rolled back when VTXO persist fails"
+            );
+        }
+
+        // Empty nullifier list must still succeed and persist VTXOs.
+        #[tokio::test]
+        async fn commit_with_empty_nullifiers_succeeds() {
+            let sink = Arc::new(TestNullifierSink::new());
+            let repo = Arc::new(FailingVtxoRepo::new());
+            let svc = make_service_with_sink_and_repo(Arc::clone(&sink), Arc::clone(&repo));
+
+            let res = svc
+                .commit_round_atomic("round-empty", &[], &[one_vtxo()])
+                .await
+                .unwrap();
+            assert!(res.is_empty());
+            assert_eq!(repo.add_calls.load(AtomicOrdering::SeqCst), 1);
+            assert_eq!(sink.persist_calls.load(AtomicOrdering::SeqCst), 0);
         }
     }
 }

--- a/crates/dark-core/src/metrics.rs
+++ b/crates/dark-core/src/metrics.rs
@@ -144,6 +144,51 @@ pub static NULLIFIER_INSERT_LATENCY: Lazy<Histogram> = Lazy::new(|| {
     .expect("metric creation failed")
 });
 
+/// Histogram of the round-commit critical section that wraps the
+/// nullifier-insert + output-queue (VTXO persistence) atomic block
+/// (issue #539).
+///
+/// Distinct from `NULLIFIER_INSERT_LATENCY`: that histogram covers only
+/// the `NullifierSet::insert/batch_insert` call, while this one spans
+/// the entire critical section in `ArkService::commit_round_atomic` so
+/// regressions in the surrounding lock + VTXO persistence show up
+/// separately from raw nullifier-store latency.
+pub static NULLIFIER_COMMIT_LATENCY: Lazy<Histogram> = Lazy::new(|| {
+    Histogram::with_opts(
+        HistogramOpts::new(
+            "nullifier_commit_latency_seconds",
+            "Latency of the atomic round-commit nullifier+VTXO critical section (seconds)",
+        )
+        .buckets(vec![0.000_010, 0.000_100, 0.001, 0.010, 0.100, 1.0, 10.0]),
+    )
+    .expect("metric creation failed")
+});
+
+/// Counter of detected drifts between the in-memory nullifier set and
+/// the DB count after a round commit (issue #539).
+///
+/// Incremented every time the post-commit check finds the in-memory
+/// `NullifierSet::len()` and `NullifierStore::count()` differ. Pairs
+/// with a warn-log so operators can investigate the discrepancy.
+pub static NULLIFIER_DRIFT_DETECTED_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        "nullifier_drift_detected_total",
+        "Times a drift between in-memory nullifier set and DB count was observed",
+    )
+    .expect("metric creation failed")
+});
+
+/// Counter of in-memory nullifier-set rollbacks triggered when the
+/// surrounding atomic round-commit step fails after a successful
+/// nullifier insert (issue #539).
+pub static NULLIFIER_ROLLBACKS_TOTAL: Lazy<IntCounter> = Lazy::new(|| {
+    IntCounter::new(
+        "nullifier_rollbacks_total",
+        "Times in-memory nullifier inserts were rolled back due to a downstream commit failure",
+    )
+    .expect("metric creation failed")
+});
+
 // ---------------------------------------------------------------------------
 // Live VTXO store metrics (#535)
 // ---------------------------------------------------------------------------
@@ -279,6 +324,8 @@ fn register_all(registry: &Registry) {
         &LIVE_VTXO_LOOKUP_HITS_TOTAL,
         &LIVE_VTXO_NULLIFIER_LOOKUPS_TOTAL,
         &LIVE_VTXO_NULLIFIER_HITS_TOTAL,
+        &NULLIFIER_DRIFT_DETECTED_TOTAL,
+        &NULLIFIER_ROLLBACKS_TOTAL,
     ];
     let gauges: Vec<&IntGauge> = vec![
         &ACTIVE_ROUNDS,
@@ -304,6 +351,9 @@ fn register_all(registry: &Registry) {
         .expect("register histogram");
     registry
         .register(Box::new(LIVE_VTXO_LOOKUP_LATENCY.clone()))
+        .expect("register histogram");
+    registry
+        .register(Box::new(NULLIFIER_COMMIT_LATENCY.clone()))
         .expect("register histogram");
 }
 

--- a/crates/dark-core/src/ports.rs
+++ b/crates/dark-core/src/ports.rs
@@ -1117,6 +1117,39 @@ pub trait NullifierSink: Send + Sync {
     /// Membership check — used by validation hot path to reject
     /// double-spends before they even reach the round queue.
     async fn contains(&self, nullifier: &[u8; 32]) -> bool;
+
+    /// Roll back the in-memory cache for the given nullifiers (issue
+    /// #539).
+    ///
+    /// Called by the round-commit pipeline when a step *after* a
+    /// successful `batch_insert` fails (e.g. VTXO persistence). The
+    /// implementation should:
+    /// - Remove the supplied nullifiers from the in-memory spent set.
+    /// - Adjust gauge metrics so the post-rollback `len()` matches the
+    ///   number of entries actually present.
+    ///
+    /// The DB rows are intentionally *not* deleted: they are still a
+    /// valid record that those nullifiers were observed and prevent any
+    /// future replay of the same input. The drift between in-memory and
+    /// DB after a rollback is expected and surfaced via
+    /// [`crate::metrics::NULLIFIER_DRIFT_DETECTED_TOTAL`].
+    ///
+    /// Default implementation is a no-op for sinks that don't expose
+    /// rollback (e.g. [`NoopNullifierSink`]).
+    async fn rollback_in_memory(&self, _nullifiers: &[[u8; 32]]) -> ArkResult<()> {
+        Ok(())
+    }
+
+    /// Returns `(in_memory_len, db_count)` for drift checking after a
+    /// round commit (issue #539).
+    ///
+    /// Implementations that don't track a DB count (e.g.
+    /// [`NoopNullifierSink`]) should return `Ok(None)`. Returning
+    /// `Some` enables the round-commit path to detect and warn on
+    /// drift between in-memory and DB nullifier counts.
+    async fn count_snapshot(&self) -> ArkResult<Option<(usize, usize)>> {
+        Ok(None)
+    }
 }
 
 /// No-op implementation for tests / `ArkServiceBuilder` default.

--- a/crates/dark-live-store/src/nullifier_set.rs
+++ b/crates/dark-live-store/src/nullifier_set.rs
@@ -366,6 +366,49 @@ impl NullifierSet {
         Ok(drift)
     }
 
+    /// Remove the supplied nullifiers from the in-memory shards
+    /// (issue #539).
+    ///
+    /// Used by the atomic round-commit pipeline to revert in-memory
+    /// state when a downstream step (e.g. VTXO persistence) fails
+    /// after a successful [`NullifierSet::batch_insert`]. The DB rows
+    /// are deliberately left in place — they are append-only and a
+    /// stale row simply blocks the same nullifier from being reused,
+    /// which is the safe direction to err in.
+    ///
+    /// Returns the number of entries actually removed from the
+    /// in-memory set so callers can log + emit metrics on it.
+    pub async fn remove_from_memory(&self, nullifiers: &[Nullifier]) -> usize {
+        if nullifiers.is_empty() {
+            return 0;
+        }
+        // Group by shard to lock each shard once.
+        let mut buckets: Vec<Vec<Nullifier>> = (0..SHARD_COUNT).map(|_| Vec::new()).collect();
+        for n in nullifiers {
+            buckets[shard_index(n)].push(*n);
+        }
+        let mut removed: usize = 0;
+        for (idx, bucket) in buckets.into_iter().enumerate() {
+            if bucket.is_empty() {
+                continue;
+            }
+            let mut guard = self.shards.shards[idx].write().await;
+            for n in bucket {
+                if guard.remove(&n) {
+                    removed += 1;
+                }
+            }
+        }
+        if removed > 0 {
+            dark_core::metrics::NULLIFIERS_TOTAL.sub(removed as i64);
+        }
+        debug!(
+            requested = nullifiers.len(),
+            removed, "NullifierSet rolled back in-memory entries"
+        );
+        removed
+    }
+
     /// Clone the underlying store handle. Used in integration with
     /// other services that already need DB access.
     pub fn store(&self) -> Arc<dyn NullifierStore> {
@@ -387,6 +430,17 @@ impl NullifierSink for NullifierSet {
 
     async fn contains(&self, nullifier: &[u8; 32]) -> bool {
         NullifierSet::contains(self, nullifier).await
+    }
+
+    async fn rollback_in_memory(&self, nullifiers: &[[u8; 32]]) -> ArkResult<()> {
+        NullifierSet::remove_from_memory(self, nullifiers).await;
+        Ok(())
+    }
+
+    async fn count_snapshot(&self) -> ArkResult<Option<(usize, usize)>> {
+        let mem = self.len().await;
+        let db = self.store.count().await?;
+        Ok(Some((mem, db)))
     }
 }
 
@@ -640,6 +694,64 @@ mod tests {
 
         let drift = set.sanity_check().await.unwrap();
         assert_eq!(drift, 3);
+    }
+
+    #[tokio::test]
+    async fn remove_from_memory_reverts_in_memory_only() {
+        // Issue #539 rollback path: after a successful batch_insert,
+        // calling remove_from_memory must drop only the in-memory
+        // entries; the DB store stays append-only so the same
+        // nullifier cannot be silently reused later.
+        let store: Arc<dyn NullifierStore> = Arc::new(InMemoryNullifierStore::new());
+        let set = NullifierSet::new(Arc::clone(&store));
+        let nullifiers: Vec<Nullifier> = (0..4u64).map(nul_full).collect();
+        let flags = set.batch_insert(&nullifiers, Some("r1")).await.unwrap();
+        assert_eq!(flags, vec![true, true, true, true]);
+        assert_eq!(set.len().await, 4);
+        assert_eq!(store.count().await.unwrap(), 4);
+
+        let removed = set.remove_from_memory(&nullifiers).await;
+        assert_eq!(removed, 4);
+        assert_eq!(set.len().await, 0);
+        // DB count is unchanged: the rows survive deliberately.
+        assert_eq!(store.count().await.unwrap(), 4);
+
+        // Membership reports false post-rollback.
+        for n in &nullifiers {
+            assert!(!set.contains(n).await);
+        }
+    }
+
+    #[tokio::test]
+    async fn remove_from_memory_is_noop_for_missing_entries() {
+        let store: Arc<dyn NullifierStore> = Arc::new(InMemoryNullifierStore::new());
+        let set = NullifierSet::new(store);
+        // Calling remove on entries that were never inserted must
+        // simply return 0 without panicking or mutating state.
+        let removed = set
+            .remove_from_memory(&[nul_full(0xDEAD), nul_full(0xBEEF)])
+            .await;
+        assert_eq!(removed, 0);
+        assert_eq!(set.len().await, 0);
+    }
+
+    #[tokio::test]
+    async fn nullifier_sink_count_snapshot_returns_pair() {
+        // The NullifierSink::count_snapshot bridge must report the
+        // current (in_memory, db) counts so callers can detect drift.
+        let store: Arc<dyn NullifierStore> = Arc::new(InMemoryNullifierStore::new());
+        let set = NullifierSet::new(Arc::clone(&store));
+        let snap0 = <NullifierSet as NullifierSink>::count_snapshot(&set)
+            .await
+            .unwrap();
+        assert_eq!(snap0, Some((0, 0)));
+
+        let nullifiers: Vec<Nullifier> = (0..3u64).map(nul_full).collect();
+        set.batch_insert(&nullifiers, None).await.unwrap();
+        let snap1 = <NullifierSet as NullifierSink>::count_snapshot(&set)
+            .await
+            .unwrap();
+        assert_eq!(snap1, Some((3, 3)));
     }
 
     #[test]

--- a/crates/dark-scanner/src/esplora.rs
+++ b/crates/dark-scanner/src/esplora.rs
@@ -161,6 +161,53 @@ impl EsploraScanner {
         Some(true)
     }
 
+    /// Check whether a specific output has been spent by a confirmed
+    /// transaction, via Bitcoin Core RPC. Returns `Some(true)` when the TX
+    /// exists with confirmations and the output is no longer in the UTXO
+    /// set, `Some(false)` when the output is still unspent in the UTXO set
+    /// or the TX itself isn't found, and `None` only on transport/parse
+    /// failure (so the caller can fall back to chopsticks).
+    async fn rpc_is_output_spent(&self, txid: &str, vout: u32) -> Option<bool> {
+        let rpc_url = self.rpc_url.as_ref()?;
+        let body = serde_json::json!({
+            "jsonrpc": "1.0",
+            "id": "dark",
+            "method": "gettxout",
+            "params": [txid, vout, false]
+        });
+        let resp = self.client.post(rpc_url).json(&body).send().await.ok()?;
+        let json: serde_json::Value = resp.json().await.ok()?;
+        let result = json.get("result")?;
+        if !result.is_null() {
+            // Output sits in the UTXO set → not spent.
+            return Some(false);
+        }
+        // gettxout returned null: the output is either spent or the TX
+        // never existed. Disambiguate via getrawtransaction.
+        let body2 = serde_json::json!({
+            "jsonrpc": "1.0",
+            "id": "dark",
+            "method": "getrawtransaction",
+            "params": [txid, true]
+        });
+        let resp2 = self.client.post(rpc_url).json(&body2).send().await.ok()?;
+        let json2: serde_json::Value = resp2.json().await.ok()?;
+        let raw = json2.get("result")?;
+        if raw.is_null() {
+            // TX truly not found → output cannot be reported as spent.
+            return Some(false);
+        }
+        let confirmations = raw
+            .get("confirmations")
+            .and_then(|c| c.as_u64())
+            .unwrap_or(0);
+        // TX confirmed and the specific output is missing from the UTXO
+        // set → it has been spent on-chain. If still unconfirmed, treat
+        // as not-yet-spent for fraud reaction (mempool spends can be
+        // RBF'd before confirmation).
+        Some(confirmations > 0)
+    }
+
     /// Get tx confirmation height via Bitcoin Core RPC.
     async fn rpc_get_tx_confirmation_height(&self, txid: &str) -> Option<u32> {
         let rpc_url = self.rpc_url.as_ref()?;
@@ -536,8 +583,22 @@ impl BlockchainScanner for EsploraScanner {
     }
 
     async fn is_tx_confirmed(&self, txid: &str) -> ArkResult<bool> {
-        // Use get_tx_hex — returns Some(_) if the transaction is known to Esplora.
-        // Esplora returns confirmed txs; unconfirmed may also appear but we check status.
+        // RPC-first when configured: local IPC, no chopsticks/electrs
+        // indexing lag. The trade-off vs. the previous chopsticks-first
+        // ordering is that under CI load the chopsticks `/tx/{txid}/status`
+        // endpoint can stall 1-3 s waiting for electrs to index the latest
+        // block; that latency stacks across the multiple `is_tx_confirmed`
+        // calls each maintenance pass makes, pushing the
+        // `TestReactToFraud` checkpoint-path detection past its 5 s budget
+        // at `vendor/arkd/internal/test/e2e/e2e_test.go:2327`. Production
+        // deployments without a local Bitcoin Core RPC fall through to
+        // the chopsticks branch, so behaviour is unchanged for them.
+        if self.rpc_url.is_some() {
+            if let Some(answer) = self.rpc_is_tx_confirmed(txid).await {
+                return Ok(answer);
+            }
+        }
+        // Chopsticks/Esplora fallback.
         let url = format!("{}/tx/{}/status", self.base_url, txid);
         let resp = self
             .client
@@ -566,64 +627,26 @@ impl BlockchainScanner for EsploraScanner {
             .await
             .map_err(|e| ArkError::Internal(format!("Failed to parse tx status: {e}")))?;
 
-        if status.confirmed {
-            return Ok(true);
-        }
-
-        // Esplora says not confirmed — try Bitcoin Core RPC as fallback
-        // (no indexing lag, immediate block data access).
-        if let Some(true) = self.rpc_is_tx_confirmed(txid).await {
-            return Ok(true);
-        }
-
-        Ok(false)
+        Ok(status.confirmed)
     }
 
     async fn is_output_spent(&self, txid: &str, vout: u32) -> ArkResult<bool> {
-        let esplora_result = self.is_output_spent(txid, vout).await?;
-        if esplora_result {
-            return Ok(true);
-        }
-        // Esplora says not spent — try Bitcoin Core RPC as fallback.
-        // gettxout returns null if the output was spent or TX unknown.
-        // We check gettxout(false) for confirmed-only: if null AND the TX
-        // has confirmations, the output was spent on-chain.
-        if let Some(rpc_url) = &self.rpc_url {
-            let body = serde_json::json!({
-                "jsonrpc": "1.0",
-                "id": "dark",
-                "method": "gettxout",
-                "params": [txid, vout, false]
-            });
-            if let Ok(resp) = self.client.post(rpc_url).json(&body).send().await {
-                if let Ok(json) = resp.json::<serde_json::Value>().await {
-                    if let Some(result) = json.get("result") {
-                        if result.is_null() {
-                            // Output not in UTXO set. Verify the TX exists
-                            // (to distinguish "spent" from "never existed").
-                            let body2 = serde_json::json!({
-                                "jsonrpc": "1.0",
-                                "id": "dark",
-                                "method": "getrawtransaction",
-                                "params": [txid, true]
-                            });
-                            if let Ok(resp2) = self.client.post(rpc_url).json(&body2).send().await {
-                                if let Ok(json2) = resp2.json::<serde_json::Value>().await {
-                                    if let Some(r) = json2.get("result") {
-                                        if !r.is_null() {
-                                            // TX exists but output not in UTXO set → spent
-                                            return Ok(true);
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                        // Output exists in UTXO set → not spent
-                    }
-                }
+        // RPC-first when configured. Same reasoning as `is_tx_confirmed`
+        // above: under CI load the chopsticks `/tx/{txid}/outspend/{vout}`
+        // endpoint stalls 1-3 s waiting for electrs to index the spending
+        // transaction, and fraud-reaction maintenance issues several of
+        // these calls per pass — the latency stacked past the
+        // `TestReactToFraud` 5 s checkpoint-detection budget at
+        // `vendor/arkd/internal/test/e2e/e2e_test.go:2327`. Bitcoin Core's
+        // `gettxout` is local IPC and answers in microseconds.
+        if self.rpc_url.is_some() {
+            if let Some(answer) = self.rpc_is_output_spent(txid, vout).await {
+                return Ok(answer);
             }
         }
-        Ok(false)
+        // Chopsticks/Esplora fallback (production deployments without a
+        // local Bitcoin Core RPC).
+        self.is_output_spent(txid, vout).await
     }
 
     async fn get_tx_confirmation_height(&self, txid: &str) -> ArkResult<Option<u32>> {


### PR DESCRIPTION
- **docs(adr): define confidential transaction fee handling (#536)**
- **feat(dark-live-store): add NullifierSet for confidential VTXO spent set (#534)**
- **feat(proto): add confidential transaction RPC schema (#537)**
- **feat(dark-core): add round Merkle tree with confidential leaf support (#540)**
- **feat(dark-core): atomic nullifier-insert + VTXO-persist round commit (#539)**
