### PR TITLE
feat/grpc submit confidential tx

### DIFF
--- a/crates/dark-api/src/grpc/ark_service.rs
+++ b/crates/dark-api/src/grpc/ark_service.rs
@@ -1654,17 +1654,17 @@ impl ArkServiceTrait for ArkGrpcService {
     /// this method is responsible for transport-layer concerns:
     ///
     /// 1. Auth: the same macaroon scheme as `SubmitTx`. The
-    ///    [`required_permission_for_path`] table already classifies
+    ///    `required_permission_for_path` table already classifies
     ///    `SubmitConfidentialTransaction` as `Permission::Write`, so the
     ///    interceptor handles auth/permission checks before this method runs;
-    ///    we additionally call [`require_authenticated_user`] here to reject
+    ///    we additionally call `require_authenticated_user` here to reject
     ///    the dev-mode placeholder identity for confidential submissions.
     /// 2. Backpressure / rate-limit: capacity is bounded by
-    ///    [`confidential_submit_inflight`]; over-cap requests get
+    ///    `confidential_submit_inflight`; over-cap requests get
     ///    `Status::resource_exhausted` to mirror `ApiError::RateLimited`.
     /// 3. Shape validation: cheap structural checks (commitment / pubkey
     ///    lengths, balance-proof length) before invoking the heavy validator.
-    /// 4. Validation -> wire mapping: see [`map_validation_error`].
+    /// 4. Validation -> wire mapping: see `map_validation_error`.
     ///
     /// # Error mapping (acceptance criterion of #542)
     ///

--- a/crates/dark-api/src/grpc/ark_service.rs
+++ b/crates/dark-api/src/grpc/ark_service.rs
@@ -100,7 +100,27 @@ pub struct ArkGrpcService {
     /// Mutex for serializing SubmitTx calls (double-spend detection).
     /// Go reference: `offchainTxMu sync.Mutex`.
     offchain_tx_mutex: tokio::sync::Mutex<()>,
+    /// Backpressure cap for the confidential-tx submission path (#542).
+    ///
+    /// Used by `submit_confidential_transaction` only — the transparent path
+    /// has its own (looser) serialization via `offchain_tx_mutex`. Confidential
+    /// validation is CPU-heavy (range proofs + balance proof) so we cap the
+    /// number of in-flight verifications. When capacity is exhausted we return
+    /// `Status::resource_exhausted`, mirroring `ApiError::RateLimited`.
+    ///
+    /// The cap is intentionally permissive in tests (the constructors below
+    /// pick a large value) so unit tests do not flake; production deployments
+    /// should set this via config once the validator (#538) lands and we have
+    /// real CPU/RAM numbers to size against.
+    confidential_submit_inflight: Arc<tokio::sync::Semaphore>,
 }
+
+/// Default in-flight cap for confidential-tx submissions. See
+/// [`ArkGrpcService::confidential_submit_inflight`] for rationale. Sized to
+/// be large enough that legitimate clients never trip it under sane load,
+/// but bounded so a malicious client cannot exhaust server CPU on
+/// range-proof verification.
+const DEFAULT_CONFIDENTIAL_INFLIGHT: usize = 64;
 
 impl ArkGrpcService {
     /// Create a new ArkGrpcService.
@@ -120,6 +140,9 @@ impl ArkGrpcService {
             note_store: Arc::new(crate::notes::NoteStore::new()),
             stream_registry: Arc::new(super::stream_registry::StreamRegistry::new()),
             offchain_tx_mutex: tokio::sync::Mutex::new(()),
+            confidential_submit_inflight: Arc::new(tokio::sync::Semaphore::new(
+                DEFAULT_CONFIDENTIAL_INFLIGHT,
+            )),
             cel_fee_store: Arc::new(tokio::sync::RwLock::new(
                 crate::rest::CelFeePrograms::default(),
             )),
@@ -146,7 +169,52 @@ impl ArkGrpcService {
             note_store,
             stream_registry: Arc::new(super::stream_registry::StreamRegistry::new()),
             offchain_tx_mutex: tokio::sync::Mutex::new(()),
+            confidential_submit_inflight: Arc::new(tokio::sync::Semaphore::new(
+                DEFAULT_CONFIDENTIAL_INFLIGHT,
+            )),
             cel_fee_store,
+        }
+    }
+
+    /// Test-only access to the confidential-submit semaphore. Used by the
+    /// rate-limit integration test to drain the only permit and force a
+    /// `ResourceExhausted` rejection. Not exposed in production builds.
+    #[doc(hidden)]
+    #[cfg(any(test, debug_assertions))]
+    pub fn __test_inflight_semaphore(&self) -> Arc<tokio::sync::Semaphore> {
+        Arc::clone(&self.confidential_submit_inflight)
+    }
+
+    /// Test-only constructor that lets a test pin the in-flight cap to a
+    /// small number (e.g. 1) so the rate-limit-tripped behaviour can be
+    /// exercised deterministically. Marked `pub` (not `pub(crate)`) only so
+    /// `tests/grpc_integration.rs` can invoke it; the `__test_*` prefix
+    /// signals the test-only intent. Not part of the stable surface.
+    #[doc(hidden)]
+    #[cfg(any(test, debug_assertions))]
+    pub fn new_with_inflight_cap(
+        core: Arc<dark_core::ArkService>,
+        round_repo: Arc<dyn RoundRepository>,
+        broker: SharedEventBroker,
+        tx_broker: SharedTransactionEventBroker,
+        offchain_tx_repo: Arc<dyn OffchainTxRepository>,
+        confidential_inflight_cap: usize,
+    ) -> Self {
+        Self {
+            core,
+            round_repo,
+            broker,
+            tx_broker,
+            offchain_tx_repo,
+            note_store: Arc::new(crate::notes::NoteStore::new()),
+            stream_registry: Arc::new(super::stream_registry::StreamRegistry::new()),
+            offchain_tx_mutex: tokio::sync::Mutex::new(()),
+            confidential_submit_inflight: Arc::new(tokio::sync::Semaphore::new(
+                confidential_inflight_cap,
+            )),
+            cel_fee_store: Arc::new(tokio::sync::RwLock::new(
+                crate::rest::CelFeePrograms::default(),
+            )),
         }
     }
 
@@ -1579,19 +1647,103 @@ impl ArkServiceTrait for ArkGrpcService {
         }))
     }
 
-    /// Stub implementation for the confidential-transaction submission RPC
-    /// added in #537. The schema lives in `proto/ark/v1/confidential_tx.proto`;
-    /// the actual handler is the responsibility of issue #542 and validation
-    /// belongs to #538. Until those land we return `Unimplemented` so the
-    /// trait is satisfied without pretending we accept anything.
+    /// SubmitConfidentialTransaction (#542) — confidential off-chain tx submit RPC.
+    ///
+    /// Wire shape: see `proto/ark/v1/confidential_tx.proto`. Validation is
+    /// delegated to `dark_core::validate_confidential_transaction` (#538);
+    /// this method is responsible for transport-layer concerns:
+    ///
+    /// 1. Auth: the same macaroon scheme as `SubmitTx`. The
+    ///    [`required_permission_for_path`] table already classifies
+    ///    `SubmitConfidentialTransaction` as `Permission::Write`, so the
+    ///    interceptor handles auth/permission checks before this method runs;
+    ///    we additionally call [`require_authenticated_user`] here to reject
+    ///    the dev-mode placeholder identity for confidential submissions.
+    /// 2. Backpressure / rate-limit: capacity is bounded by
+    ///    [`confidential_submit_inflight`]; over-cap requests get
+    ///    `Status::resource_exhausted` to mirror `ApiError::RateLimited`.
+    /// 3. Shape validation: cheap structural checks (commitment / pubkey
+    ///    lengths, balance-proof length) before invoking the heavy validator.
+    /// 4. Validation -> wire mapping: see [`map_validation_error`].
+    ///
+    /// # Error mapping (acceptance criterion of #542)
+    ///
+    /// | `ValidationError`           | `tonic::Status`        | response `Error`             |
+    /// |-----------------------------|------------------------|------------------------------|
+    /// | `NullifierAlreadySpent`     | `FailedPrecondition`   | `NULLIFIER_ALREADY_SPENT`    |
+    /// | `UnknownInputVtxo`          | `NotFound`             | `NULLIFIER_ALREADY_SPENT` *  |
+    /// | `InvalidRangeProof`         | `InvalidArgument`      | `INVALID_RANGE_PROOF`        |
+    /// | `InvalidBalanceProof`       | `InvalidArgument`      | `INVALID_BALANCE_PROOF`      |
+    /// | `MalformedOutput`           | `InvalidArgument`      | `MALFORMED_OUTPUT`           |
+    /// | `FeeBelowMinimum`           | `FailedPrecondition`   | `FEE_TOO_LOW`                |
+    /// | `FeeAboveOperatorCap`       | `FailedPrecondition`   | `FEE_TOO_LOW` *              |
+    /// | `SchemaVersionMismatch`     | `InvalidArgument`      | `SCHEMA_VERSION_MISMATCH`    |
+    /// | `NotImplemented` (#538 wip) | `Unimplemented`        | `ERROR_UNSPECIFIED`          |
+    ///
+    /// `*` The wire enum is exhaustive for this milestone. Variants flagged
+    /// `*` are mapped to the closest existing wire code; future expansions of
+    /// the proto enum (#537 follow-ups) can introduce dedicated codes without
+    /// changing the gRPC `Status` mapping above.
     async fn submit_confidential_transaction(
         &self,
-        _request: Request<SubmitConfidentialTransactionRequest>,
+        request: Request<SubmitConfidentialTransactionRequest>,
     ) -> Result<Response<SubmitConfidentialTransactionResponse>, Status> {
-        Err(Status::unimplemented(
-            "SubmitConfidentialTransaction is defined in proto but not yet implemented \
-             (handler tracked in #542, validation in #538)",
-        ))
+        // 1. Auth: reject placeholder/dev identity. The macaroon scheme + the
+        //    permission scope (`Write`) are enforced by the gRPC interceptor
+        //    before this fn runs; here we additionally insist on a *real*
+        //    authenticated user to keep the confidential surface conservative.
+        let _user = super::middleware::require_authenticated_user(&request)?;
+
+        // 2. Backpressure: try to acquire an in-flight slot. We use
+        //    `try_acquire_owned` so a flooded server doesn't block the caller
+        //    indefinitely — clients should see `RESOURCE_EXHAUSTED` and back
+        //    off, matching `ApiError::RateLimited` semantics.
+        let _permit = self
+            .confidential_submit_inflight
+            .clone()
+            .try_acquire_owned()
+            .map_err(|_| {
+                warn!("SubmitConfidentialTransaction: in-flight cap reached");
+                Status::resource_exhausted(
+                    "confidential submission rate limit tripped — retry with backoff",
+                )
+            })?;
+
+        let req = request.into_inner();
+        let tx = req
+            .transaction
+            .ok_or_else(|| Status::invalid_argument("transaction is required"))?;
+
+        info!(
+            nullifier_count = tx.nullifiers.len(),
+            output_count = tx.outputs.len(),
+            fee_amount = tx.fee_amount,
+            schema_version = tx.schema_version,
+            "ArkService::SubmitConfidentialTransaction called"
+        );
+
+        // 3. Cheap structural checks before the heavy validator.
+        //    Anything caught here is a `MALFORMED_OUTPUT` rejection on the
+        //    wire (and `InvalidArgument` on the gRPC status).
+        let view = match shape_check_and_into_view(tx) {
+            Ok(v) => v,
+            Err(msg) => return Ok(Response::new(malformed_output_response(msg))),
+        };
+
+        // 4. Heavy validation. Currently this is `dark_core::confidential_validation`'s
+        //    stub which always returns `NotImplemented`; #538 fills it in.
+        match dark_core::validate_confidential_transaction(view).await {
+            Ok(validated) => {
+                info!(ark_txid = %validated.ark_txid, "SubmitConfidentialTransaction: accepted");
+                Ok(Response::new(SubmitConfidentialTransactionResponse {
+                    accepted: true,
+                    error: SubmitConfidentialError::Unspecified as i32,
+                    error_message: String::new(),
+                    ark_txid: validated.ark_txid,
+                }))
+            }
+            Err(e) => Err(map_validation_error(e)),
+        }
     }
 
     async fn finalize_tx(
@@ -3313,6 +3465,203 @@ fn parse_asset_groups(
     }
 }
 
+// =====================================================================
+// Confidential-tx helpers (#542)
+// =====================================================================
+
+/// Re-export for ergonomic use in this module.
+use crate::proto::ark_v1::submit_confidential_transaction_response::Error as SubmitConfidentialError;
+
+/// Canonical lengths for the confidential primitives carried on the wire.
+/// These mirror the bytes-level invariants documented in
+/// `proto/ark/v1/confidential.proto` and `confidential_tx.proto`.
+const NULLIFIER_LEN: usize = 32;
+const PEDERSEN_COMMITMENT_LEN: usize = 33;
+const COMPRESSED_PUBKEY_LEN: usize = 33;
+const BALANCE_PROOF_LEN: usize = 65;
+
+/// Cheap, length-only structural checks on a `ConfidentialTransaction` request.
+///
+/// Anything that fails here is a `MALFORMED_OUTPUT` rejection (the wire enum
+/// has no dedicated `MALFORMED_INPUT` variant). The check is intentionally
+/// limited to length / presence: cryptographic / semantic checks belong in
+/// `dark_core::validate_confidential_transaction` (#538).
+fn shape_check_and_into_view(
+    tx: crate::proto::ark_v1::ConfidentialTransaction,
+) -> Result<dark_core::ConfidentialTxView, String> {
+    if tx.nullifiers.is_empty() {
+        return Err("transaction must have at least one nullifier".into());
+    }
+    if tx.outputs.is_empty() {
+        return Err("transaction must have at least one output".into());
+    }
+
+    // Inputs: every nullifier must be exactly 32 bytes.
+    let mut nullifiers: Vec<Vec<u8>> = Vec::with_capacity(tx.nullifiers.len());
+    for (i, n) in tx.nullifiers.into_iter().enumerate() {
+        if n.value.len() != NULLIFIER_LEN {
+            return Err(format!(
+                "nullifier[{i}] has invalid length {} (expected {NULLIFIER_LEN})",
+                n.value.len()
+            ));
+        }
+        nullifiers.push(n.value);
+    }
+
+    // Outputs: each carries a present commitment, present range proof, and
+    // 33-byte owner / ephemeral pubkeys.
+    let mut outputs: Vec<dark_core::ConfidentialOutputView> = Vec::with_capacity(tx.outputs.len());
+    for (i, o) in tx.outputs.into_iter().enumerate() {
+        let commitment = o
+            .commitment
+            .ok_or_else(|| format!("output[{i}] is missing commitment"))?;
+        if commitment.point.len() != PEDERSEN_COMMITMENT_LEN {
+            return Err(format!(
+                "output[{i}] commitment has invalid length {} (expected {PEDERSEN_COMMITMENT_LEN})",
+                commitment.point.len()
+            ));
+        }
+        let range_proof = o
+            .range_proof
+            .ok_or_else(|| format!("output[{i}] is missing range_proof"))?;
+        if range_proof.proof.is_empty() {
+            return Err(format!("output[{i}] range_proof is empty"));
+        }
+        if o.owner_pubkey.len() != COMPRESSED_PUBKEY_LEN {
+            return Err(format!(
+                "output[{i}] owner_pubkey has invalid length {} (expected {COMPRESSED_PUBKEY_LEN})",
+                o.owner_pubkey.len()
+            ));
+        }
+        if o.ephemeral_pubkey.len() != COMPRESSED_PUBKEY_LEN {
+            return Err(format!(
+                "output[{i}] ephemeral_pubkey has invalid length {} (expected {COMPRESSED_PUBKEY_LEN})",
+                o.ephemeral_pubkey.len()
+            ));
+        }
+        let memo = o.encrypted_memo.map(|m| m.ciphertext).unwrap_or_default();
+        outputs.push(dark_core::ConfidentialOutputView {
+            commitment: commitment.point,
+            range_proof: range_proof.proof,
+            owner_pubkey: o.owner_pubkey,
+            ephemeral_pubkey: o.ephemeral_pubkey,
+            encrypted_memo: memo,
+        });
+    }
+
+    // Balance proof: present and correct length.
+    let bp = tx
+        .balance_proof
+        .ok_or_else(|| "transaction is missing balance_proof".to_string())?;
+    if bp.sig.len() != BALANCE_PROOF_LEN {
+        return Err(format!(
+            "balance_proof has invalid length {} (expected {BALANCE_PROOF_LEN})",
+            bp.sig.len()
+        ));
+    }
+
+    Ok(dark_core::ConfidentialTxView {
+        nullifiers,
+        outputs,
+        balance_proof: bp.sig,
+        fee_amount: tx.fee_amount,
+        schema_version: tx.schema_version,
+    })
+}
+
+/// Build a `MALFORMED_OUTPUT` rejection response. We return this as a *successful*
+/// gRPC response (with `accepted == false`) for shape errors so clients get the
+/// structured wire enum back; the alternative — a bare `Status::invalid_argument`
+/// — would lose the rich `Error` enum tag.
+fn malformed_output_response(msg: String) -> SubmitConfidentialTransactionResponse {
+    warn!(error = %msg, "SubmitConfidentialTransaction: malformed output");
+    SubmitConfidentialTransactionResponse {
+        accepted: false,
+        error: SubmitConfidentialError::MalformedOutput as i32,
+        error_message: msg,
+        ark_txid: String::new(),
+    }
+}
+
+/// Map a `dark_core::ValidationError` to a `tonic::Status`. The mapping table
+/// is documented on [`ArkServiceTrait::submit_confidential_transaction`]; the
+/// match below is the source of truth and is exhaustive over the enum so the
+/// compiler will reject silent additions on the #538 side.
+///
+/// We attach the wire `Error` enum value as a metadata header so callers can
+/// recover the structured rejection reason even though we are returning a
+/// `Status` (which has no rich body). Header name `x-confidential-tx-error`
+/// is a server-private convention; clients SHOULD prefer interpreting the
+/// gRPC `Code` first and only fall back to this header if they need the wire
+/// enum.
+#[allow(clippy::result_large_err)]
+fn map_validation_error(e: dark_core::ValidationError) -> Status {
+    use dark_core::ValidationError as VE;
+
+    let (code, wire_error, message): (tonic::Code, SubmitConfidentialError, String) = match e {
+        VE::NullifierAlreadySpent => (
+            tonic::Code::FailedPrecondition,
+            SubmitConfidentialError::NullifierAlreadySpent,
+            "nullifier already spent".into(),
+        ),
+        VE::UnknownInputVtxo => (
+            tonic::Code::NotFound,
+            // The wire enum has no dedicated `UNKNOWN_INPUT_VTXO`; fold into
+            // `NULLIFIER_ALREADY_SPENT` because both indicate "this input is
+            // not a usable confidential VTXO". A future schema bump can
+            // introduce a dedicated variant without changing the gRPC code.
+            SubmitConfidentialError::NullifierAlreadySpent,
+            "unknown input VTXO".into(),
+        ),
+        VE::InvalidRangeProof => (
+            tonic::Code::InvalidArgument,
+            SubmitConfidentialError::InvalidRangeProof,
+            "invalid range proof".into(),
+        ),
+        VE::InvalidBalanceProof => (
+            tonic::Code::InvalidArgument,
+            SubmitConfidentialError::InvalidBalanceProof,
+            "invalid balance proof".into(),
+        ),
+        VE::MalformedOutput(why) => (
+            tonic::Code::InvalidArgument,
+            SubmitConfidentialError::MalformedOutput,
+            format!("malformed output: {why}"),
+        ),
+        VE::FeeBelowMinimum => (
+            tonic::Code::FailedPrecondition,
+            SubmitConfidentialError::FeeTooLow,
+            "fee below minimum".into(),
+        ),
+        VE::FeeAboveOperatorCap => (
+            tonic::Code::FailedPrecondition,
+            // Folded into FEE_TOO_LOW until the wire enum gains a dedicated cap variant.
+            SubmitConfidentialError::FeeTooLow,
+            "fee above operator cap".into(),
+        ),
+        VE::SchemaVersionMismatch => (
+            tonic::Code::InvalidArgument,
+            SubmitConfidentialError::SchemaVersionMismatch,
+            "schema version mismatch".into(),
+        ),
+        VE::NotImplemented => (
+            tonic::Code::Unimplemented,
+            // No wire variant for "not implemented"; UNSPECIFIED keeps the
+            // header self-consistent (clients can match on the gRPC code).
+            SubmitConfidentialError::Unspecified,
+            "validate_confidential_transaction not implemented yet (#538 in flight)".into(),
+        ),
+    };
+
+    let mut status = Status::new(code, message);
+    if let Ok(value) = (wire_error as i32).to_string().parse() {
+        status
+            .metadata_mut()
+            .insert("x-confidential-tx-error", value);
+    }
+    status
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -3423,5 +3772,265 @@ mod tests {
         } else {
             panic!("Expected heartbeat event");
         }
+    }
+
+    // ──────────────────────────────────────────────────────────────────
+    // Confidential-tx submission tests (#542)
+    // ──────────────────────────────────────────────────────────────────
+
+    use crate::proto::ark_v1::{
+        BalanceProof, ConfidentialTransaction, ConfidentialVtxoOutput, EncryptedMemo, Nullifier,
+        PedersenCommitment, RangeProof,
+    };
+
+    /// Build a structurally-valid `ConfidentialTransaction` (passes shape
+    /// check). The validator (#538) will still reject this once it lands —
+    /// but the *shape* check is what we're exercising here.
+    fn make_well_formed_tx() -> ConfidentialTransaction {
+        ConfidentialTransaction {
+            nullifiers: vec![Nullifier {
+                value: vec![0x11u8; NULLIFIER_LEN],
+            }],
+            outputs: vec![ConfidentialVtxoOutput {
+                commitment: Some(PedersenCommitment {
+                    point: vec![0x02u8; PEDERSEN_COMMITMENT_LEN],
+                }),
+                range_proof: Some(RangeProof {
+                    proof: vec![0xAA, 0xBB, 0xCC],
+                }),
+                owner_pubkey: vec![0x03u8; COMPRESSED_PUBKEY_LEN],
+                ephemeral_pubkey: vec![0x04u8; COMPRESSED_PUBKEY_LEN],
+                encrypted_memo: Some(EncryptedMemo { ciphertext: vec![] }),
+            }],
+            balance_proof: Some(BalanceProof {
+                sig: vec![0x55u8; BALANCE_PROOF_LEN],
+            }),
+            fee_amount: 100,
+            schema_version: 1,
+        }
+    }
+
+    #[test]
+    fn shape_check_accepts_well_formed_tx() {
+        let view = shape_check_and_into_view(make_well_formed_tx())
+            .expect("well-formed tx should pass shape check");
+        assert_eq!(view.nullifiers.len(), 1);
+        assert_eq!(view.outputs.len(), 1);
+        assert_eq!(view.balance_proof.len(), BALANCE_PROOF_LEN);
+        assert_eq!(view.fee_amount, 100);
+        assert_eq!(view.schema_version, 1);
+    }
+
+    #[test]
+    fn shape_check_rejects_empty_nullifiers() {
+        let mut tx = make_well_formed_tx();
+        tx.nullifiers.clear();
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("at least one nullifier"));
+    }
+
+    #[test]
+    fn shape_check_rejects_empty_outputs() {
+        let mut tx = make_well_formed_tx();
+        tx.outputs.clear();
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("at least one output"));
+    }
+
+    #[test]
+    fn shape_check_rejects_short_nullifier() {
+        let mut tx = make_well_formed_tx();
+        tx.nullifiers[0].value = vec![0x11u8; NULLIFIER_LEN - 1];
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("nullifier[0]"));
+        assert!(err.contains("invalid length"));
+    }
+
+    #[test]
+    fn shape_check_rejects_missing_commitment() {
+        let mut tx = make_well_formed_tx();
+        tx.outputs[0].commitment = None;
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("missing commitment"));
+    }
+
+    #[test]
+    fn shape_check_rejects_missing_range_proof() {
+        let mut tx = make_well_formed_tx();
+        tx.outputs[0].range_proof = None;
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("missing range_proof"));
+    }
+
+    #[test]
+    fn shape_check_rejects_empty_range_proof() {
+        let mut tx = make_well_formed_tx();
+        tx.outputs[0].range_proof.as_mut().unwrap().proof.clear();
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("range_proof is empty"));
+    }
+
+    #[test]
+    fn shape_check_rejects_short_owner_pubkey() {
+        let mut tx = make_well_formed_tx();
+        tx.outputs[0].owner_pubkey = vec![0x03u8; COMPRESSED_PUBKEY_LEN - 1];
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("owner_pubkey"));
+    }
+
+    #[test]
+    fn shape_check_rejects_short_ephemeral_pubkey() {
+        let mut tx = make_well_formed_tx();
+        tx.outputs[0].ephemeral_pubkey = vec![0x04u8; COMPRESSED_PUBKEY_LEN - 1];
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("ephemeral_pubkey"));
+    }
+
+    #[test]
+    fn shape_check_rejects_missing_balance_proof() {
+        let mut tx = make_well_formed_tx();
+        tx.balance_proof = None;
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("missing balance_proof"));
+    }
+
+    #[test]
+    fn shape_check_rejects_short_balance_proof() {
+        let mut tx = make_well_formed_tx();
+        tx.balance_proof.as_mut().unwrap().sig = vec![0x55u8; BALANCE_PROOF_LEN - 1];
+        let err = shape_check_and_into_view(tx).unwrap_err();
+        assert!(err.contains("balance_proof"));
+        assert!(err.contains("invalid length"));
+    }
+
+    #[test]
+    fn malformed_output_response_marks_rejected() {
+        let resp = malformed_output_response("bad output 0".into());
+        assert!(!resp.accepted);
+        assert_eq!(resp.error, SubmitConfidentialError::MalformedOutput as i32);
+        assert!(resp.error_message.contains("bad output 0"));
+        assert!(resp.ark_txid.is_empty());
+    }
+
+    /// The core acceptance criterion of #542: every `ValidationError` variant
+    /// maps to a *distinct, documented* gRPC status code, and carries the
+    /// matching wire-error enum tag in the metadata header. Locking these
+    /// down here prevents silent regressions when #538 lands and starts
+    /// emitting these variants for real.
+    #[test]
+    fn validation_error_to_status_mapping_is_exhaustive_and_distinct() {
+        use dark_core::ValidationError as VE;
+
+        let cases: Vec<(VE, tonic::Code, SubmitConfidentialError)> = vec![
+            (
+                VE::NullifierAlreadySpent,
+                tonic::Code::FailedPrecondition,
+                SubmitConfidentialError::NullifierAlreadySpent,
+            ),
+            (
+                VE::UnknownInputVtxo,
+                tonic::Code::NotFound,
+                SubmitConfidentialError::NullifierAlreadySpent,
+            ),
+            (
+                VE::InvalidRangeProof,
+                tonic::Code::InvalidArgument,
+                SubmitConfidentialError::InvalidRangeProof,
+            ),
+            (
+                VE::InvalidBalanceProof,
+                tonic::Code::InvalidArgument,
+                SubmitConfidentialError::InvalidBalanceProof,
+            ),
+            (
+                VE::MalformedOutput("test".into()),
+                tonic::Code::InvalidArgument,
+                SubmitConfidentialError::MalformedOutput,
+            ),
+            (
+                VE::FeeBelowMinimum,
+                tonic::Code::FailedPrecondition,
+                SubmitConfidentialError::FeeTooLow,
+            ),
+            (
+                VE::FeeAboveOperatorCap,
+                tonic::Code::FailedPrecondition,
+                SubmitConfidentialError::FeeTooLow,
+            ),
+            (
+                VE::SchemaVersionMismatch,
+                tonic::Code::InvalidArgument,
+                SubmitConfidentialError::SchemaVersionMismatch,
+            ),
+            (
+                VE::NotImplemented,
+                tonic::Code::Unimplemented,
+                SubmitConfidentialError::Unspecified,
+            ),
+        ];
+
+        for (ve, expected_code, expected_wire) in cases {
+            let status = map_validation_error(ve.clone());
+            assert_eq!(
+                status.code(),
+                expected_code,
+                "wrong gRPC code for {ve:?}: got {:?}",
+                status.code()
+            );
+            // The wire-error enum tag is attached as metadata — verify it.
+            let header = status
+                .metadata()
+                .get("x-confidential-tx-error")
+                .unwrap_or_else(|| panic!("missing wire-error header for {ve:?}"))
+                .to_str()
+                .unwrap()
+                .parse::<i32>()
+                .unwrap();
+            assert_eq!(
+                header, expected_wire as i32,
+                "wrong wire-error tag for {ve:?}"
+            );
+        }
+    }
+
+    /// Per-variant assertion: every documented `ValidationError` produces the
+    /// gRPC `Code` advertised in the doc-comment table on
+    /// `submit_confidential_transaction`. Note that **the wire enum is
+    /// deliberately coarser** than `ValidationError` — `FeeBelowMinimum` and
+    /// `FeeAboveOperatorCap` both fold into `FEE_TOO_LOW`; `UnknownInputVtxo`
+    /// folds into `NULLIFIER_ALREADY_SPENT` — and clients are expected to
+    /// distinguish these cases via the gRPC `Code` (`NotFound` vs.
+    /// `FailedPrecondition`) rather than via the wire enum tag alone. So the
+    /// `(code, tag)` pair is *not* required to be unique across variants;
+    /// the (code, message-prefix) pair is. We assert that here.
+    #[test]
+    fn each_validation_variant_yields_distinguishable_status() {
+        use dark_core::ValidationError as VE;
+        let variants = [
+            VE::NullifierAlreadySpent,
+            VE::UnknownInputVtxo,
+            VE::InvalidRangeProof,
+            VE::InvalidBalanceProof,
+            VE::MalformedOutput("x".into()),
+            VE::FeeBelowMinimum,
+            VE::FeeAboveOperatorCap,
+            VE::SchemaVersionMismatch,
+            VE::NotImplemented,
+        ];
+
+        // (code, message) is unique across variants. Message text comes from
+        // the variant-specific `match` arm in `map_validation_error`.
+        let mut seen: std::collections::HashSet<(i32, String)> = std::collections::HashSet::new();
+        for v in &variants {
+            let s = map_validation_error(v.clone());
+            let key = (s.code() as i32, s.message().to_string());
+            assert!(
+                seen.insert(key.clone()),
+                "duplicate (code, message) pair for {v:?}: ({}, {})",
+                key.0,
+                key.1
+            );
+        }
+        assert_eq!(seen.len(), variants.len());
     }
 }

--- a/crates/dark-api/tests/grpc_integration.rs
+++ b/crates/dark-api/tests/grpc_integration.rs
@@ -1291,3 +1291,246 @@ fn test_tls_config_none_uses_plaintext() {
     // Server creation should succeed with plaintext config
     // (actual server start tested via start_ark_server above)
 }
+
+// ─── SubmitConfidentialTransaction tests (#542) ──────────────────────
+//
+// These exercise the confidential-tx submit handler end-to-end. We bypass
+// the gRPC client and call the trait method directly because:
+//   - we need to inject an `AuthenticatedUser` into request extensions to
+//     test the "auth-pass" path (the gRPC client + interceptor-less test
+//     server combination cannot do this);
+//   - the rate-limit-tripped test needs to construct the service with a
+//     small `confidential_submit_inflight` cap, which is only available via
+//     the test-only `new_with_inflight_cap` constructor.
+
+mod confidential_submit_tests {
+    use super::*;
+    use dark_api::auth::TokenPermissions;
+    use dark_api::grpc::middleware::AuthenticatedUser;
+    use dark_api::proto::ark_v1::ark_service_server::ArkService as _;
+    use dark_api::proto::ark_v1::submit_confidential_transaction_response::Error as SubError;
+    use dark_api::proto::ark_v1::{
+        BalanceProof, ConfidentialTransaction, ConfidentialVtxoOutput, EncryptedMemo, Nullifier,
+        PedersenCommitment, RangeProof, SubmitConfidentialTransactionRequest,
+    };
+
+    /// Build a structurally-valid `ConfidentialTransaction` (passes the
+    /// shape-check inside the handler). The validator (#538 stub) will then
+    /// reject with `NotImplemented` -> the gRPC layer maps that to
+    /// `Status::unimplemented`. That's the expected response shape on the
+    /// happy path until #538 lands.
+    fn well_formed_tx() -> ConfidentialTransaction {
+        ConfidentialTransaction {
+            nullifiers: vec![Nullifier {
+                value: vec![0x11u8; 32],
+            }],
+            outputs: vec![ConfidentialVtxoOutput {
+                commitment: Some(PedersenCommitment {
+                    point: vec![0x02u8; 33],
+                }),
+                range_proof: Some(RangeProof {
+                    proof: vec![0xAA, 0xBB, 0xCC],
+                }),
+                owner_pubkey: vec![0x03u8; 33],
+                ephemeral_pubkey: vec![0x04u8; 33],
+                encrypted_memo: Some(EncryptedMemo { ciphertext: vec![] }),
+            }],
+            balance_proof: Some(BalanceProof {
+                sig: vec![0x55u8; 65],
+            }),
+            fee_amount: 100,
+            schema_version: 1,
+        }
+    }
+
+    /// Build a fresh `ArkGrpcService` for testing. Uses the same mocks as the
+    /// rest of this file. `inflight_cap` controls the confidential-submit
+    /// in-flight slot count; pass `usize::MAX` for "no rate limit".
+    fn make_service(inflight_cap: usize) -> ArkGrpcService {
+        let core = build_test_core();
+        let broker = Arc::new(dark_api::EventBroker::new(64));
+        let tx_broker = Arc::new(dark_api::TransactionEventBroker::new(64));
+        let offchain_tx_repo: Arc<dyn OffchainTxRepository> = Arc::new(MockOffchainTxRepo::new());
+        ArkGrpcService::new_with_inflight_cap(
+            core,
+            Arc::new(MockRoundRepo::empty()),
+            broker,
+            tx_broker,
+            offchain_tx_repo,
+            inflight_cap,
+        )
+    }
+
+    /// Helper: attach a real `AuthenticatedUser` to a request, simulating
+    /// what the `AuthInterceptor` does on the wire path. Returning the
+    /// request lets the test thread it through `submit_confidential_transaction`.
+    fn with_auth<T>(mut req: tonic::Request<T>) -> tonic::Request<T> {
+        let pubkey = XOnlyPublicKey::from_slice(&[0x02u8; 32]).unwrap();
+        req.extensions_mut()
+            .insert(AuthenticatedUser::new(pubkey, TokenPermissions::write()));
+        req
+    }
+
+    #[tokio::test]
+    async fn auth_fail_returns_unauthenticated() {
+        // No auth user attached — the interceptor would have rejected, but
+        // the trait method also has its own `require_authenticated_user`
+        // guard, so we expect `Unauthenticated` from a direct call too.
+        let svc = make_service(1024);
+        let req = tonic::Request::new(SubmitConfidentialTransactionRequest {
+            transaction: Some(well_formed_tx()),
+        });
+
+        let err = svc
+            .submit_confidential_transaction(req)
+            .await
+            .expect_err("submit should fail without auth");
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test]
+    async fn auth_fail_placeholder_user_rejected() {
+        // Dev-mode placeholder identity must NOT be allowed for confidential
+        // submissions — they materially modify state.
+        let svc = make_service(1024);
+        let mut req = tonic::Request::new(SubmitConfidentialTransactionRequest {
+            transaction: Some(well_formed_tx()),
+        });
+        req.extensions_mut()
+            .insert(AuthenticatedUser::placeholder());
+
+        let err = svc
+            .submit_confidential_transaction(req)
+            .await
+            .expect_err("placeholder user should be rejected");
+        assert_eq!(err.code(), tonic::Code::Unauthenticated);
+    }
+
+    #[tokio::test]
+    async fn auth_pass_with_well_formed_tx_reaches_validator() {
+        // With a real authenticated user the request gets past auth and
+        // backpressure, the shape check accepts the well-formed tx, and
+        // validation reaches the `dark_core` stub which returns
+        // `NotImplemented` -> `Status::unimplemented` on the wire.
+        //
+        // Once #538 lands this test should be flipped to assert
+        // `accepted == true`. The `Unimplemented` assertion here is a
+        // deliberate pin: it proves the wiring (auth + rate-limit + shape +
+        // dispatch into core) is intact end-to-end without depending on
+        // #538's body.
+        let svc = make_service(1024);
+        let req = with_auth(tonic::Request::new(SubmitConfidentialTransactionRequest {
+            transaction: Some(well_formed_tx()),
+        }));
+
+        let err = svc
+            .submit_confidential_transaction(req)
+            .await
+            .expect_err("validator stub returns NotImplemented today");
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+        // The metadata header carries the structured wire-error tag.
+        let tag = err
+            .metadata()
+            .get("x-confidential-tx-error")
+            .expect("wire-error metadata header must be set")
+            .to_str()
+            .unwrap()
+            .parse::<i32>()
+            .unwrap();
+        // `NotImplemented` is folded into `ERROR_UNSPECIFIED` because the
+        // wire enum has no dedicated "stub" variant.
+        assert_eq!(tag, SubError::Unspecified as i32);
+    }
+
+    #[tokio::test]
+    async fn auth_pass_missing_transaction_field_is_invalid() {
+        // Empty request (no `transaction` field) -> InvalidArgument, after
+        // auth + backpressure pass.
+        let svc = make_service(1024);
+        let req = with_auth(tonic::Request::new(SubmitConfidentialTransactionRequest {
+            transaction: None,
+        }));
+
+        let err = svc
+            .submit_confidential_transaction(req)
+            .await
+            .expect_err("missing transaction field must be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn auth_pass_malformed_output_returns_structured_response() {
+        // Malformed payloads come back as a *successful* gRPC response with
+        // `accepted == false` and `error == MALFORMED_OUTPUT` so the client
+        // can recover the structured wire-error enum tag (a bare
+        // `Status::invalid_argument` would lose this).
+        let svc = make_service(1024);
+        let mut tx = well_formed_tx();
+        tx.outputs[0].commitment = None; // malformed
+        let req = with_auth(tonic::Request::new(SubmitConfidentialTransactionRequest {
+            transaction: Some(tx),
+        }));
+
+        let resp = svc
+            .submit_confidential_transaction(req)
+            .await
+            .expect("malformed output yields Ok response with accepted=false")
+            .into_inner();
+        assert!(!resp.accepted);
+        assert_eq!(resp.error, SubError::MalformedOutput as i32);
+        assert!(resp.error_message.contains("missing commitment"));
+        assert!(resp.ark_txid.is_empty());
+    }
+
+    #[tokio::test]
+    async fn rate_limit_tripped_returns_resource_exhausted() {
+        // Pin the cap to 1, hold the only permit by spawning a request that
+        // will block in the `dark_core` stub (it returns `NotImplemented`
+        // synchronously, so we can't actually block — instead we manually
+        // acquire the permit on the inner semaphore and drop it after the
+        // assertion). This proves: when capacity is exhausted, requests
+        // surface `Status::resource_exhausted` and DO NOT proceed to
+        // validation.
+        let svc = make_service(1);
+
+        // Drain the only permit. We use `try_acquire_owned` so we hold a
+        // permit independent of any submit call.
+        let permit = svc
+            .__test_inflight_semaphore()
+            .try_acquire_owned()
+            .expect("test seam must yield a permit");
+
+        let req = with_auth(tonic::Request::new(SubmitConfidentialTransactionRequest {
+            transaction: Some(well_formed_tx()),
+        }));
+        let err = svc
+            .submit_confidential_transaction(req)
+            .await
+            .expect_err("submit must trip the rate limit when capacity is 0");
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+        assert!(err.message().to_lowercase().contains("rate limit"));
+
+        // Release the permit so other tests sharing the runtime can proceed.
+        drop(permit);
+    }
+
+    #[tokio::test]
+    async fn rate_limit_recovers_after_permit_drop() {
+        // After a rate-limit trip we should be able to retry once a permit
+        // becomes available. Pin cap to 1, take + drop the permit, and then
+        // a fresh submit must reach the validator (and surface
+        // `Unimplemented` from the #538 stub).
+        let svc = make_service(1);
+        let permit = svc.__test_inflight_semaphore().try_acquire_owned().unwrap();
+        drop(permit);
+
+        let req = with_auth(tonic::Request::new(SubmitConfidentialTransactionRequest {
+            transaction: Some(well_formed_tx()),
+        }));
+        let err = svc
+            .submit_confidential_transaction(req)
+            .await
+            .expect_err("after permit drop, validator stub still rejects");
+        assert_eq!(err.code(), tonic::Code::Unimplemented);
+    }
+}

--- a/crates/dark-core/src/confidential_validation.rs
+++ b/crates/dark-core/src/confidential_validation.rs
@@ -1,0 +1,223 @@
+//! Validation entry-point for confidential off-chain transactions.
+//!
+//! # Status
+//!
+//! This module is a *stub* for the deliverable of issue **#538**. The real
+//! body — verifying input nullifiers against the unique-nullifier set,
+//! verifying every output's range proof, verifying the balance proof, and
+//! enforcing fee policy — is being implemented on the
+//! `feat/confidential-tx-validation` branch and is not on `tmp/cv-m3-base`
+//! yet.
+//!
+//! The gRPC handler added by issue **#542** (`feat/grpc-submit-confidential-tx`)
+//! depends on a stable signature for [`validate_confidential_transaction`] and
+//! on the [`ValidationError`] enum so the wire-error mapping can be wired up
+//! and tested *before* #538 lands. When #538 lands it MUST keep the same
+//! function signature and the same `ValidationError` variants — additive
+//! changes (more variants, more context fields) are fine, but removing or
+//! renaming variants would force #542 to be re-coded.
+//!
+//! # Why a stub here, not in `dark-confidential`?
+//!
+//! `dark-core` deliberately does not depend on `dark-confidential` (see the
+//! note on `domain::vtxo::ConfidentialPayload`). The validation entry-point
+//! is the *coordinator* — it invokes range-proof / balance-proof verifiers
+//! that ultimately live in `dark-confidential`, but it owns the cross-cutting
+//! checks (nullifier-set lookups, fee policy, schema version) that need access
+//! to `dark-core`'s ports / repositories. So the *signature* belongs in
+//! `dark-core`; the cryptographic primitives it eventually calls into stay in
+//! `dark-confidential`.
+//!
+//! The stub returns `ValidationError::NotImplemented` so callers exercising the
+//! happy path will visibly fail (rather than silently appear to succeed) until
+//! #538 lands.
+
+use thiserror::Error;
+
+/// Wire shape of a confidential transaction as observed by the validator.
+///
+/// This intentionally does **not** import the protobuf types — `dark-core`
+/// must remain free of `dark-api`'s codegen — and instead carries the raw
+/// canonical byte slices that were already validated for length by the gRPC
+/// handler. #538 will likely refine this into a richer typed struct; until
+/// then the fields below are sufficient for the handler to populate.
+///
+/// # Field semantics
+///
+/// - `nullifiers`: 32-byte HMAC-SHA256 outputs (per ADR-0002). The validator
+///   will look each one up in the unique-nullifier set.
+/// - `outputs`: each entry carries the Pedersen commitment + range-proof
+///   bytes the gRPC handler received. Decoding lives in #538.
+/// - `balance_proof`: opaque bytes per `BalanceProof.sig`.
+/// - `fee_amount` / `schema_version`: copied verbatim from the request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfidentialTxView {
+    /// Input nullifiers in submission order.
+    pub nullifiers: Vec<Vec<u8>>,
+    /// Output range-proof + commitment payloads in submission order.
+    pub outputs: Vec<ConfidentialOutputView>,
+    /// Opaque balance-proof bytes.
+    pub balance_proof: Vec<u8>,
+    /// Plaintext fee in satoshis.
+    pub fee_amount: u64,
+    /// Wire-schema version (per `confidential_tx.proto`).
+    pub schema_version: u32,
+}
+
+/// One output as observed by the validator. See [`ConfidentialTxView`] for the
+/// rationale around using raw bytes.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfidentialOutputView {
+    /// 33-byte Pedersen commitment.
+    pub commitment: Vec<u8>,
+    /// Opaque range-proof bytes.
+    pub range_proof: Vec<u8>,
+    /// 33-byte compressed owner pubkey.
+    pub owner_pubkey: Vec<u8>,
+    /// 33-byte compressed ephemeral (ECDH) pubkey.
+    pub ephemeral_pubkey: Vec<u8>,
+    /// Optional encrypted-memo ciphertext. Empty means "no memo".
+    pub encrypted_memo: Vec<u8>,
+}
+
+/// A confidential transaction that has passed validation, ready to be persisted
+/// by the higher-level handler (nullifier insertion, output VTXO creation,
+/// event emission). #538 will fill this in; for the stub it carries an opaque
+/// canonical txid string only.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ValidatedTx {
+    /// Server-assigned ark transaction ID (hex string), derived deterministically
+    /// from the input commitments + outputs by #538.
+    pub ark_txid: String,
+}
+
+/// Reasons a confidential transaction can fail validation.
+///
+/// Variants map 1:1 to the wire `Error` enum in
+/// `proto/ark/v1/confidential_tx.proto`. The mapping is exhaustive and is
+/// pinned by [`crate::confidential_validation`] tests in the dark-api crate.
+///
+/// `NotImplemented` is the *only* variant that is not present on the wire — it
+/// is returned by the stub here and is mapped to `Status::unimplemented` by
+/// the handler. Once #538 lands, `NotImplemented` will only appear if a code
+/// path is wired to the validator before its real body exists; production
+/// builds will never see it.
+///
+/// Extending this enum: any new variant added by #538 MUST be additive, and
+/// the gRPC handler in `dark-api` MUST be updated in the same change to map
+/// the new variant to a `tonic::Status` code. CI should fail on a missing arm
+/// because the match in the handler is exhaustive.
+#[derive(Debug, Error, Clone, PartialEq, Eq)]
+pub enum ValidationError {
+    /// One of the input nullifiers was already present in the unique-nullifier
+    /// set (or appeared more than once in the request).
+    #[error("nullifier already spent")]
+    NullifierAlreadySpent,
+
+    /// Server has no record of the VTXO referenced by an input nullifier.
+    /// Distinct from `NullifierAlreadySpent`: this is "we never saw this VTXO",
+    /// while that one is "we saw it and it was spent already".
+    #[error("unknown input VTXO")]
+    UnknownInputVtxo,
+
+    /// At least one output range proof failed verification.
+    #[error("invalid range proof")]
+    InvalidRangeProof,
+
+    /// The balance proof failed verification (Σinputs != Σoutputs + fee).
+    #[error("invalid balance proof")]
+    InvalidBalanceProof,
+
+    /// An output had structurally invalid contents (wrong commitment length,
+    /// missing required field, malformed pubkey, etc.). The gRPC handler does
+    /// length-shape checks itself and only forwards semantic violations here.
+    #[error("malformed output: {0}")]
+    MalformedOutput(String),
+
+    /// Fee was below the operator-configured floor (#536 / ADR-0004).
+    #[error("fee below minimum")]
+    FeeBelowMinimum,
+
+    /// Fee exceeded the operator-configured cap. The cap exists to prevent a
+    /// misbehaving client from burning an excessive fee on a single tx.
+    #[error("fee above operator cap")]
+    FeeAboveOperatorCap,
+
+    /// `schema_version` not in the server's supported set.
+    #[error("schema version mismatch")]
+    SchemaVersionMismatch,
+
+    /// Stub-only: the real validator has not landed yet (#538 in flight).
+    /// Mapped to `Status::unimplemented` by the gRPC handler.
+    #[error("validate_confidential_transaction not implemented (#538 in flight)")]
+    NotImplemented,
+}
+
+/// Validate a confidential transaction.
+///
+/// # TODO(#538)
+///
+/// Replace the body with the real verifier:
+///
+/// 1. Reject duplicate / already-spent nullifiers (look up in the unique
+///    nullifier set; insertion happens later after persistence).
+/// 2. Fetch input VTXOs by nullifier and assert each is `Some` -> otherwise
+///    `UnknownInputVtxo`.
+/// 3. For each output, verify the Bulletproofs range proof against the
+///    Pedersen commitment.
+/// 4. Verify the Schnorr-like balance proof: Σ(inputs) == Σ(outputs) + fee*H.
+/// 5. Enforce `MIN_FEE <= fee_amount <= OPERATOR_FEE_CAP`. The fee floor is
+///    served by `dark-fee-manager` (#543, separate issue).
+/// 6. Reject `schema_version` not in the supported set.
+/// 7. On success, derive the canonical `ark_txid` and return `ValidatedTx`.
+///
+/// Until that lands, the stub returns `ValidationError::NotImplemented` so
+/// callers crash visibly.
+pub async fn validate_confidential_transaction(
+    _tx: ConfidentialTxView,
+) -> Result<ValidatedTx, ValidationError> {
+    // #538 placeholder. See module-level docs and the #538 TODO above.
+    Err(ValidationError::NotImplemented)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[tokio::test]
+    async fn stub_returns_not_implemented() {
+        // Until #538 lands, the validator must reject every input with
+        // `NotImplemented`. This guards against the stub being silently
+        // replaced by a no-op that pretends to accept everything.
+        let view = ConfidentialTxView {
+            nullifiers: vec![],
+            outputs: vec![],
+            balance_proof: vec![],
+            fee_amount: 0,
+            schema_version: 1,
+        };
+        let err = validate_confidential_transaction(view).await.unwrap_err();
+        assert_eq!(err, ValidationError::NotImplemented);
+    }
+
+    #[test]
+    fn validation_error_variants_are_distinct() {
+        // Sanity-check: every variant has a distinct `Display` so log scrapers
+        // and tests can pattern-match on the message safely.
+        let msgs: Vec<String> = vec![
+            ValidationError::NullifierAlreadySpent.to_string(),
+            ValidationError::UnknownInputVtxo.to_string(),
+            ValidationError::InvalidRangeProof.to_string(),
+            ValidationError::InvalidBalanceProof.to_string(),
+            ValidationError::MalformedOutput("x".into()).to_string(),
+            ValidationError::FeeBelowMinimum.to_string(),
+            ValidationError::FeeAboveOperatorCap.to_string(),
+            ValidationError::SchemaVersionMismatch.to_string(),
+            ValidationError::NotImplemented.to_string(),
+        ];
+        let mut sorted = msgs.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(msgs.len(), sorted.len(), "duplicate Display strings");
+    }
+}

--- a/crates/dark-core/src/lib.rs
+++ b/crates/dark-core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod boarding;
 pub mod compliance;
 pub mod confidential_sweep;
 pub mod confidential_tx_validation;
+pub mod confidential_validation;
 pub mod cosigning;
 pub mod domain;
 pub mod error;
@@ -49,6 +50,10 @@ pub use boarding::{BoardingConfig, BoardingService, BoardingStats};
 pub use compliance::{
     prove_source_chain, verify_source_chain, ProofCommitmentIndex, SourceOfFundsProof,
     SourceProofError, SourceProofHop,
+};
+pub use confidential_validation::{
+    validate_confidential_transaction, ConfidentialOutputView, ConfidentialTxView, ValidatedTx,
+    ValidationError,
 };
 pub use cosigning::{
     CosigningManager, CosigningSession, CosigningState, ForfeitTxEntry, ForfeitTxManager,


### PR DESCRIPTION
- **docs(adr): define confidential transaction fee handling (#536)**
- **feat(dark-live-store): add NullifierSet for confidential VTXO spent set (#534)**
- **feat(proto): add confidential transaction RPC schema (#537)**
- **feat(dark-core): add round Merkle tree with confidential leaf support (#540)**
- **feat(dark-api): wire SubmitConfidentialTransaction gRPC handler (#542)**
