### PR TITLE
feat/fee manager confidential integration

### DIFF
--- a/crates/dark-core/src/domain/fee.rs
+++ b/crates/dark-core/src/domain/fee.rs
@@ -55,6 +55,31 @@ impl FeeProgram {
             + self.offchain_output_fee * offchain_outputs as u64
             + self.onchain_output_fee * onchain_outputs as u64
     }
+
+    /// Calculate the minimum fee for a confidential transaction from
+    /// nullifier (input) and output-commitment counts only.
+    ///
+    /// Per ADR-0004 §"Privacy boundary for CEL", confidential transactions
+    /// expose only counts to the operator — input/output **amounts** live
+    /// inside Pedersen commitments and are unavailable. CEL therefore scores
+    /// confidential intents purely on shape:
+    ///
+    /// ```text
+    /// fee = base_fee
+    ///     + offchain_input_fee  × inputs
+    ///     + offchain_output_fee × outputs
+    /// ```
+    ///
+    /// Confidential VTXOs are off-chain by construction, so onchain-input
+    /// and onchain-output rates are not consulted here. Operators wanting
+    /// finer-grained pricing for confidential traffic configure the
+    /// `offchain_*_fee` rates directly (the same parameters that already
+    /// price transparent off-chain VTXOs).
+    pub fn calculate_confidential_intent_fee(&self, inputs: u32, outputs: u32) -> u64 {
+        self.base_fee
+            + self.offchain_input_fee * inputs as u64
+            + self.offchain_output_fee * outputs as u64
+    }
 }
 
 impl Default for FeeProgram {
@@ -131,5 +156,51 @@ mod tests {
         let json = serde_json::to_string(&fp).unwrap();
         let fp2: FeeProgram = serde_json::from_str(&json).unwrap();
         assert_eq!(fp, fp2);
+    }
+
+    #[test]
+    fn test_calculate_confidential_intent_fee_zero_program() {
+        let fp = FeeProgram::default_zero();
+        assert_eq!(fp.calculate_confidential_intent_fee(2, 3), 0);
+    }
+
+    #[test]
+    fn test_calculate_confidential_intent_fee_base_only() {
+        let fp = FeeProgram {
+            base_fee: 100,
+            ..FeeProgram::default_zero()
+        };
+        assert_eq!(fp.calculate_confidential_intent_fee(0, 0), 100);
+        assert_eq!(fp.calculate_confidential_intent_fee(5, 5), 100);
+    }
+
+    #[test]
+    fn test_calculate_confidential_intent_fee_uses_offchain_rates() {
+        // Confidential VTXOs are off-chain only; onchain rates MUST be ignored.
+        let fp = FeeProgram {
+            offchain_input_fee: 10,
+            onchain_input_fee: 999_999, // sentinel: must not be used
+            offchain_output_fee: 30,
+            onchain_output_fee: 999_999, // sentinel: must not be used
+            base_fee: 100,
+        };
+        // 100 + 10*2 + 30*3 = 100 + 20 + 90 = 210
+        assert_eq!(fp.calculate_confidential_intent_fee(2, 3), 210);
+    }
+
+    #[test]
+    fn test_calculate_confidential_intent_fee_scales_with_counts() {
+        let fp = FeeProgram {
+            offchain_input_fee: 5,
+            offchain_output_fee: 7,
+            base_fee: 10,
+            ..FeeProgram::default_zero()
+        };
+        let fee_1 = fp.calculate_confidential_intent_fee(1, 1);
+        let fee_5 = fp.calculate_confidential_intent_fee(5, 5);
+        assert!(fee_5 > fee_1);
+        // 10 + 5*1 + 7*1 = 22; 10 + 5*5 + 7*5 = 70
+        assert_eq!(fee_1, 22);
+        assert_eq!(fee_5, 70);
     }
 }

--- a/crates/dark-core/src/ports.rs
+++ b/crates/dark-core/src/ports.rs
@@ -684,6 +684,29 @@ pub trait FeeManagerService: Send + Sync {
             + vtxo_inputs.len() as u32;
         self.round_fee(total).await
     }
+
+    /// Calculate the minimum acceptable fee for a confidential transaction in
+    /// satoshis.
+    ///
+    /// Per ADR-0004 §"Constraints on #543", this is the single `u64`-returning
+    /// method the validator (#538) calls before invoking
+    /// `dark_confidential::balance_proof::verify_balance`. The implementation
+    /// MUST receive only confidential-tx counts (nullifier count = `inputs`,
+    /// output-commitment count = `outputs`); plaintext input/output amounts
+    /// are NOT available on the confidential side and MUST NOT be plumbed
+    /// through.
+    ///
+    /// Each backend (Static / RPC / Weight / CEL) collapses to a single `u64`
+    /// minimum fee here; how it arrived at that number (flat-rate, fee-rate ×
+    /// weight, CEL counts) is opaque to the caller.
+    async fn minimum_fee_confidential(&self, inputs: usize, outputs: usize) -> ArkResult<u64> {
+        // Default: fall back to round_fee with the input+output count. This
+        // is intentionally conservative — backends that know the confidential
+        // weight constants (e.g. WeightBasedFeeManager) override this with a
+        // tighter estimate.
+        let total = inputs as u32 + outputs as u32;
+        self.round_fee(total).await
+    }
 }
 
 /// No-op fee manager service that returns zero fees (fee_rate=1).
@@ -1266,6 +1289,15 @@ mod tests {
         assert_eq!(fm.transfer_fee(50_000).await.unwrap(), 0);
         assert_eq!(fm.round_fee(10).await.unwrap(), 0);
         assert_eq!(fm.current_fee_rate().await.unwrap(), 1);
+    }
+
+    #[tokio::test]
+    async fn test_noop_fee_manager_minimum_fee_confidential() {
+        // NoopFeeManager defers to round_fee via the trait default,
+        // which returns 0; confidential fee gate must accept any fee.
+        let fm = NoopFeeManager;
+        assert_eq!(fm.minimum_fee_confidential(0, 0).await.unwrap(), 0);
+        assert_eq!(fm.minimum_fee_confidential(2, 3).await.unwrap(), 0);
     }
 
     #[test]

--- a/crates/dark-fee-manager/src/bitcoin_core.rs
+++ b/crates/dark-fee-manager/src/bitcoin_core.rs
@@ -9,9 +9,10 @@ use tokio::sync::RwLock;
 use tracing::{debug, warn};
 
 use dark_core::error::{ArkError, ArkResult};
-use dark_core::ports::{FeeManager, FeeStrategy};
+use dark_core::ports::{FeeManager, FeeManagerService, FeeStrategy};
 
 use crate::btc_per_kb_to_sat_per_vbyte;
+use crate::confidential::minimum_fee_for_rate;
 
 /// Default cache TTL: 60 seconds
 const DEFAULT_CACHE_TTL_SECS: u64 = 60;
@@ -187,6 +188,51 @@ impl FeeManager for BitcoinCoreFeeManager {
         cache.clear();
         debug!("Fee manager cache invalidated");
         Ok(())
+    }
+}
+
+/// `FeeManagerService` impl for the Bitcoin Core RPC path.
+///
+/// Per ADR-0004 §"Constraints on #543" the RPC backend "applies unchanged"
+/// — we lower its `sat/vbyte` rate into a `u64` minimum fee using the
+/// shared confidential-tx weight table in [`crate::confidential`]. The RPC
+/// only ever sees the operator's own node; no confidential metadata
+/// crosses the boundary.
+///
+/// Boarding/transfer/round surfaces fall back to `current_fee_rate`-times-
+/// confidential-vbytes for parity with the transparent
+/// `WeightBasedFeeManager`. Callers using this manager for *transparent*
+/// rounds should compose with `WeightBasedFeeManager` directly.
+#[async_trait]
+impl FeeManagerService for BitcoinCoreFeeManager {
+    async fn boarding_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        // The RPC backend exposes only fee rates; transparent boarding
+        // fee scoring is owned by `WeightBasedFeeManager`. The
+        // `FeeManagerService` impl exists primarily for the confidential
+        // path; transparent surfaces fall back to a per-input/output
+        // approximation at the current rate.
+        let rate = self.estimate_fee_rate(FeeStrategy::Conservative).await?;
+        Ok(rate.saturating_mul(150))
+    }
+
+    async fn transfer_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        let rate = self.estimate_fee_rate(FeeStrategy::Conservative).await?;
+        Ok(rate.saturating_mul(100))
+    }
+
+    async fn round_fee(&self, vtxo_count: u32) -> ArkResult<u64> {
+        let rate = self.estimate_fee_rate(FeeStrategy::Conservative).await?;
+        Ok(rate.saturating_mul(vtxo_count as u64 * 50 + 200))
+    }
+
+    async fn current_fee_rate(&self) -> ArkResult<u64> {
+        self.estimate_fee_rate(FeeStrategy::Conservative).await
+    }
+
+    async fn minimum_fee_confidential(&self, inputs: usize, outputs: usize) -> ArkResult<u64> {
+        // RPC path (ADR-0004): rate from estimatesmartfee × confidential-tx
+        // vbytes. Counts only — no amounts plumbed into the RPC.
+        minimum_fee_for_rate(self, FeeStrategy::Conservative, inputs, outputs, 0).await
     }
 }
 

--- a/crates/dark-fee-manager/src/confidential.rs
+++ b/crates/dark-fee-manager/src/confidential.rs
@@ -1,0 +1,267 @@
+//! Weight constants for confidential transactions and a small helper that
+//! lowers `(inputs, outputs, fee_rate)` into a `u64` minimum fee.
+//!
+//! These constants calibrate `WeightBasedFeeManager`'s confidential-tx
+//! scoring per ADR-0004 §"Weight estimation for confidential transactions".
+//! The numbers are sourced from `docs/benchmarks/confidential-primitives.md`
+//! and `docs/protocol/confidential-vtxo-schema.md`:
+//!
+//! - **Per-output range proof:** ~1.3 KB at the Back-Maxwell sizing
+//!   (`secp256k1-zkp = 0.11`); see the bench doc's "Range proofs" table for
+//!   the single-output measurement we calibrate against.
+//! - **Per-output Pedersen commitment + ephemeral pubkey + owner pubkey:**
+//!   33 + 33 + 33 = 99 bytes on the wire (SEC1 compressed points).
+//! - **Per-output encrypted memo overhead:** ~80 bytes (varint length + AEAD
+//!   ciphertext envelope per ADR-0003). Memos themselves are bounded to a
+//!   small fixed cap by the schema; we charge a representative average.
+//! - **Per-input nullifier:** 32 bytes plus a small per-input metadata block.
+//! - **Per-tx overhead:** balance proof (65 bytes = 33 R || 32 s per
+//!   `dark-confidential::balance_proof`), schema_version (varint), proto
+//!   framing, and the plaintext `fee_amount` field itself.
+//!
+//! Per ADR-0004 the *exact* constants are an issue-#543-owned calibration;
+//! the ADR pins the **interface** (counts in, `u64` out). We accept the
+//! benchmarks as authoritative and round to whole vbytes.
+//!
+//! ## Why these constants live here, not in `dark-confidential`
+//!
+//! The fee-manager treats confidential-tx weight the same way it already
+//! treats P2TR weight in `weight.rs`: a small table of vbyte constants per
+//! input / per output / per tx. Coupling the constants to the cryptography
+//! crate would force every fee-manager backend to depend on
+//! `dark-confidential`; instead, the bench numbers are the source of truth
+//! and any drift caught by the `confidential-primitives` regression policy
+//! prompts an update here.
+
+use async_trait::async_trait;
+
+use dark_core::error::ArkResult;
+use dark_core::ports::{FeeManager, FeeManagerService, FeeStrategy};
+
+/// Per-confidential-tx fixed overhead in milli-vbytes.
+///
+/// Balance proof (65 B) + schema_version + fee_amount varint + framing.
+/// Represented as 80 vbytes = 80_000 mvB.
+pub const CONFIDENTIAL_TX_OVERHEAD_MVB: u64 = 80_000;
+
+/// Per-confidential-input cost in milli-vbytes.
+///
+/// 32-byte nullifier + per-input proto framing + metadata block.
+/// Represented as 40 vbytes = 40_000 mvB.
+pub const CONFIDENTIAL_INPUT_MVB: u64 = 40_000;
+
+/// Per-confidential-output cost in milli-vbytes.
+///
+/// Range proof (~1300 B at Back-Maxwell single-output sizing) +
+/// commitment (33 B) + owner_pubkey (33 B) + ephemeral_pubkey (33 B) +
+/// encrypted_memo envelope (~80 B) + framing.
+/// Rounded to 1500 vbytes = 1_500_000 mvB.
+pub const CONFIDENTIAL_OUTPUT_MVB: u64 = 1_500_000;
+
+/// Compute the confidential-tx weight in vbytes from input and output
+/// counts.
+///
+/// ```text
+/// vbytes = ceil(
+///     (overhead_mvb
+///        + inputs  × per_input_mvb
+///        + outputs × per_output_mvb)
+///     / 1000
+/// )
+/// ```
+///
+/// Pure integer arithmetic; no floating-point. The result is the vbyte
+/// count fee-rate-driven backends multiply by their `sat/vbyte` rate.
+pub fn confidential_vbytes(inputs: u64, outputs: u64) -> u64 {
+    let total_mvb = CONFIDENTIAL_TX_OVERHEAD_MVB
+        + inputs.saturating_mul(CONFIDENTIAL_INPUT_MVB)
+        + outputs.saturating_mul(CONFIDENTIAL_OUTPUT_MVB);
+    total_mvb.div_ceil(1000)
+}
+
+/// Compute the minimum fee for a confidential transaction given a
+/// fee-rate-providing backend (`FeeManager`) and the input/output counts.
+///
+/// This is the helper used by `BitcoinCoreFeeManager` and
+/// `MempoolSpaceFeeManager`'s `FeeManagerService` impls (RPC path) and by
+/// any other component that needs to lower a `sat/vbyte` rate into a
+/// per-confidential-tx minimum.
+///
+/// `min_fee_sats` clamps the result from below — backends use it to honour
+/// their per-deployment minimum-fee policy.
+pub async fn minimum_fee_for_rate<F: FeeManager + ?Sized>(
+    fee_manager: &F,
+    strategy: FeeStrategy,
+    inputs: usize,
+    outputs: usize,
+    min_fee_sats: u64,
+) -> ArkResult<u64> {
+    let rate = fee_manager.estimate_fee_rate(strategy).await?;
+    let vbytes = confidential_vbytes(inputs as u64, outputs as u64);
+    Ok(vbytes.saturating_mul(rate).max(min_fee_sats))
+}
+
+/// `FeeManagerService` adapter that wraps any `FeeManager` (rate-only)
+/// backend so it can answer `minimum_fee_confidential` queries against the
+/// shared confidential-tx weight table.
+///
+/// Used by the RPC fee managers (`BitcoinCoreFeeManager`,
+/// `MempoolSpaceFeeManager`) to honour ADR-0004 §"Constraints on #543"
+/// without duplicating the weight constants in each backend.
+pub struct ConfidentialFeeAdapter<F> {
+    inner: F,
+    strategy: FeeStrategy,
+    min_fee_sats: u64,
+}
+
+impl<F> ConfidentialFeeAdapter<F> {
+    /// Wrap a fee-rate provider for confidential-tx fee scoring.
+    pub fn new(inner: F, strategy: FeeStrategy, min_fee_sats: u64) -> Self {
+        Self {
+            inner,
+            strategy,
+            min_fee_sats,
+        }
+    }
+
+    /// Inner fee-rate provider (read-only).
+    pub fn inner(&self) -> &F {
+        &self.inner
+    }
+}
+
+#[async_trait]
+impl<F> FeeManagerService for ConfidentialFeeAdapter<F>
+where
+    F: FeeManager + Send + Sync,
+{
+    async fn boarding_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        // Adapter is dedicated to the confidential path; transparent
+        // surfaces stay on the underlying transparent FeeManagerService.
+        self.round_fee(1).await
+    }
+
+    async fn transfer_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        self.round_fee(1).await
+    }
+
+    async fn round_fee(&self, vtxo_count: u32) -> ArkResult<u64> {
+        // Rough round-fee fallback at the underlying rate, treating each
+        // VTXO as a single input/output pair. This is only used when the
+        // adapter is consulted on transparent rounds; primary surface is
+        // `minimum_fee_confidential` below.
+        let rate = self.inner.estimate_fee_rate(self.strategy).await?;
+        let vbytes = confidential_vbytes(vtxo_count as u64, vtxo_count as u64);
+        Ok(vbytes.saturating_mul(rate).max(self.min_fee_sats))
+    }
+
+    async fn current_fee_rate(&self) -> ArkResult<u64> {
+        self.inner.estimate_fee_rate(self.strategy).await
+    }
+
+    async fn minimum_fee_confidential(&self, inputs: usize, outputs: usize) -> ArkResult<u64> {
+        minimum_fee_for_rate(
+            &self.inner,
+            self.strategy,
+            inputs,
+            outputs,
+            self.min_fee_sats,
+        )
+        .await
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark_core::error::ArkResult;
+    use dark_core::ports::{FeeManager, FeeStrategy};
+
+    /// Tiny `FeeManager` that returns a fixed `sat/vbyte` rate.
+    struct FixedRate(u64);
+
+    #[async_trait]
+    impl FeeManager for FixedRate {
+        async fn estimate_fee_rate(&self, strategy: FeeStrategy) -> ArkResult<u64> {
+            match strategy {
+                FeeStrategy::Custom(r) => Ok(r),
+                _ => Ok(self.0),
+            }
+        }
+
+        async fn invalidate_cache(&self) -> ArkResult<()> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn confidential_vbytes_zero_inputs_zero_outputs() {
+        // overhead only: ceil(80_000 / 1000) = 80
+        assert_eq!(confidential_vbytes(0, 0), 80);
+    }
+
+    #[test]
+    fn confidential_vbytes_one_input_one_output() {
+        // ceil((80_000 + 40_000 + 1_500_000) / 1000) = 1620
+        assert_eq!(confidential_vbytes(1, 1), 1620);
+    }
+
+    #[test]
+    fn confidential_vbytes_scales_linearly_with_outputs() {
+        let one = confidential_vbytes(1, 1);
+        let two = confidential_vbytes(1, 2);
+        // Each extra output adds 1500 vbytes
+        assert_eq!(two - one, 1500);
+    }
+
+    #[test]
+    fn confidential_vbytes_scales_linearly_with_inputs() {
+        let one = confidential_vbytes(1, 1);
+        let two = confidential_vbytes(2, 1);
+        // Each extra input adds 40 vbytes
+        assert_eq!(two - one, 40);
+    }
+
+    #[tokio::test]
+    async fn minimum_fee_for_rate_zero_rate_returns_min_floor() {
+        let fm = FixedRate(0);
+        let fee = minimum_fee_for_rate(&fm, FeeStrategy::Conservative, 1, 1, 546)
+            .await
+            .unwrap();
+        // 1620 * 0 = 0, clamped to min 546
+        assert_eq!(fee, 546);
+    }
+
+    #[tokio::test]
+    async fn minimum_fee_for_rate_uses_rate_times_vbytes() {
+        let fm = FixedRate(2);
+        let fee = minimum_fee_for_rate(&fm, FeeStrategy::Conservative, 1, 1, 0)
+            .await
+            .unwrap();
+        // 1620 * 2 = 3240
+        assert_eq!(fee, 3240);
+    }
+
+    #[tokio::test]
+    async fn adapter_minimum_fee_confidential_matches_helper() {
+        let fm = FixedRate(5);
+        let adapter = ConfidentialFeeAdapter::new(fm, FeeStrategy::Conservative, 100);
+        let direct = minimum_fee_for_rate(&FixedRate(5), FeeStrategy::Conservative, 2, 3, 100)
+            .await
+            .unwrap();
+        let via_adapter = adapter.minimum_fee_confidential(2, 3).await.unwrap();
+        assert_eq!(direct, via_adapter);
+    }
+
+    #[tokio::test]
+    async fn adapter_current_fee_rate_uses_strategy() {
+        let adapter = ConfidentialFeeAdapter::new(FixedRate(7), FeeStrategy::Economical, 0);
+        assert_eq!(adapter.current_fee_rate().await.unwrap(), 7);
+    }
+
+    #[tokio::test]
+    async fn adapter_min_fee_floor_applies() {
+        let adapter = ConfidentialFeeAdapter::new(FixedRate(0), FeeStrategy::Conservative, 1_234);
+        assert_eq!(adapter.minimum_fee_confidential(1, 1).await.unwrap(), 1_234);
+    }
+}

--- a/crates/dark-fee-manager/src/lib.rs
+++ b/crates/dark-fee-manager/src/lib.rs
@@ -6,14 +6,31 @@
 //! - [`StaticFeeManager`]: Fixed fee rate (useful for testing)
 //! - [`SimpleFeeManager`]: Flat-rate fee calculator for transaction types
 //! - [`WeightBasedFeeManager`]: Weight-based fee computation
+//!
+//! ## Confidential transactions
+//!
+//! Per ADR-0004, the fee for a confidential transaction is a plaintext
+//! `u64` (sats) on the wire and is scored through the same
+//! [`FeeManagerService`](dark_core::ports::FeeManagerService) trait used
+//! for transparent transactions. The `minimum_fee_confidential` method
+//! takes only **counts** (nullifier count = inputs, output-commitment
+//! count = outputs); plaintext amounts are not visible on the
+//! confidential side and MUST NOT be plumbed through. Calibration
+//! constants for the weight-based backend live in
+//! [`confidential`].
 
 pub mod bitcoin_core;
+pub mod confidential;
 pub mod mempool_space;
 pub mod simple;
 pub mod static_fee;
 pub mod weight;
 
 pub use bitcoin_core::BitcoinCoreFeeManager;
+pub use confidential::{
+    confidential_vbytes, minimum_fee_for_rate, ConfidentialFeeAdapter, CONFIDENTIAL_INPUT_MVB,
+    CONFIDENTIAL_OUTPUT_MVB, CONFIDENTIAL_TX_OVERHEAD_MVB,
+};
 pub use mempool_space::{MempoolNetwork, MempoolSpaceFeeManager, RecommendedFees};
 pub use simple::SimpleFeeManager;
 pub use static_fee::StaticFeeManager;

--- a/crates/dark-fee-manager/src/mempool_space.rs
+++ b/crates/dark-fee-manager/src/mempool_space.rs
@@ -11,7 +11,9 @@ use tokio::sync::RwLock;
 use tracing::debug;
 
 use dark_core::error::{ArkError, ArkResult};
-use dark_core::ports::{FeeManager, FeeStrategy};
+use dark_core::ports::{FeeManager, FeeManagerService, FeeStrategy};
+
+use crate::confidential::minimum_fee_for_rate;
 
 /// Default cache TTL: 60 seconds
 const DEFAULT_CACHE_TTL_SECS: u64 = 60;
@@ -254,6 +256,41 @@ impl FeeManager for MempoolSpaceFeeManager {
         *cache = None;
         debug!("mempool.space fee cache invalidated");
         Ok(())
+    }
+}
+
+/// `FeeManagerService` impl for the mempool.space RPC path.
+///
+/// Per ADR-0004 §"Constraints on #543" the mempool.space backend "applies
+/// unchanged" — we lower its `sat/vbyte` rate into a `u64` minimum fee
+/// using the shared confidential-tx weight table in
+/// [`crate::confidential`]. The RPC sees only the operator's own polling
+/// load; no confidential metadata crosses the boundary.
+#[async_trait]
+impl FeeManagerService for MempoolSpaceFeeManager {
+    async fn boarding_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        let rate = self.estimate_fee_rate(FeeStrategy::Conservative).await?;
+        Ok(rate.saturating_mul(150))
+    }
+
+    async fn transfer_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        let rate = self.estimate_fee_rate(FeeStrategy::Conservative).await?;
+        Ok(rate.saturating_mul(100))
+    }
+
+    async fn round_fee(&self, vtxo_count: u32) -> ArkResult<u64> {
+        let rate = self.estimate_fee_rate(FeeStrategy::Conservative).await?;
+        Ok(rate.saturating_mul(vtxo_count as u64 * 50 + 200))
+    }
+
+    async fn current_fee_rate(&self) -> ArkResult<u64> {
+        self.estimate_fee_rate(FeeStrategy::Conservative).await
+    }
+
+    async fn minimum_fee_confidential(&self, inputs: usize, outputs: usize) -> ArkResult<u64> {
+        // RPC path (ADR-0004): rate from mempool.space × confidential-tx
+        // vbytes. Counts only — no amounts plumbed into the RPC.
+        minimum_fee_for_rate(self, FeeStrategy::Conservative, inputs, outputs, 0).await
     }
 }
 

--- a/crates/dark-fee-manager/src/simple.rs
+++ b/crates/dark-fee-manager/src/simple.rs
@@ -4,6 +4,8 @@ use async_trait::async_trait;
 use dark_core::error::ArkResult;
 use dark_core::ports::FeeManagerService;
 
+use crate::confidential::confidential_vbytes;
+
 /// Simple fee manager with a flat fee rate and minimum fee.
 ///
 /// Calculates fees based on estimated transaction sizes:
@@ -60,5 +62,44 @@ impl FeeManagerService for SimpleFeeManager {
 
     async fn current_fee_rate(&self) -> ArkResult<u64> {
         Ok(self.fee_rate_sats_per_vbyte)
+    }
+
+    async fn minimum_fee_confidential(&self, inputs: usize, outputs: usize) -> ArkResult<u64> {
+        // Static path (ADR-0004): flat fee rate × confidential-tx vbytes,
+        // floored at the deployment-configured minimum.
+        let vbytes = confidential_vbytes(inputs as u64, outputs as u64);
+        Ok((vbytes * self.fee_rate_sats_per_vbyte).max(self.min_fee_sats))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::confidential::confidential_vbytes;
+
+    #[tokio::test]
+    async fn simple_minimum_fee_confidential_uses_flat_rate() {
+        let fm = SimpleFeeManager::new(2, 0);
+        // 1 input, 1 output -> 1620 vbytes -> 3240 sats at 2 sat/vB
+        let fee = fm.minimum_fee_confidential(1, 1).await.unwrap();
+        let vbytes = confidential_vbytes(1, 1);
+        assert_eq!(fee, vbytes * 2);
+    }
+
+    #[tokio::test]
+    async fn simple_minimum_fee_confidential_clamps_to_min() {
+        let fm = SimpleFeeManager::new(0, 1_000);
+        let fee = fm.minimum_fee_confidential(1, 1).await.unwrap();
+        // rate = 0, so vbytes * 0 = 0; clamped to min 1_000
+        assert_eq!(fee, 1_000);
+    }
+
+    #[tokio::test]
+    async fn simple_minimum_fee_confidential_scales_with_outputs() {
+        let fm = SimpleFeeManager::new(1, 0);
+        let f1 = fm.minimum_fee_confidential(1, 1).await.unwrap();
+        let f2 = fm.minimum_fee_confidential(1, 2).await.unwrap();
+        // Each extra output adds ~1500 vbytes at 1 sat/vB
+        assert_eq!(f2 - f1, 1500);
     }
 }

--- a/crates/dark-fee-manager/src/weight.rs
+++ b/crates/dark-fee-manager/src/weight.rs
@@ -13,6 +13,8 @@ use dark_core::domain::Vtxo;
 use dark_core::error::ArkResult;
 use dark_core::ports::{BoardingInput, FeeManagerService};
 
+use crate::confidential::confidential_vbytes;
+
 /// Transaction overhead in milli-vbytes (10.5 vbytes = 10_500 mvB).
 const TX_OVERHEAD_MVB: u64 = 10_500;
 /// P2TR input weight in milli-vbytes (57.5 vbytes = 57_500 mvB).
@@ -67,6 +69,19 @@ impl WeightBasedFeeManager {
         let fee = (weight_mvb * self.fee_rate_sats_per_vbyte).div_ceil(1000);
         fee.max(self.min_fee_sats)
     }
+
+    /// Estimate the fee in satoshis for a confidential transaction with
+    /// the given number of inputs and outputs.
+    ///
+    /// Per ADR-0004 §"Weight estimation for confidential transactions",
+    /// uses the dedicated `confidential::*_MVB` constants instead of the
+    /// transparent P2TR weights. Receives **counts only** — input and
+    /// output amounts are not visible on the confidential side.
+    pub fn estimate_confidential_fee(&self, num_inputs: u64, num_outputs: u64) -> u64 {
+        let vbytes = confidential_vbytes(num_inputs, num_outputs);
+        let fee = vbytes.saturating_mul(self.fee_rate_sats_per_vbyte);
+        fee.max(self.min_fee_sats)
+    }
 }
 
 #[async_trait]
@@ -104,6 +119,13 @@ impl FeeManagerService for WeightBasedFeeManager {
         let num_inputs = boarding_inputs.len() as u64 + vtxo_inputs.len() as u64;
         let num_outputs = onchain_outputs as u64 + offchain_outputs as u64;
         Ok(self.estimate_fee(num_inputs, num_outputs))
+    }
+
+    async fn minimum_fee_confidential(&self, inputs: usize, outputs: usize) -> ArkResult<u64> {
+        // Weight path (ADR-0004): use the confidential-tx weight constants
+        // calibrated against `docs/benchmarks/confidential-primitives.md`,
+        // multiplied by the configured fee rate.
+        Ok(self.estimate_confidential_fee(inputs as u64, outputs as u64))
     }
 }
 
@@ -181,7 +203,7 @@ mod tests {
         // Each additional input adds 57.5 vbytes = ~58 sats at 1 sat/vbyte
         let diff = fee_5 - fee_1;
         assert!(
-            diff >= 4 * 57 && diff <= 4 * 58,
+            (4 * 57..=4 * 58).contains(&diff),
             "4 extra inputs should add ~230 sats, got {}",
             diff
         );
@@ -321,7 +343,7 @@ mod tests {
         assert!(fee10 > fee1);
         // 10 inputs, 1 output vs 1 input, 1 output: diff = 9 * 57.5 = 517.5
         let diff = fee10 - fee1;
-        assert!(diff >= 517 && diff <= 518);
+        assert!((517..=518).contains(&diff));
     }
 
     #[tokio::test]
@@ -335,5 +357,56 @@ mod tests {
         let fm = WeightBasedFeeManager::new(100, 0);
         // 1 input, 1 output: ceil(111_000 * 100 / 1000) = 11_100
         assert_eq!(fm.estimate_fee(1, 1), 11_100);
+    }
+
+    #[tokio::test]
+    async fn test_minimum_fee_confidential_uses_confidential_weights() {
+        let fm = WeightBasedFeeManager::new(1, 0);
+        // 1 input + 1 output -> 1620 vbytes -> 1620 sats at 1 sat/vB
+        let fee = fm.minimum_fee_confidential(1, 1).await.unwrap();
+        assert_eq!(fee, 1620);
+    }
+
+    #[tokio::test]
+    async fn test_minimum_fee_confidential_uses_only_counts_no_amounts() {
+        // No-amounts contract: the function takes only counts. The same
+        // (inputs, outputs) tuple yields the same fee regardless of how
+        // many sats those VTXOs carry.
+        let fm = WeightBasedFeeManager::new(5, 0);
+        let f1 = fm.minimum_fee_confidential(2, 3).await.unwrap();
+        let f2 = fm.minimum_fee_confidential(2, 3).await.unwrap();
+        assert_eq!(f1, f2);
+    }
+
+    #[tokio::test]
+    async fn test_minimum_fee_confidential_clamps_to_min() {
+        let fm = WeightBasedFeeManager::new(0, 1_500);
+        // Rate=0, so weight*rate=0, clamped to min_fee_sats=1_500
+        let fee = fm.minimum_fee_confidential(1, 1).await.unwrap();
+        assert_eq!(fee, 1_500);
+    }
+
+    #[tokio::test]
+    async fn test_minimum_fee_confidential_scales_with_input_count() {
+        let fm = WeightBasedFeeManager::new(1, 0);
+        let f1 = fm.minimum_fee_confidential(1, 1).await.unwrap();
+        let f5 = fm.minimum_fee_confidential(5, 1).await.unwrap();
+        // Each extra input adds 40 vbytes at 1 sat/vB
+        assert_eq!(f5 - f1, 4 * 40);
+    }
+
+    #[tokio::test]
+    async fn test_minimum_fee_confidential_scales_with_output_count() {
+        let fm = WeightBasedFeeManager::new(2, 0);
+        let f1 = fm.minimum_fee_confidential(1, 1).await.unwrap();
+        let f3 = fm.minimum_fee_confidential(1, 3).await.unwrap();
+        // Each extra output adds 1500 vbytes; at 2 sat/vB that's 3000 sats
+        assert_eq!(f3 - f1, 2 * 1500 * 2);
+    }
+
+    #[test]
+    fn test_estimate_confidential_fee_zero_rate_clamped_to_min() {
+        let fm = WeightBasedFeeManager::new(0, 999);
+        assert_eq!(fm.estimate_confidential_fee(1, 1), 999);
     }
 }

--- a/crates/dark-fee-manager/tests/confidential_fee_integration.rs
+++ b/crates/dark-fee-manager/tests/confidential_fee_integration.rs
@@ -1,0 +1,287 @@
+//! Integration test for ADR-0004 §"Constraints on #543" / acceptance
+//! criterion 2:
+//!
+//! > Provide an integration test that submits a confidential tx with
+//! > `fee_amount = operator_min_fee − 1` (rejected) and another with
+//! > `fee_amount = operator_min_fee` (accepted).
+//!
+//! The end-to-end submission pipeline (gRPC handler, balance-proof
+//! verification, nullifier set update) is owned by issues #538 and #542 and
+//! lives in `dark-api` / `dark-confidential`. From the *fee-manager* side
+//! the contract this PR (#543) freezes is narrower:
+//!
+//! 1. `FeeManagerService::minimum_fee_confidential(inputs, outputs)`
+//!    returns a single `u64` minimum fee derived from confidential-tx
+//!    counts only — no plaintext amounts, no tuple, no parallel trait.
+//! 2. The validator's fee gate (per the pseudocode in ADR-0004) compares
+//!    `tx.fee_amount` against that `u64` and short-circuits on failure.
+//!
+//! The tests below exercise that contract for every #543-wired backend
+//! (Static / Weight / RPC-adapter / CEL) plus the trait default that
+//! `NoopFeeManager` falls into.
+
+use async_trait::async_trait;
+
+use dark_core::domain::FeeProgram;
+use dark_core::error::ArkResult;
+use dark_core::ports::{FeeManager, FeeManagerService, FeeStrategy, NoopFeeManager};
+use dark_fee_manager::confidential::ConfidentialFeeAdapter;
+use dark_fee_manager::{SimpleFeeManager, WeightBasedFeeManager};
+
+/// Minimal `ConfidentialTransaction` mirror sufficient for fee-gate tests.
+///
+/// Mirrors the proto field shape (`fee_amount: u64`) and counts but stops
+/// short of the cryptographic payload, which lives in #538 territory.
+struct FakeConfidentialTransaction {
+    fee_amount: u64,
+    inputs: usize,
+    outputs: usize,
+}
+
+impl FakeConfidentialTransaction {
+    fn new(fee_amount: u64, inputs: usize, outputs: usize) -> Self {
+        Self {
+            fee_amount,
+            inputs,
+            outputs,
+        }
+    }
+}
+
+/// Verdict returned by the fee gate.
+///
+/// Mirrors `SubmitConfidentialTransactionResponse.{accepted, Error}` from
+/// `proto/ark/v1/confidential_tx.proto` (#537) without pulling in the
+/// proto bindings.
+#[derive(Debug, PartialEq, Eq)]
+enum Verdict {
+    Accepted,
+    /// Maps to `Error::ERROR_FEE_TOO_LOW` on the wire.
+    RejectedFeeTooLow {
+        fee: u64,
+        min: u64,
+    },
+}
+
+/// Implements the fee gate from ADR-0004 §"Validation pseudocode" steps
+/// (1)-(3): parse, sanity cap (skipped here, owned by #538), minimum-fee
+/// gate.
+///
+/// The gate consults a `FeeManagerService` for the per-tx minimum and
+/// compares it against `tx.fee_amount` exactly once (per ADR-0004 §"#538
+/// MUST NOT" rule "Read `tx.fee_amount` more than once").
+async fn fee_gate(
+    fee_manager: &dyn FeeManagerService,
+    tx: &FakeConfidentialTransaction,
+) -> ArkResult<Verdict> {
+    let fee = tx.fee_amount;
+    let min = fee_manager
+        .minimum_fee_confidential(tx.inputs, tx.outputs)
+        .await?;
+    if fee < min {
+        Ok(Verdict::RejectedFeeTooLow { fee, min })
+    } else {
+        Ok(Verdict::Accepted)
+    }
+}
+
+/// Asserts the rejected/accepted pair for a single fee-manager backend.
+///
+/// `tx_inputs` and `tx_outputs` must match what the gate sees on the wire;
+/// `min - 1` is rejected, `min` is accepted, exactly per ADR-0004's
+/// acceptance criterion 2.
+async fn assert_rejected_then_accepted(
+    fee_manager: &dyn FeeManagerService,
+    tx_inputs: usize,
+    tx_outputs: usize,
+) {
+    let min = fee_manager
+        .minimum_fee_confidential(tx_inputs, tx_outputs)
+        .await
+        .expect("minimum_fee_confidential should succeed");
+    assert!(
+        min > 0,
+        "test prerequisite: backend must publish a non-zero minimum so \
+         (min - 1) is well-defined"
+    );
+
+    // (a) fee = min - 1 -> rejected with FEE_TOO_LOW
+    let too_low = FakeConfidentialTransaction::new(min - 1, tx_inputs, tx_outputs);
+    let verdict = fee_gate(fee_manager, &too_low).await.unwrap();
+    assert_eq!(
+        verdict,
+        Verdict::RejectedFeeTooLow { fee: min - 1, min },
+        "fee_amount = min - 1 must be rejected with FEE_TOO_LOW"
+    );
+
+    // (b) fee = min -> accepted
+    let exact = FakeConfidentialTransaction::new(min, tx_inputs, tx_outputs);
+    let verdict = fee_gate(fee_manager, &exact).await.unwrap();
+    assert_eq!(
+        verdict,
+        Verdict::Accepted,
+        "fee_amount = min must be accepted"
+    );
+
+    // (c) fee = min + 1 -> still accepted (gate is `>=`, not `==`)
+    let above = FakeConfidentialTransaction::new(min + 1, tx_inputs, tx_outputs);
+    let verdict = fee_gate(fee_manager, &above).await.unwrap();
+    assert_eq!(verdict, Verdict::Accepted);
+}
+
+// -- Static path -------------------------------------------------------------
+
+#[tokio::test]
+async fn confidential_fee_gate_static_rejects_below_min_accepts_at_min() {
+    // SimpleFeeManager (Static): flat fee rate × confidential vbytes.
+    // 5 sat/vB at 1 input, 1 output -> 1620 vbytes -> 8100 sats min.
+    let fm = SimpleFeeManager::new(5, 0);
+    assert_rejected_then_accepted(&fm, 1, 1).await;
+}
+
+#[tokio::test]
+async fn confidential_fee_gate_static_scales_with_outputs() {
+    // Verify the gate threshold grows with output count, exercising the
+    // count-based scoring required by ADR-0004 (no amounts).
+    let fm = SimpleFeeManager::new(5, 0);
+    let one = fm.minimum_fee_confidential(1, 1).await.unwrap();
+    let three = fm.minimum_fee_confidential(1, 3).await.unwrap();
+    assert!(three > one);
+    assert_rejected_then_accepted(&fm, 1, 3).await;
+}
+
+// -- Weight path -------------------------------------------------------------
+
+#[tokio::test]
+async fn confidential_fee_gate_weight_rejects_below_min_accepts_at_min() {
+    // WeightBasedFeeManager: confidential weight constants × fee rate.
+    let fm = WeightBasedFeeManager::new(2, 0);
+    assert_rejected_then_accepted(&fm, 1, 1).await;
+}
+
+#[tokio::test]
+async fn confidential_fee_gate_weight_realistic_round() {
+    // 4 nullifiers, 4 outputs at 5 sat/vB — typical mid-sized confidential
+    // round shape from the m3 protocol design.
+    let fm = WeightBasedFeeManager::new(5, 0);
+    assert_rejected_then_accepted(&fm, 4, 4).await;
+}
+
+// -- RPC path (Bitcoin Core / mempool.space) --------------------------------
+
+/// Minimal `FeeManager` test double that returns a fixed `sat/vbyte` rate.
+///
+/// Stands in for `BitcoinCoreFeeManager` and `MempoolSpaceFeeManager` in
+/// the unit-test domain — both lower their RPC-derived rate into the same
+/// `ConfidentialFeeAdapter` machinery, so the gate behaviour is identical
+/// regardless of which RPC source backed the rate.
+struct StubRpcRate(u64);
+
+#[async_trait]
+impl FeeManager for StubRpcRate {
+    async fn estimate_fee_rate(&self, strategy: FeeStrategy) -> ArkResult<u64> {
+        match strategy {
+            FeeStrategy::Custom(r) => Ok(r),
+            _ => Ok(self.0),
+        }
+    }
+
+    async fn invalidate_cache(&self) -> ArkResult<()> {
+        Ok(())
+    }
+}
+
+#[tokio::test]
+async fn confidential_fee_gate_rpc_rejects_below_min_accepts_at_min() {
+    // RPC (BitcoinCore / mempool.space) is wrapped via the adapter so the
+    // same fee-gate semantics apply.
+    let fm = ConfidentialFeeAdapter::new(StubRpcRate(3), FeeStrategy::Conservative, 0);
+    assert_rejected_then_accepted(&fm, 1, 1).await;
+}
+
+// -- CEL path ----------------------------------------------------------------
+
+/// Wraps a `FeeProgram` (CEL surface) as a `FeeManagerService` so it
+/// participates in the same fee gate as the other backends.
+///
+/// Per ADR-0004 §"Privacy boundary for CEL" the program is evaluated
+/// against **counts only**. This wrapper enforces that contract by
+/// construction: it never receives amounts, so it cannot leak them.
+struct CelFeeService {
+    program: FeeProgram,
+}
+
+#[async_trait]
+impl FeeManagerService for CelFeeService {
+    async fn boarding_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        Ok(self.program.base_fee)
+    }
+    async fn transfer_fee(&self, _amount_sats: u64) -> ArkResult<u64> {
+        Ok(self.program.base_fee)
+    }
+    async fn round_fee(&self, _vtxo_count: u32) -> ArkResult<u64> {
+        Ok(self.program.base_fee)
+    }
+    async fn current_fee_rate(&self) -> ArkResult<u64> {
+        Ok(1)
+    }
+    async fn minimum_fee_confidential(&self, inputs: usize, outputs: usize) -> ArkResult<u64> {
+        // CEL path: counts only — no amounts.
+        Ok(self
+            .program
+            .calculate_confidential_intent_fee(inputs as u32, outputs as u32))
+    }
+}
+
+#[tokio::test]
+async fn confidential_fee_gate_cel_rejects_below_min_accepts_at_min() {
+    let fm = CelFeeService {
+        program: FeeProgram {
+            offchain_input_fee: 50,
+            offchain_output_fee: 200,
+            base_fee: 100,
+            ..FeeProgram::default_zero()
+        },
+    };
+    // Expected min for (2, 3): 100 + 50*2 + 200*3 = 800
+    assert_eq!(fm.minimum_fee_confidential(2, 3).await.unwrap(), 800);
+    assert_rejected_then_accepted(&fm, 2, 3).await;
+}
+
+#[tokio::test]
+async fn confidential_fee_gate_cel_no_amount_passthrough() {
+    // Sentinel: CEL's onchain_*_fee rates are deliberately huge; the
+    // confidential surface MUST ignore them (see ADR-0004 §"Privacy
+    // boundary for CEL" — confidential VTXOs are off-chain by
+    // construction).
+    let fm = CelFeeService {
+        program: FeeProgram {
+            offchain_input_fee: 10,
+            offchain_output_fee: 20,
+            onchain_input_fee: u64::MAX / 2,
+            onchain_output_fee: u64::MAX / 2,
+            base_fee: 0,
+        },
+    };
+    let min = fm.minimum_fee_confidential(2, 2).await.unwrap();
+    // 10*2 + 20*2 = 60; if onchain rates leaked in we'd overflow long
+    // before getting here.
+    assert_eq!(min, 60);
+}
+
+// -- Trait default (NoopFeeManager) -----------------------------------------
+
+#[tokio::test]
+async fn confidential_fee_gate_noop_accepts_zero_fee() {
+    // NoopFeeManager (test deployments / fee-free configurations) lives
+    // on the trait default and returns 0 — every confidential tx passes
+    // the gate. This is the explicit `fee_amount = 0`,
+    // `operator_min_fee = 0` row in ADR-0004 §"Edge-case matrix".
+    let fm = NoopFeeManager;
+    let min = fm.minimum_fee_confidential(1, 1).await.unwrap();
+    assert_eq!(min, 0);
+
+    let zero = FakeConfidentialTransaction::new(0, 1, 1);
+    let verdict = fee_gate(&fm, &zero).await.unwrap();
+    assert_eq!(verdict, Verdict::Accepted);
+}

--- a/docs/protocol/confidential-fees.md
+++ b/docs/protocol/confidential-fees.md
@@ -1,0 +1,254 @@
+# Confidential transaction fee handling (#543)
+
+This document is the operator-facing reference for how
+`dark-fee-manager` scores confidential transactions. It is the deliverable
+named in issue #543 ("document the exact fee-calculation path") and
+implements the constraints in
+[ADR-0004](../adr/0004-confidential-fee-handling.md).
+
+The wire shape (plaintext `fee_amount: u64` on
+`ConfidentialTransaction`) and the validator-side gate (#538) are out of
+scope for this file — see ADR-0004 §"Wire format" and §"Validation
+pseudocode" respectively.
+
+## Scope
+
+ADR-0004 §"Constraints on #543" requires:
+
+> Add a single new method on `FeeManagerService` (or a sibling trait
+> living in `dark-fee-manager`) that takes confidential-tx metadata
+> (nullifier count, output count, optionally the operator's intent-layer
+> hints) and returns `u64`.
+
+Issue #543 lands the method, wires it through every existing fee program
+(static, RPC, weight-based, CEL), pins the calibration constants for the
+weight-based backend, and ships an integration test proving
+fee-too-low / correct-fee acceptance against each backend.
+
+## Trait surface
+
+The method is added to the existing `FeeManagerService` trait in
+`crates/dark-core/src/ports.rs`:
+
+```rust
+async fn minimum_fee_confidential(
+    &self,
+    inputs: usize,
+    outputs: usize,
+) -> ArkResult<u64>;
+```
+
+Inputs:
+
+- `inputs`: nullifier count from `ConfidentialTransaction.nullifiers`.
+- `outputs`: output-commitment count from
+  `ConfidentialTransaction.outputs`.
+
+Output: a single `u64` minimum-fee value in **satoshis**, comparable
+directly against `tx.fee_amount` on the wire.
+
+The trait stays object-safe and keeps its existing object-safety
+property (`dyn FeeManagerService` continues to compile and is exercised
+by `crates/dark-core/src/ports.rs::tests::test_fee_manager_service_object_safe`).
+
+A default implementation falls back to `round_fee(inputs + outputs)` so
+existing backends that have not opted in (e.g. third-party
+`FeeManagerService` implementors) keep compiling unchanged.
+
+### What the surface MUST NOT do
+
+Per ADR-0004 §"Constraints on #543" the method MUST NOT:
+
+- Return a tuple `(min_fee, range_bits)` or any non-`u64` shape.
+- Receive plaintext input or output amounts. The operator does not have
+  the amounts; the trait does not surface them.
+- Set or read `operator_max_fee` — that is round-policy and lives in
+  `dark-core`'s round layer.
+- Spawn a parallel trait. The same `FeeManagerService` services
+  transparent and confidential paths.
+
+## Per-backend wiring
+
+Every backend implements `minimum_fee_confidential` and reduces, by its
+own internal logic, to a single `u64` minimum fee.
+
+### Static (`SimpleFeeManager`)
+
+`crates/dark-fee-manager/src/simple.rs`. Configured with a flat fee rate
+in `sat/vbyte` and a deployment minimum:
+
+```text
+minimum_fee_confidential(inputs, outputs)
+  = max(
+      confidential_vbytes(inputs, outputs) × fee_rate_sats_per_vbyte,
+      min_fee_sats
+    )
+```
+
+Suitable for dev / test deployments and the `NoopFeeManager`-equivalent
+zero-rate configuration.
+
+### RPC (`BitcoinCoreFeeManager`, `MempoolSpaceFeeManager`)
+
+`crates/dark-fee-manager/src/bitcoin_core.rs` and `mempool_space.rs`. The
+RPC backend queries `estimatesmartfee` (Bitcoin Core) or
+`/api/v1/fees/recommended` (mempool.space) for the operator's **own**
+node — confidential metadata never leaves the operator. The
+`minimum_fee_confidential` method lowers the fetched `sat/vbyte` rate
+through the shared confidential weight table:
+
+```text
+minimum_fee_confidential(inputs, outputs)
+  = max(
+      confidential_vbytes(inputs, outputs) × estimate_fee_rate(Conservative),
+      0
+    )
+```
+
+Operators wanting a deployment-side fee floor wrap the RPC manager in
+`ConfidentialFeeAdapter` (see
+`crates/dark-fee-manager/src/confidential.rs`), which exposes the same
+`FeeManagerService` surface and clamps the result to a configured
+minimum.
+
+### Weight-based (`WeightBasedFeeManager`)
+
+`crates/dark-fee-manager/src/weight.rs`. The dedicated weight backend
+charges a per-input, per-output, per-tx weight calibrated against
+`docs/benchmarks/confidential-primitives.md`:
+
+```text
+weight_mvb = CONFIDENTIAL_TX_OVERHEAD_MVB
+           + inputs  × CONFIDENTIAL_INPUT_MVB
+           + outputs × CONFIDENTIAL_OUTPUT_MVB
+
+vbytes     = ceil(weight_mvb / 1000)
+
+minimum_fee_confidential(inputs, outputs)
+  = max(vbytes × fee_rate_sats_per_vbyte, min_fee_sats)
+```
+
+The constants live in `crates/dark-fee-manager/src/confidential.rs` and
+are reused by all rate-only backends through `confidential_vbytes`.
+
+### CEL (`FeeProgram`)
+
+`crates/dark-core/src/domain/fee.rs`. A new method on `FeeProgram`
+scores confidential intents from counts only:
+
+```rust
+pub fn calculate_confidential_intent_fee(&self, inputs: u32, outputs: u32) -> u64 {
+    self.base_fee
+        + self.offchain_input_fee  * inputs  as u64
+        + self.offchain_output_fee * outputs as u64
+}
+```
+
+Confidential VTXOs are off-chain by construction — the `onchain_*_fee`
+rates are deliberately ignored on this surface (a sentinel test pins the
+contract). Operators wanting per-confidential pricing tune the
+`offchain_*_fee` rates that already drive transparent off-chain VTXO
+intents.
+
+Per ADR-0004 §"Privacy boundary for CEL" the program receives no
+plaintext amounts — it cannot, because the operator does not have them.
+This is a structural property of the input shape, not a policy enforced
+by code review.
+
+## Calibration constants
+
+The weight constants in `crates/dark-fee-manager/src/confidential.rs`:
+
+| Constant                          | Value        | Source                                  |
+|-----------------------------------|--------------|-----------------------------------------|
+| `CONFIDENTIAL_TX_OVERHEAD_MVB`    | `80_000`     | balance proof (65 B) + framing + varints |
+| `CONFIDENTIAL_INPUT_MVB`          | `40_000`     | 32-byte nullifier + per-input metadata  |
+| `CONFIDENTIAL_OUTPUT_MVB`         | `1_500_000`  | range proof (~1.3 KB) + commitment (33 B) + ephemeral pubkey (33 B) + owner pubkey (33 B) + memo envelope (~80 B) + framing |
+
+All values are in **milli-vbytes** (mvB); divide by 1000 (with `div_ceil`)
+to obtain vbytes. Pure integer arithmetic — no floating point.
+
+The numbers are derived from
+[`docs/benchmarks/confidential-primitives.md`](../benchmarks/confidential-primitives.md)
+(range proofs, balance proofs, Pedersen commitments) and from the
+on-the-wire byte counts pinned in
+[`docs/protocol/confidential-vtxo-schema.md`](confidential-vtxo-schema.md).
+A bench regression that shifts proof-byte sizes is the trigger for
+updating these constants in the same PR that touches the bench doc.
+
+### Worked example
+
+For a confidential transaction with 1 input and 1 output:
+
+```text
+weight_mvb = 80_000 + 1×40_000 + 1×1_500_000 = 1_620_000
+vbytes     = ceil(1_620_000 / 1000) = 1_620
+```
+
+At 5 sat/vB this lowers to a minimum fee of `1_620 × 5 = 8_100 sats`.
+At 1 sat/vB (testnet default) the minimum is `1_620 sats` — directly
+comparable against the `fee_amount` field on the wire.
+
+## Validator integration (cross-issue)
+
+The validator (#538) uses the result of `minimum_fee_confidential`
+exactly once per submission, per the ADR-0004 §"Validation pseudocode":
+
+```text
+let min  = fee_manager.minimum_fee_confidential(inputs, outputs).await?;
+let fee  = tx.fee_amount;                            // single read
+
+if !is_operator_initiated && fee < min {
+    return Err(ValidationError::FeeBelowMinimum { fee, min });
+}
+```
+
+Operator-initiated sweeps bypass the gate (see ADR-0004 step (3) of
+`validate_fee`). The validator also enforces the per-deployment cap
+`operator_max_fee` and the fee-bump increment, both of which live in
+`dark-core` and are out of scope for the fee-manager.
+
+## Tests
+
+### Unit tests (per backend)
+
+- `crates/dark-fee-manager/src/confidential.rs::tests` — weight constants,
+  `confidential_vbytes`, `minimum_fee_for_rate`, `ConfidentialFeeAdapter`.
+- `crates/dark-fee-manager/src/simple.rs::tests` —
+  `minimum_fee_confidential` clamping, scaling, rate behaviour.
+- `crates/dark-fee-manager/src/weight.rs::tests` —
+  `estimate_confidential_fee`, count-only contract, scaling per
+  input / per output.
+- `crates/dark-core/src/domain/fee.rs::tests` —
+  `calculate_confidential_intent_fee` zero-program, base-only,
+  offchain-only invariant, scaling.
+
+### Integration test (acceptance criterion 2)
+
+`crates/dark-fee-manager/tests/confidential_fee_integration.rs` exercises
+the rejected/accepted contract for every wired backend (Static / Weight
+/ RPC-adapter / CEL / Noop) against a tiny in-test fee gate that mirrors
+the ADR-0004 §"Validation pseudocode". For each backend it asserts:
+
+1. `fee_amount = min - 1` rejects with `ERROR_FEE_TOO_LOW` (mapped to
+   the `Verdict::RejectedFeeTooLow` variant in-test).
+2. `fee_amount = min` accepts.
+3. `fee_amount = min + 1` accepts.
+4. The CEL surface ignores `onchain_*_fee` (sentinel value pins this).
+5. `NoopFeeManager` accepts a zero-fee confidential tx (zero-min config,
+   per ADR-0004 edge-case row "`fee_amount = 0`,
+   `operator_min_fee = 0`").
+
+## References
+
+- [ADR-0004 — Fee handling in confidential transactions](../adr/0004-confidential-fee-handling.md)
+- [Confidential VTXO + transaction proto schema](confidential-vtxo-schema.md)
+- [`dark-confidential` benchmark baseline](../benchmarks/confidential-primitives.md)
+- Issue #536 — ADR drafting
+- Issue #537 — `ConfidentialTransaction` proto + RPC surface
+- Issue #538 — validation pipeline in `dark-core`
+- Issue #543 — this document's owning issue
+- `crates/dark-fee-manager/src/confidential.rs` — weight constants and
+  `ConfidentialFeeAdapter`
+- `crates/dark-core/src/ports.rs` — `FeeManagerService` trait
+- `crates/dark-core/src/domain/fee.rs` — `FeeProgram` (CEL) surface


### PR DESCRIPTION
- **docs(adr): define confidential transaction fee handling (#536)**
- **feat(dark-live-store): add NullifierSet for confidential VTXO spent set (#534)**
- **feat(proto): add confidential transaction RPC schema (#537)**
- **feat(dark-core): add round Merkle tree with confidential leaf support (#540)**
- **feat(dark-fee-manager): add confidential-tx fee scoring (#543)**
