### PR TITLE
feat(dark-db): round announcement storage (#556)

### DIFF
--- a/crates/dark-core/src/lib.rs
+++ b/crates/dark-core/src/lib.rs
@@ -78,10 +78,11 @@ pub use ports::{
     FraudDetector, IndexerService, IndexerStats, LoggingEventPublisher, NewBlockEvent, NoopAlerts,
     NoopBlockchainScanner, NoopCheckpointRepository, NoopConvictionRepository, NoopFeeManager,
     NoopForfeitRepository, NoopFraudDetector, NoopIndexerService, NoopNullifierSink,
-    NoopOffchainTxRepository, NoopScheduledSessionRepository, NoopSweepService, NoopTxDecoder,
-    NullifierSink, OffchainTxRepository, RoundRepository, ScheduledSessionRepository,
-    ScriptSpentEvent, SignerService, SweepResult, SweepService, TxBuilder, TxDecoder, Unlocker,
-    VtxoRepository, WalletBalance, WalletService,
+    NoopOffchainTxRepository, NoopRoundAnnouncementRepository, NoopScheduledSessionRepository,
+    NoopSweepService, NoopTxDecoder, NullifierSink, OffchainTxRepository, RoundAnnouncement,
+    RoundAnnouncementRepository, RoundRepository, ScheduledSessionRepository, ScriptSpentEvent,
+    SignerService, SweepResult, SweepService, TxBuilder, TxDecoder, Unlocker, VtxoRepository,
+    WalletBalance, WalletService,
 };
 pub use round_batching::{
     assert_anchor_path_variant_agnostic, count_variants_from_intents, count_variants_from_vtxos,

--- a/crates/dark-core/src/ports.rs
+++ b/crates/dark-core/src/ports.rs
@@ -40,6 +40,86 @@ pub struct RoundAnnouncement {
     pub ephemeral_pubkey: String,
 }
 
+/// Persistent storage for per-round stealth announcements (issue #556).
+///
+/// Round announcements are the public `(round_id, vtxo_id, ephemeral_pubkey)`
+/// tuples scanning clients fetch to detect incoming stealth VTXOs. Each
+/// announcement is tagged with the on-chain `block_height` of the round so
+/// clients can resume sync after going offline and so the operator can
+/// honour the retention policy from issue #552 (`m5-dd-pruning`).
+///
+/// ## Concurrency contract
+///
+/// - `insert_announcements` MUST be atomic across the batch: either every
+///   tuple lands or none do. Implementations are expected to wrap the
+///   inserts in a single transaction.
+/// - Inserts are idempotent on `(round_id, vtxo_id)`; replaying a round
+///   commit must not duplicate rows.
+/// - The other methods are read-mostly and safe to call concurrently.
+#[async_trait]
+pub trait RoundAnnouncementRepository: Send + Sync {
+    /// Persist a batch of announcements emitted by a single round commit.
+    ///
+    /// `block_height` is the height at which the round committed; it is
+    /// recorded against every row so `prune_before` and `list_after_height`
+    /// can range-scan it.
+    async fn insert_announcements(
+        &self,
+        announcements: &[RoundAnnouncement],
+        block_height: u32,
+    ) -> ArkResult<()>;
+
+    /// List every announcement for a single round, ordered by `vtxo_id`
+    /// for stable iteration.
+    async fn list_for_round(&self, round_id: &str) -> ArkResult<Vec<RoundAnnouncement>>;
+
+    /// List announcements committed at a `block_height` strictly greater
+    /// than `height`, ordered by `(block_height, round_id, vtxo_id)` to
+    /// give scanning clients a stable resume cursor.
+    ///
+    /// `limit` MUST be honoured by the implementation; callers paginate
+    /// by passing the highest `block_height` they have seen back as the
+    /// next `height`.
+    async fn list_after_height(&self, height: u32, limit: u32)
+        -> ArkResult<Vec<RoundAnnouncement>>;
+
+    /// Delete every announcement with `block_height < cutoff_block`.
+    /// Returns the number of rows removed so the pruning job can emit a
+    /// metric.
+    async fn prune_before(&self, cutoff_block: u32) -> ArkResult<u64>;
+}
+
+/// No-op implementation. Inserts and prunes report success; reads return
+/// empty. Wire this when announcement persistence is not yet configured.
+pub struct NoopRoundAnnouncementRepository;
+
+#[async_trait]
+impl RoundAnnouncementRepository for NoopRoundAnnouncementRepository {
+    async fn insert_announcements(
+        &self,
+        _announcements: &[RoundAnnouncement],
+        _block_height: u32,
+    ) -> ArkResult<()> {
+        Ok(())
+    }
+
+    async fn list_for_round(&self, _round_id: &str) -> ArkResult<Vec<RoundAnnouncement>> {
+        Ok(Vec::new())
+    }
+
+    async fn list_after_height(
+        &self,
+        _height: u32,
+        _limit: u32,
+    ) -> ArkResult<Vec<RoundAnnouncement>> {
+        Ok(Vec::new())
+    }
+
+    async fn prune_before(&self, _cutoff_block: u32) -> ArkResult<u64> {
+        Ok(0)
+    }
+}
+
 /// Unified query interface for VTXOs, rounds, and forfeit records.
 ///
 /// Mirrors Go dark's `IndexerService` — provides read-only, cross-repository

--- a/crates/dark-db/migrations/010_round_announcements.sql
+++ b/crates/dark-db/migrations/010_round_announcements.sql
@@ -1,0 +1,47 @@
+-- Migration 010: Round announcement storage and indexing (issue #556)
+--
+-- Persists per-round stealth-VTXO announcement tuples
+-- (round_id, vtxo_id, ephemeral_pubkey) so scanning clients can fetch them
+-- without downloading full VTXO data. Retention follows the policy decided in
+-- issue #552 (m5-dd-pruning) — this migration only provides the schema and
+-- the indexes the pruning job requires.
+--
+-- Schema choices:
+--   - `(round_id, vtxo_id)` as the composite PRIMARY KEY makes inserts
+--     idempotent at the DB layer (re-emitting a round commit does not produce
+--     duplicate rows). It also gives us the stable ordering scanning clients
+--     paginate over.
+--   - `block_height` is recorded on insert so the pruning job can drop
+--     announcements below a cutoff in O(log N) via the index below. It also
+--     lets clients resume sync from a block height after a long offline
+--     period.
+--   - `created_at` is a wall-clock fallback for diagnostics / metrics — not
+--     used for ordering or pruning.
+--   - `ephemeral_pubkey` is stored as TEXT (hex-encoded compressed pubkey)
+--     to match the API surface in `RoundAnnouncement` and to avoid a BLOB
+--     conversion at every read.
+--
+-- Indexes:
+--   - PK on `(round_id, vtxo_id)` covers `list_for_round` and the
+--     paginated `(round_id, vtxo_id)` cursor used by the gRPC stream.
+--   - `idx_round_announcements_block_height` covers `list_after_height` and
+--     `prune_before` — both are range scans on `block_height`.
+--   - `idx_round_announcements_vtxo_id` covers reverse lookups
+--     ("which round announced this VTXO?") used by client-side rescans.
+--
+-- Idempotent: every CREATE uses IF NOT EXISTS, so re-running this migration
+-- against an already-migrated database is a no-op.
+CREATE TABLE IF NOT EXISTS round_announcements (
+    round_id         TEXT    NOT NULL,
+    vtxo_id          TEXT    NOT NULL,
+    ephemeral_pubkey TEXT    NOT NULL,
+    block_height     INTEGER NOT NULL DEFAULT 0,
+    created_at       INTEGER NOT NULL DEFAULT (strftime('%s','now')),
+    PRIMARY KEY (round_id, vtxo_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_round_announcements_block_height
+    ON round_announcements(block_height);
+
+CREATE INDEX IF NOT EXISTS idx_round_announcements_vtxo_id
+    ON round_announcements(vtxo_id);

--- a/crates/dark-db/migrations/pg/007_round_announcements.sql
+++ b/crates/dark-db/migrations/pg/007_round_announcements.sql
@@ -1,0 +1,22 @@
+-- Migration 007 (pg): Round announcement storage and indexing (#556).
+--
+-- Mirrors the SQLite migration 010. See that file for the schema rationale,
+-- the index strategy, and the relationship to the pruning policy in #552.
+--
+-- Idempotent: every CREATE uses IF NOT EXISTS, so re-running this migration
+-- against an already-migrated database is a no-op.
+
+CREATE TABLE IF NOT EXISTS round_announcements (
+    round_id         TEXT        NOT NULL,
+    vtxo_id          TEXT        NOT NULL,
+    ephemeral_pubkey TEXT        NOT NULL,
+    block_height     BIGINT      NOT NULL DEFAULT 0,
+    created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (round_id, vtxo_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_round_announcements_block_height
+    ON round_announcements(block_height);
+
+CREATE INDEX IF NOT EXISTS idx_round_announcements_vtxo_id
+    ON round_announcements(vtxo_id);

--- a/crates/dark-db/src/lib.rs
+++ b/crates/dark-db/src/lib.rs
@@ -33,14 +33,16 @@ pub use pool::Database;
 pub use repos::{
     SqliteAssetRepository, SqliteBoardingRepository, SqliteCheckpointRepository,
     SqliteConfirmationStore, SqliteConvictionRepository, SqliteForfeitRepository,
-    SqliteNullifierStore, SqliteOffchainTxRepository, SqliteRoundRepository,
-    SqliteSigningSessionStore, SqliteVtxoRepository,
+    SqliteNullifierStore, SqliteOffchainTxRepository, SqliteRoundAnnouncementRepository,
+    SqliteRoundRepository, SqliteSigningSessionStore, SqliteVtxoRepository,
 };
 
 #[cfg(feature = "postgres")]
 pub use pool_postgres::{create_postgres_pool, run_postgres_migrations};
 #[cfg(feature = "postgres")]
-pub use repos::{PgOffchainTxRepository, PgRoundRepository, PgVtxoRepository};
+pub use repos::{
+    PgOffchainTxRepository, PgRoundAnnouncementRepository, PgRoundRepository, PgVtxoRepository,
+};
 
 pub use sled_repos::{SledConvictionRepository, SledEventStore, SledScheduledSessionRepository};
 

--- a/crates/dark-db/src/pool.rs
+++ b/crates/dark-db/src/pool.rs
@@ -123,6 +123,7 @@ impl Database {
                 include_str!("../migrations/007_vtxo_assets.sql"),
                 include_str!("../migrations/008_confidential_vtxos.sql"),
                 include_str!("../migrations/009_nullifiers.sql"),
+                include_str!("../migrations/010_round_announcements.sql"),
             ];
 
             for (i, migration_sql) in migrations.iter().enumerate() {
@@ -147,7 +148,7 @@ impl Database {
                     })?;
                 }
             }
-            info!("Migrations applied successfully (001-009)");
+            info!("Migrations applied successfully (001-010)");
         }
         Ok(())
     }

--- a/crates/dark-db/src/pool_postgres.rs
+++ b/crates/dark-db/src/pool_postgres.rs
@@ -82,6 +82,12 @@ pub async fn run_postgres_migrations(pool: &PgPool) -> DatabaseResult<()> {
         .await
         .map_err(|e| DatabaseError::MigrationError(format!("PG migration 006 failed: {e}")))?;
 
+    let migration_007 = include_str!("../migrations/pg/007_round_announcements.sql");
+    sqlx::query(migration_007)
+        .execute(pool)
+        .await
+        .map_err(|e| DatabaseError::MigrationError(format!("PG migration 007 failed: {e}")))?;
+
     info!("PostgreSQL migrations applied successfully");
     Ok(())
 }

--- a/crates/dark-db/src/repos/mod.rs
+++ b/crates/dark-db/src/repos/mod.rs
@@ -20,6 +20,8 @@ pub mod nullifier_store;
 #[cfg(feature = "sqlite")]
 pub mod offchain_tx_repo;
 #[cfg(feature = "sqlite")]
+pub mod round_announcement_repo;
+#[cfg(feature = "sqlite")]
 pub mod round_repo;
 #[cfg(feature = "sqlite")]
 pub mod scheduled_session_repo;
@@ -30,6 +32,8 @@ pub mod vtxo_repo;
 
 #[cfg(feature = "postgres")]
 pub mod offchain_tx_repo_pg;
+#[cfg(feature = "postgres")]
+pub mod round_announcement_repo_pg;
 #[cfg(feature = "postgres")]
 pub mod round_repo_pg;
 #[cfg(feature = "postgres")]
@@ -52,6 +56,8 @@ pub use nullifier_store::SqliteNullifierStore;
 #[cfg(feature = "sqlite")]
 pub use offchain_tx_repo::SqliteOffchainTxRepository;
 #[cfg(feature = "sqlite")]
+pub use round_announcement_repo::SqliteRoundAnnouncementRepository;
+#[cfg(feature = "sqlite")]
 pub use round_repo::SqliteRoundRepository;
 #[cfg(feature = "sqlite")]
 pub use scheduled_session_repo::SqliteScheduledSessionRepository;
@@ -65,6 +71,8 @@ pub mod scheduled_session_repo_pg;
 
 #[cfg(feature = "postgres")]
 pub use offchain_tx_repo_pg::PgOffchainTxRepository;
+#[cfg(feature = "postgres")]
+pub use round_announcement_repo_pg::PgRoundAnnouncementRepository;
 #[cfg(feature = "postgres")]
 pub use round_repo_pg::PgRoundRepository;
 #[cfg(feature = "postgres")]

--- a/crates/dark-db/src/repos/round_announcement_repo.rs
+++ b/crates/dark-db/src/repos/round_announcement_repo.rs
@@ -1,0 +1,319 @@
+//! Round announcement repository — SQLite implementation of
+//! `dark_core::ports::RoundAnnouncementRepository` (issue #556).
+//!
+//! Persists `(round_id, vtxo_id, ephemeral_pubkey)` tuples emitted by every
+//! round commit so scanning clients can detect incoming stealth VTXOs without
+//! downloading full VTXO data. The schema lives in migration 010.
+
+use async_trait::async_trait;
+use dark_core::error::{ArkError, ArkResult};
+use dark_core::ports::{RoundAnnouncement, RoundAnnouncementRepository};
+use sqlx::SqlitePool;
+use tracing::debug;
+
+/// SQLite-backed announcement repository.
+pub struct SqliteRoundAnnouncementRepository {
+    pool: SqlitePool,
+}
+
+impl SqliteRoundAnnouncementRepository {
+    /// Wrap an existing pool. The caller owns migration execution; this
+    /// constructor does not validate that table `round_announcements` exists.
+    pub fn new(pool: SqlitePool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl RoundAnnouncementRepository for SqliteRoundAnnouncementRepository {
+    async fn insert_announcements(
+        &self,
+        announcements: &[RoundAnnouncement],
+        block_height: u32,
+    ) -> ArkResult<()> {
+        if announcements.is_empty() {
+            return Ok(());
+        }
+
+        debug!(
+            count = announcements.len(),
+            block_height, "Inserting round announcements"
+        );
+
+        // One transaction so the whole batch lands atomically with the
+        // round commit caller.
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        for ann in announcements {
+            sqlx::query(
+                r#"
+                INSERT INTO round_announcements
+                    (round_id, vtxo_id, ephemeral_pubkey, block_height)
+                VALUES (?1, ?2, ?3, ?4)
+                ON CONFLICT(round_id, vtxo_id) DO UPDATE SET
+                    ephemeral_pubkey = excluded.ephemeral_pubkey,
+                    block_height = excluded.block_height
+                "#,
+            )
+            .bind(&ann.round_id)
+            .bind(&ann.vtxo_id)
+            .bind(&ann.ephemeral_pubkey)
+            .bind(block_height as i64)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn list_for_round(&self, round_id: &str) -> ArkResult<Vec<RoundAnnouncement>> {
+        debug!(round_id, "Listing round announcements for round");
+
+        let rows = sqlx::query_as::<_, AnnouncementRow>(
+            r#"
+            SELECT round_id, vtxo_id, ephemeral_pubkey
+            FROM round_announcements
+            WHERE round_id = ?1
+            ORDER BY vtxo_id ASC
+            "#,
+        )
+        .bind(round_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(AnnouncementRow::into_announcement)
+            .collect())
+    }
+
+    async fn list_after_height(
+        &self,
+        height: u32,
+        limit: u32,
+    ) -> ArkResult<Vec<RoundAnnouncement>> {
+        debug!(height, limit, "Listing round announcements after height");
+
+        let rows = sqlx::query_as::<_, AnnouncementRow>(
+            r#"
+            SELECT round_id, vtxo_id, ephemeral_pubkey
+            FROM round_announcements
+            WHERE block_height > ?1
+            ORDER BY block_height ASC, round_id ASC, vtxo_id ASC
+            LIMIT ?2
+            "#,
+        )
+        .bind(height as i64)
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(AnnouncementRow::into_announcement)
+            .collect())
+    }
+
+    async fn prune_before(&self, cutoff_block: u32) -> ArkResult<u64> {
+        debug!(cutoff_block, "Pruning round announcements before cutoff");
+
+        let result = sqlx::query("DELETE FROM round_announcements WHERE block_height < ?1")
+            .bind(cutoff_block as i64)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(result.rows_affected())
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct AnnouncementRow {
+    round_id: String,
+    vtxo_id: String,
+    ephemeral_pubkey: String,
+}
+
+impl AnnouncementRow {
+    fn into_announcement(self) -> RoundAnnouncement {
+        RoundAnnouncement {
+            round_id: self.round_id,
+            vtxo_id: self.vtxo_id,
+            ephemeral_pubkey: self.ephemeral_pubkey,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Database;
+
+    async fn fresh_repo() -> SqliteRoundAnnouncementRepository {
+        let db = Database::connect_in_memory().await.unwrap();
+        SqliteRoundAnnouncementRepository::new(db.sqlite_pool().unwrap().clone())
+    }
+
+    fn make_announcement(
+        round_id: &str,
+        vtxo_id: &str,
+        ephemeral_pubkey: &str,
+    ) -> RoundAnnouncement {
+        RoundAnnouncement {
+            round_id: round_id.to_string(),
+            vtxo_id: vtxo_id.to_string(),
+            ephemeral_pubkey: ephemeral_pubkey.to_string(),
+        }
+    }
+
+    #[tokio::test]
+    async fn insert_empty_batch_is_a_no_op() {
+        let repo = fresh_repo().await;
+        repo.insert_announcements(&[], 100).await.unwrap();
+        assert!(repo.list_for_round("any").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn insert_and_list_for_round_round_trips() {
+        let repo = fresh_repo().await;
+
+        let batch = vec![
+            make_announcement("round-1", "vtxo-b:0", "pk_b"),
+            make_announcement("round-1", "vtxo-a:0", "pk_a"),
+            make_announcement("round-2", "vtxo-c:0", "pk_c"),
+        ];
+        repo.insert_announcements(&batch, 800_000).await.unwrap();
+
+        let round1 = repo.list_for_round("round-1").await.unwrap();
+        // Returned in stable vtxo_id order regardless of insert order.
+        assert_eq!(round1.len(), 2);
+        assert_eq!(round1[0].vtxo_id, "vtxo-a:0");
+        assert_eq!(round1[1].vtxo_id, "vtxo-b:0");
+
+        let round2 = repo.list_for_round("round-2").await.unwrap();
+        assert_eq!(round2.len(), 1);
+        assert_eq!(round2[0].ephemeral_pubkey, "pk_c");
+    }
+
+    #[tokio::test]
+    async fn insert_is_idempotent_on_round_id_and_vtxo_id() {
+        let repo = fresh_repo().await;
+
+        let ann = make_announcement("round-1", "vtxo-a:0", "pk_a");
+        repo.insert_announcements(std::slice::from_ref(&ann), 800_000)
+            .await
+            .unwrap();
+
+        // Replay the same round commit — must not produce a duplicate row.
+        repo.insert_announcements(&[ann], 800_000).await.unwrap();
+
+        let round1 = repo.list_for_round("round-1").await.unwrap();
+        assert_eq!(round1.len(), 1);
+    }
+
+    #[tokio::test]
+    async fn list_for_round_unknown_returns_empty() {
+        let repo = fresh_repo().await;
+        assert!(repo.list_for_round("missing").await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn list_after_height_orders_by_height_then_id() {
+        let repo = fresh_repo().await;
+
+        repo.insert_announcements(&[make_announcement("r-100", "v1:0", "pk1")], 100)
+            .await
+            .unwrap();
+        repo.insert_announcements(&[make_announcement("r-200", "v2:0", "pk2")], 200)
+            .await
+            .unwrap();
+        repo.insert_announcements(&[make_announcement("r-300", "v3:0", "pk3")], 300)
+            .await
+            .unwrap();
+
+        // Strictly greater than the cutoff.
+        let after_100 = repo.list_after_height(100, 100).await.unwrap();
+        assert_eq!(after_100.len(), 2);
+        assert_eq!(after_100[0].round_id, "r-200");
+        assert_eq!(after_100[1].round_id, "r-300");
+
+        // Limit is honoured.
+        let after_50_limit_2 = repo.list_after_height(50, 2).await.unwrap();
+        assert_eq!(after_50_limit_2.len(), 2);
+        assert_eq!(after_50_limit_2[0].round_id, "r-100");
+        assert_eq!(after_50_limit_2[1].round_id, "r-200");
+    }
+
+    #[tokio::test]
+    async fn list_after_height_above_max_returns_empty() {
+        let repo = fresh_repo().await;
+        repo.insert_announcements(&[make_announcement("r1", "v1:0", "pk1")], 100)
+            .await
+            .unwrap();
+
+        assert!(repo.list_after_height(100, 100).await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn prune_before_drops_only_below_cutoff_and_returns_count() {
+        let repo = fresh_repo().await;
+
+        repo.insert_announcements(&[make_announcement("r-100", "v1:0", "pk1")], 100)
+            .await
+            .unwrap();
+        repo.insert_announcements(&[make_announcement("r-200", "v2:0", "pk2")], 200)
+            .await
+            .unwrap();
+        repo.insert_announcements(&[make_announcement("r-300", "v3:0", "pk3")], 300)
+            .await
+            .unwrap();
+
+        // Strictly less than: 200 stays, 100 is dropped.
+        let pruned = repo.prune_before(200).await.unwrap();
+        assert_eq!(pruned, 1);
+
+        let remaining = repo.list_after_height(0, 100).await.unwrap();
+        assert_eq!(remaining.len(), 2);
+        assert_eq!(remaining[0].round_id, "r-200");
+        assert_eq!(remaining[1].round_id, "r-300");
+    }
+
+    #[tokio::test]
+    async fn prune_before_with_no_matches_is_a_no_op() {
+        let repo = fresh_repo().await;
+        repo.insert_announcements(&[make_announcement("r-100", "v1:0", "pk1")], 100)
+            .await
+            .unwrap();
+
+        let pruned = repo.prune_before(50).await.unwrap();
+        assert_eq!(pruned, 0);
+
+        assert_eq!(repo.list_for_round("r-100").await.unwrap().len(), 1);
+    }
+
+    #[tokio::test]
+    async fn batch_insert_is_atomic() {
+        // The batch insert opens a single transaction; verify all rows are
+        // visible after commit (and that a successful batch leaves the
+        // count consistent with the input length).
+        let repo = fresh_repo().await;
+
+        let batch: Vec<RoundAnnouncement> = (0..16)
+            .map(|i| make_announcement("round-1", &format!("vtxo-{i}:0"), &format!("pk{i}")))
+            .collect();
+        repo.insert_announcements(&batch, 12_345).await.unwrap();
+
+        let stored = repo.list_for_round("round-1").await.unwrap();
+        assert_eq!(stored.len(), 16);
+    }
+}

--- a/crates/dark-db/src/repos/round_announcement_repo_pg.rs
+++ b/crates/dark-db/src/repos/round_announcement_repo_pg.rs
@@ -1,0 +1,157 @@
+//! Round announcement repository — PostgreSQL implementation of
+//! `dark_core::ports::RoundAnnouncementRepository` (issue #556).
+//!
+//! Mirrors the SQLite implementation. See `round_announcement_repo.rs` for
+//! the schema rationale and the per-method contract.
+
+use async_trait::async_trait;
+use dark_core::error::{ArkError, ArkResult};
+use dark_core::ports::{RoundAnnouncement, RoundAnnouncementRepository};
+use sqlx::PgPool;
+use tracing::debug;
+
+/// PostgreSQL-backed announcement repository.
+pub struct PgRoundAnnouncementRepository {
+    pool: PgPool,
+}
+
+impl PgRoundAnnouncementRepository {
+    /// Wrap an existing pool. The caller owns migration execution.
+    pub fn new(pool: PgPool) -> Self {
+        Self { pool }
+    }
+}
+
+#[async_trait]
+impl RoundAnnouncementRepository for PgRoundAnnouncementRepository {
+    async fn insert_announcements(
+        &self,
+        announcements: &[RoundAnnouncement],
+        block_height: u32,
+    ) -> ArkResult<()> {
+        if announcements.is_empty() {
+            return Ok(());
+        }
+
+        debug!(
+            count = announcements.len(),
+            block_height, "Inserting round announcements (PG)"
+        );
+
+        let mut tx = self
+            .pool
+            .begin()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        for ann in announcements {
+            sqlx::query(
+                r#"
+                INSERT INTO round_announcements
+                    (round_id, vtxo_id, ephemeral_pubkey, block_height)
+                VALUES ($1, $2, $3, $4)
+                ON CONFLICT (round_id, vtxo_id) DO UPDATE SET
+                    ephemeral_pubkey = EXCLUDED.ephemeral_pubkey,
+                    block_height = EXCLUDED.block_height
+                "#,
+            )
+            .bind(&ann.round_id)
+            .bind(&ann.vtxo_id)
+            .bind(&ann.ephemeral_pubkey)
+            .bind(block_height as i64)
+            .execute(&mut *tx)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        }
+
+        tx.commit()
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+        Ok(())
+    }
+
+    async fn list_for_round(&self, round_id: &str) -> ArkResult<Vec<RoundAnnouncement>> {
+        debug!(round_id, "Listing round announcements for round (PG)");
+
+        let rows = sqlx::query_as::<_, AnnouncementRow>(
+            r#"
+            SELECT round_id, vtxo_id, ephemeral_pubkey
+            FROM round_announcements
+            WHERE round_id = $1
+            ORDER BY vtxo_id ASC
+            "#,
+        )
+        .bind(round_id)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(AnnouncementRow::into_announcement)
+            .collect())
+    }
+
+    async fn list_after_height(
+        &self,
+        height: u32,
+        limit: u32,
+    ) -> ArkResult<Vec<RoundAnnouncement>> {
+        debug!(
+            height,
+            limit, "Listing round announcements after height (PG)"
+        );
+
+        let rows = sqlx::query_as::<_, AnnouncementRow>(
+            r#"
+            SELECT round_id, vtxo_id, ephemeral_pubkey
+            FROM round_announcements
+            WHERE block_height > $1
+            ORDER BY block_height ASC, round_id ASC, vtxo_id ASC
+            LIMIT $2
+            "#,
+        )
+        .bind(height as i64)
+        .bind(limit as i64)
+        .fetch_all(&self.pool)
+        .await
+        .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(rows
+            .into_iter()
+            .map(AnnouncementRow::into_announcement)
+            .collect())
+    }
+
+    async fn prune_before(&self, cutoff_block: u32) -> ArkResult<u64> {
+        debug!(
+            cutoff_block,
+            "Pruning round announcements before cutoff (PG)"
+        );
+
+        let result = sqlx::query("DELETE FROM round_announcements WHERE block_height < $1")
+            .bind(cutoff_block as i64)
+            .execute(&self.pool)
+            .await
+            .map_err(|e| ArkError::DatabaseError(e.to_string()))?;
+
+        Ok(result.rows_affected())
+    }
+}
+
+#[derive(Debug, sqlx::FromRow)]
+struct AnnouncementRow {
+    round_id: String,
+    vtxo_id: String,
+    ephemeral_pubkey: String,
+}
+
+impl AnnouncementRow {
+    fn into_announcement(self) -> RoundAnnouncement {
+        RoundAnnouncement {
+            round_id: self.round_id,
+            vtxo_id: self.vtxo_id,
+            ephemeral_pubkey: self.ephemeral_pubkey,
+        }
+    }
+}

--- a/crates/dark-db/tests/postgres_e2e.rs
+++ b/crates/dark-db/tests/postgres_e2e.rs
@@ -10,8 +10,10 @@
 #![cfg(feature = "postgres")]
 
 use dark_core::domain::{Round, RoundStage, Stage};
-use dark_core::ports::RoundRepository;
-use dark_db::{create_postgres_pool, run_postgres_migrations, PgRoundRepository};
+use dark_core::ports::{RoundAnnouncement, RoundAnnouncementRepository, RoundRepository};
+use dark_db::{
+    create_postgres_pool, run_postgres_migrations, PgRoundAnnouncementRepository, PgRoundRepository,
+};
 
 /// Full round-trip: connect → migrate → insert round → read back → verify.
 #[tokio::test]
@@ -86,4 +88,111 @@ async fn postgres_round_trip() {
         .execute(&pool)
         .await
         .expect("Failed to clean up test round");
+}
+
+/// Full round-trip for the round announcement repo (issue #556).
+///
+/// Inserts a small batch, reads back via every query method, prunes a
+/// cutoff, and verifies the row counts at each step. Cleans up its own
+/// rows so the test is idempotent.
+#[tokio::test]
+async fn postgres_round_announcement_round_trip() {
+    let db_url = match std::env::var("DATABASE_URL") {
+        Ok(url) => url,
+        Err(_) => {
+            eprintln!("DATABASE_URL not set — skipping PostgreSQL E2E test");
+            return;
+        }
+    };
+
+    let pool = create_postgres_pool(&db_url)
+        .await
+        .expect("Failed to create PostgreSQL pool");
+    run_postgres_migrations(&pool)
+        .await
+        .expect("Failed to run migrations");
+
+    // Use a unique round-id prefix so concurrent runs do not collide.
+    let test_prefix = format!("e2e-ann-{}", uuid::Uuid::new_v4());
+    let round_low = format!("{test_prefix}-low");
+    let round_mid = format!("{test_prefix}-mid");
+    let round_high = format!("{test_prefix}-high");
+
+    let repo = PgRoundAnnouncementRepository::new(pool.clone());
+
+    let make = |round_id: &str, vtxo_id: &str, pk: &str| RoundAnnouncement {
+        round_id: round_id.to_string(),
+        vtxo_id: vtxo_id.to_string(),
+        ephemeral_pubkey: pk.to_string(),
+    };
+
+    // Insert three rounds at different block heights.
+    repo.insert_announcements(
+        &[
+            make(&round_low, "vtxo-b:0", "pk_b"),
+            make(&round_low, "vtxo-a:0", "pk_a"),
+        ],
+        100,
+    )
+    .await
+    .expect("insert low");
+    repo.insert_announcements(&[make(&round_mid, "vtxo-c:0", "pk_c")], 200)
+        .await
+        .expect("insert mid");
+    repo.insert_announcements(&[make(&round_high, "vtxo-d:0", "pk_d")], 300)
+        .await
+        .expect("insert high");
+
+    // list_for_round returns rows ordered by vtxo_id.
+    let low_rows = repo.list_for_round(&round_low).await.expect("list low");
+    assert_eq!(low_rows.len(), 2);
+    assert_eq!(low_rows[0].vtxo_id, "vtxo-a:0");
+    assert_eq!(low_rows[1].vtxo_id, "vtxo-b:0");
+
+    // list_after_height returns strictly greater rows ordered by height.
+    let after_100: Vec<_> = repo
+        .list_after_height(100, 100)
+        .await
+        .expect("list after height")
+        .into_iter()
+        .filter(|r| r.round_id.starts_with(&test_prefix))
+        .collect();
+    assert_eq!(after_100.len(), 2);
+    assert_eq!(after_100[0].round_id, round_mid);
+    assert_eq!(after_100[1].round_id, round_high);
+
+    // Idempotent insert: replaying the same row does not duplicate it.
+    repo.insert_announcements(&[make(&round_low, "vtxo-a:0", "pk_a")], 100)
+        .await
+        .expect("idempotent insert");
+    assert_eq!(
+        repo.list_for_round(&round_low)
+            .await
+            .expect("re-list low")
+            .len(),
+        2
+    );
+
+    // prune_before drops only rows strictly below the cutoff and reports
+    // the count.
+    let pruned = repo.prune_before(200).await.expect("prune");
+    assert!(pruned >= 2, "should prune at least the two low rows");
+
+    let after_prune: Vec<_> = repo
+        .list_after_height(0, 100)
+        .await
+        .expect("list after prune")
+        .into_iter()
+        .filter(|r| r.round_id.starts_with(&test_prefix))
+        .collect();
+    assert_eq!(after_prune.len(), 2);
+    assert!(after_prune.iter().any(|r| r.round_id == round_mid));
+    assert!(after_prune.iter().any(|r| r.round_id == round_high));
+
+    // Clean up everything we inserted.
+    sqlx::query("DELETE FROM round_announcements WHERE round_id LIKE $1")
+        .bind(format!("{test_prefix}%"))
+        .execute(&pool)
+        .await
+        .expect("Failed to clean up test announcements");
 }


### PR DESCRIPTION
Closes #556. SQLite + Postgres migrations, RoundAnnouncementRepository trait + Noop. PK (round_id, vtxo_id) for idempotent inserts; indexes on block_height (pruning) and vtxo_id.