### PR TITLE
feat(dark-client): background stealth scanning loop (#558)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1200,6 +1200,7 @@ name = "dark-client"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "async-stream",
  "async-trait",
  "base64 0.22.1",
  "bech32",
@@ -1219,6 +1220,7 @@ dependencies = [
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
+ "tokio-util",
  "tonic",
  "tracing",
 ]

--- a/crates/dark-client/Cargo.toml
+++ b/crates/dark-client/Cargo.toml
@@ -33,3 +33,7 @@ base64 = "0.22"
 hex = "0.4"
 bech32 = "0.11"
 tokio-stream = "0.1"
+tokio-util = "0.7"
+
+[dev-dependencies]
+async-stream = "0.3"

--- a/crates/dark-client/src/lib.rs
+++ b/crates/dark-client/src/lib.rs
@@ -56,6 +56,7 @@ pub mod confidential_exit;
 pub mod error;
 pub mod explorer;
 pub mod sdk;
+pub mod stealth_scan;
 pub mod store;
 pub mod types;
 pub mod wallet;

--- a/crates/dark-client/src/stealth_scan.rs
+++ b/crates/dark-client/src/stealth_scan.rs
@@ -1,0 +1,665 @@
+//! Background stealth scanning loop for `dark-client`.
+//!
+//! `StealthScanner` is a long-running task that polls the operator's
+//! `GetRoundAnnouncements` stream for new stealth announcements, scans each
+//! one against the recipient's view key, and persists discovered VTXOs into
+//! the local [`InMemoryStore`].
+//!
+//! ## Lifecycle
+//!
+//! The scanner is constructed with the recipient's keys, an
+//! [`AnnouncementSource`], a local [`InMemoryStore`], and a
+//! [`tokio_util::sync::CancellationToken`] for shutdown. Calling
+//! [`StealthScanner::start`] consumes it and spawns a tokio task that loops
+//! until cancellation:
+//!
+//! 1. Fetch the next page of announcements (resuming from the persisted
+//!    checkpoint).
+//! 2. Scan each announcement; persist matches.
+//! 3. Persist the new checkpoint.
+//! 4. Sleep `poll_interval` (interruptible by the cancellation token).
+//!
+//! On startup the checkpoint is hydrated from the store's metadata under
+//! [`CHECKPOINT_METADATA_KEY`]; if absent the scanner starts from genesis.
+//!
+//! ## Stubbed dependencies
+//!
+//! - **#555** — recipient-side scan logic. [`scan_announcement`] is currently
+//!   a placeholder that matches when an announcement's `ephemeral_pubkey`
+//!   equals the hex-encoded compressed `spend_pk`. This is sufficient to
+//!   exercise the loop end-to-end; the real ECDH-based check will replace
+//!   it.
+//! - **#557** — the typed gRPC `GetRoundAnnouncements` client already
+//!   exists on [`ArkClient::get_round_announcements`]. We wrap it behind the
+//!   [`AnnouncementSource`] trait so tests can substitute a fake source
+//!   without spinning up a full gRPC server.
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_trait::async_trait;
+use bitcoin::secp256k1::{PublicKey, SecretKey};
+use tokio::sync::Mutex;
+use tokio::task::JoinHandle;
+use tokio::time;
+use tokio_util::sync::CancellationToken;
+use tracing::{debug, info, warn};
+
+use crate::client::ArkClient;
+use crate::error::ClientResult;
+use crate::store::InMemoryStore;
+use crate::types::{RoundAnnouncement, Vtxo};
+
+/// Default poll interval for the scanner loop.
+pub const DEFAULT_POLL_INTERVAL: Duration = Duration::from_secs(30);
+
+/// Default page size when fetching announcements.
+pub const DEFAULT_PAGE_LIMIT: u32 = 1_000;
+
+/// Metadata key under which the scanner persists its resume cursor.
+pub const CHECKPOINT_METADATA_KEY: &str = "stealth_scan:checkpoint";
+
+/// Resume cursor for the announcement stream.
+///
+/// `(round_id, vtxo_id)` is treated as exclusive — the next fetch will start
+/// strictly after this pair, mirroring the server's cursor semantics.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ScannerCheckpoint {
+    pub round_id: String,
+    pub vtxo_id: String,
+}
+
+impl ScannerCheckpoint {
+    /// True for the genesis (empty) checkpoint — i.e. nothing scanned yet.
+    pub fn is_genesis(&self) -> bool {
+        self.round_id.is_empty() && self.vtxo_id.is_empty()
+    }
+
+    /// Encode as `<round_id>\n<vtxo_id>` — the format consumed by the
+    /// `GetRoundAnnouncements` `cursor` field.
+    pub fn encode(&self) -> String {
+        format!("{}\n{}", self.round_id, self.vtxo_id)
+    }
+
+    /// Decode a serialized checkpoint produced by [`Self::encode`].
+    pub fn decode(raw: &str) -> Option<Self> {
+        let (round_id, vtxo_id) = raw.split_once('\n')?;
+        Some(Self {
+            round_id: round_id.to_string(),
+            vtxo_id: vtxo_id.to_string(),
+        })
+    }
+}
+
+/// Result of a successful announcement scan.
+///
+/// TODO(#555): expand to carry the shared secret and one-time spend key
+/// derivation material once the real recipient-scan logic lands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StealthMatch {
+    pub vtxo_id: String,
+    pub round_id: String,
+}
+
+/// Scan a single announcement against the recipient's keys.
+///
+/// TODO(#555): replace this stub with the real `ECDH(scan_priv, ephemeral_pk)`
+/// derivation and constant-time compare against the announced one-time key.
+/// For now the announcement matches when its `ephemeral_pubkey` equals the
+/// hex-encoded compressed serialization of `spend_pk` — a placeholder that
+/// lets the scanner loop be exercised end-to-end.
+pub fn scan_announcement(
+    _scan_priv: &SecretKey,
+    spend_pk: &PublicKey,
+    announcement: &RoundAnnouncement,
+) -> Option<StealthMatch> {
+    let expected = hex::encode(spend_pk.serialize());
+    if announcement.ephemeral_pubkey == expected {
+        Some(StealthMatch {
+            vtxo_id: announcement.vtxo_id.clone(),
+            round_id: announcement.round_id.clone(),
+        })
+    } else {
+        None
+    }
+}
+
+/// Source of round announcements — abstracted so tests can supply a fake
+/// without depending on a running gRPC server.
+#[async_trait]
+pub trait AnnouncementSource: Send + Sync {
+    /// Fetch the next page of announcements after `cursor` (exclusive). When
+    /// `cursor.is_genesis()`, the implementation may return the very first
+    /// page from the server's view of history.
+    async fn fetch(
+        &self,
+        cursor: &ScannerCheckpoint,
+        limit: u32,
+    ) -> ClientResult<Vec<RoundAnnouncement>>;
+
+    /// Fetch the full VTXO for a matched announcement so the scanner can
+    /// persist it locally.
+    ///
+    /// TODO(#558): the real implementation will fetch the VTXO over gRPC,
+    /// decrypt the memo, and store the opening alongside `(amount, blinding,
+    /// one_time_sk)`. The default impl returns `None`, leaving it up to the
+    /// caller (or a richer source) to materialize VTXO bodies.
+    async fn fetch_vtxo(&self, _matched: &StealthMatch) -> ClientResult<Option<Vtxo>> {
+        Ok(None)
+    }
+}
+
+/// [`AnnouncementSource`] backed by a shared [`ArkClient`].
+pub struct ArkClientSource {
+    client: Arc<Mutex<ArkClient>>,
+}
+
+impl ArkClientSource {
+    pub fn new(client: Arc<Mutex<ArkClient>>) -> Self {
+        Self { client }
+    }
+}
+
+#[async_trait]
+impl AnnouncementSource for ArkClientSource {
+    async fn fetch(
+        &self,
+        cursor: &ScannerCheckpoint,
+        limit: u32,
+    ) -> ClientResult<Vec<RoundAnnouncement>> {
+        let mut client = self.client.lock().await;
+        // The server requires either a cursor or both round_id_start and
+        // round_id_end. From genesis we use a wide-open range; otherwise we
+        // resume from the encoded cursor.
+        if cursor.is_genesis() {
+            client
+                .get_round_announcements(Some(""), Some("\u{10FFFF}"), None, Some(limit))
+                .await
+        } else {
+            let encoded = cursor.encode();
+            client
+                .get_round_announcements(None, None, Some(&encoded), Some(limit))
+                .await
+        }
+    }
+}
+
+/// Atomic counters exposed for observability — scan rate and match count
+/// can be sampled cheaply from any thread. The string `round_id` of the
+/// most recently scanned announcement lives on [`StealthScanner::checkpoint`].
+#[derive(Debug, Default)]
+pub struct ScannerMetrics {
+    /// Total announcements processed since startup.
+    pub announcements_scanned: AtomicU64,
+    /// Total announcements that produced a `StealthMatch`.
+    pub matches_found: AtomicU64,
+    /// Number of poll iterations completed.
+    pub poll_iterations: AtomicU64,
+    /// Number of polls that failed with a transient error.
+    pub poll_errors: AtomicU64,
+    /// Number of non-empty pages observed — useful as a rough scan-rate
+    /// signal independent of `poll_iterations`.
+    pub pages_with_data: AtomicU64,
+}
+
+impl ScannerMetrics {
+    pub fn announcements_scanned(&self) -> u64 {
+        self.announcements_scanned.load(Ordering::Relaxed)
+    }
+    pub fn matches_found(&self) -> u64 {
+        self.matches_found.load(Ordering::Relaxed)
+    }
+    pub fn poll_iterations(&self) -> u64 {
+        self.poll_iterations.load(Ordering::Relaxed)
+    }
+    pub fn poll_errors(&self) -> u64 {
+        self.poll_errors.load(Ordering::Relaxed)
+    }
+    pub fn pages_with_data(&self) -> u64 {
+        self.pages_with_data.load(Ordering::Relaxed)
+    }
+}
+
+/// Configuration for [`StealthScanner`].
+#[derive(Debug, Clone)]
+pub struct ScannerConfig {
+    pub poll_interval: Duration,
+    pub page_limit: u32,
+}
+
+impl Default for ScannerConfig {
+    fn default() -> Self {
+        Self {
+            poll_interval: DEFAULT_POLL_INTERVAL,
+            page_limit: DEFAULT_PAGE_LIMIT,
+        }
+    }
+}
+
+/// Long-running stealth scanner — see module docs for the lifecycle.
+pub struct StealthScanner {
+    scan_priv: SecretKey,
+    spend_pk: PublicKey,
+    source: Arc<dyn AnnouncementSource>,
+    store: InMemoryStore,
+    config: ScannerConfig,
+    cancel: CancellationToken,
+    metrics: Arc<ScannerMetrics>,
+    checkpoint: Arc<Mutex<ScannerCheckpoint>>,
+}
+
+impl StealthScanner {
+    pub fn new(
+        scan_priv: SecretKey,
+        spend_pk: PublicKey,
+        source: Arc<dyn AnnouncementSource>,
+        store: InMemoryStore,
+    ) -> Self {
+        Self::with_config(scan_priv, spend_pk, source, store, ScannerConfig::default())
+    }
+
+    pub fn with_config(
+        scan_priv: SecretKey,
+        spend_pk: PublicKey,
+        source: Arc<dyn AnnouncementSource>,
+        store: InMemoryStore,
+        config: ScannerConfig,
+    ) -> Self {
+        let checkpoint = hydrate_checkpoint(&store);
+        Self {
+            scan_priv,
+            spend_pk,
+            source,
+            store,
+            config,
+            cancel: CancellationToken::new(),
+            metrics: Arc::new(ScannerMetrics::default()),
+            checkpoint: Arc::new(Mutex::new(checkpoint)),
+        }
+    }
+
+    /// Replace the default cancellation token. Useful when callers want to
+    /// drive multiple background tasks from a single shared token.
+    pub fn with_cancellation(mut self, cancel: CancellationToken) -> Self {
+        self.cancel = cancel;
+        self
+    }
+
+    /// Handle to the cancellation token — call `.cancel()` to request a
+    /// graceful shutdown.
+    pub fn cancellation_token(&self) -> CancellationToken {
+        self.cancel.clone()
+    }
+
+    /// Cloneable handle to the scanner's metrics counters.
+    pub fn metrics(&self) -> Arc<ScannerMetrics> {
+        Arc::clone(&self.metrics)
+    }
+
+    /// Snapshot of the current resume cursor.
+    pub async fn checkpoint(&self) -> ScannerCheckpoint {
+        self.checkpoint.lock().await.clone()
+    }
+
+    /// Spawn the scanning loop on the current tokio runtime.
+    pub fn start(self) -> JoinHandle<()> {
+        tokio::spawn(self.run())
+    }
+
+    /// Drive the loop on the current task. Returns when cancellation fires.
+    pub async fn run(self) {
+        info!(
+            poll_interval_ms = self.config.poll_interval.as_millis() as u64,
+            "Stealth scanner started"
+        );
+        loop {
+            self.poll_once().await;
+            self.metrics.poll_iterations.fetch_add(1, Ordering::Relaxed);
+
+            tokio::select! {
+                _ = self.cancel.cancelled() => {
+                    info!("Stealth scanner shutting down");
+                    return;
+                }
+                _ = time::sleep(self.config.poll_interval) => {}
+            }
+        }
+    }
+
+    async fn poll_once(&self) {
+        let cursor = self.checkpoint.lock().await.clone();
+        let announcements = match self.source.fetch(&cursor, self.config.page_limit).await {
+            Ok(a) => a,
+            Err(err) => {
+                warn!(%err, "Stealth scanner: announcement fetch failed");
+                self.metrics.poll_errors.fetch_add(1, Ordering::Relaxed);
+                return;
+            }
+        };
+
+        if announcements.is_empty() {
+            debug!("Stealth scanner: no new announcements");
+            return;
+        }
+
+        let mut matches = 0u64;
+        let mut last_seen = cursor;
+        for announcement in &announcements {
+            self.metrics
+                .announcements_scanned
+                .fetch_add(1, Ordering::Relaxed);
+
+            if let Some(matched) = scan_announcement(&self.scan_priv, &self.spend_pk, announcement)
+            {
+                matches += 1;
+                self.persist_match(&matched).await;
+            }
+
+            last_seen = ScannerCheckpoint {
+                round_id: announcement.round_id.clone(),
+                vtxo_id: announcement.vtxo_id.clone(),
+            };
+        }
+
+        self.metrics
+            .matches_found
+            .fetch_add(matches, Ordering::Relaxed);
+        self.metrics.pages_with_data.fetch_add(1, Ordering::Relaxed);
+
+        self.advance_checkpoint(last_seen).await;
+
+        debug!(
+            scanned = announcements.len(),
+            matched = matches,
+            "Stealth scanner: poll complete"
+        );
+    }
+
+    async fn persist_match(&self, matched: &StealthMatch) {
+        match self.source.fetch_vtxo(matched).await {
+            Ok(Some(vtxo)) => self.store.upsert_vtxo(vtxo),
+            Ok(None) => {
+                // TODO(#558): once `fetch_vtxo` is wired to the operator,
+                // remove this fallback. For now we record a placeholder so
+                // tests can verify the persist path.
+                self.store.upsert_vtxo(placeholder_vtxo(matched));
+            }
+            Err(err) => warn!(
+                %err,
+                vtxo_id = %matched.vtxo_id,
+                "Stealth scanner: VTXO fetch failed"
+            ),
+        }
+    }
+
+    async fn advance_checkpoint(&self, new_cursor: ScannerCheckpoint) {
+        {
+            let mut current = self.checkpoint.lock().await;
+            *current = new_cursor.clone();
+        }
+        self.store
+            .set_metadata(CHECKPOINT_METADATA_KEY, new_cursor.encode());
+    }
+}
+
+fn hydrate_checkpoint(store: &InMemoryStore) -> ScannerCheckpoint {
+    store
+        .get_metadata(CHECKPOINT_METADATA_KEY)
+        .and_then(|raw| ScannerCheckpoint::decode(&raw))
+        .unwrap_or_default()
+}
+
+/// Build a placeholder [`Vtxo`] for a stealth match while the full-fetch path
+/// (#558) is still stubbed. Carries only the IDs needed to verify scanner
+/// persistence in tests.
+fn placeholder_vtxo(matched: &StealthMatch) -> Vtxo {
+    let (txid, vout) = parse_vtxo_id(&matched.vtxo_id).unwrap_or((matched.vtxo_id.clone(), 0));
+    Vtxo {
+        id: matched.vtxo_id.clone(),
+        txid,
+        vout,
+        amount: 0,
+        script: String::new(),
+        created_at: 0,
+        expires_at: 0,
+        is_spent: false,
+        is_swept: false,
+        is_unrolled: false,
+        spent_by: String::new(),
+        ark_txid: matched.round_id.clone(),
+        assets: Vec::new(),
+    }
+}
+
+fn parse_vtxo_id(id: &str) -> Option<(String, u32)> {
+    let (txid, vout) = id.rsplit_once(':')?;
+    Some((txid.to_string(), vout.parse().ok()?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use bitcoin::secp256k1::{Secp256k1, SecretKey};
+    use tokio::sync::Mutex as TokioMutex;
+
+    /// In-memory fake announcement source backed by a list mutated between
+    /// polls. Lets tests script the scanner's view of the world.
+    #[derive(Default)]
+    struct FakeSource {
+        pages: TokioMutex<Vec<Vec<RoundAnnouncement>>>,
+        fetch_calls: AtomicU64,
+    }
+
+    impl FakeSource {
+        fn with_pages(pages: Vec<Vec<RoundAnnouncement>>) -> Self {
+            Self {
+                pages: TokioMutex::new(pages),
+                fetch_calls: AtomicU64::new(0),
+            }
+        }
+
+        fn calls(&self) -> u64 {
+            self.fetch_calls.load(Ordering::Relaxed)
+        }
+    }
+
+    #[async_trait]
+    impl AnnouncementSource for FakeSource {
+        async fn fetch(
+            &self,
+            _cursor: &ScannerCheckpoint,
+            _limit: u32,
+        ) -> ClientResult<Vec<RoundAnnouncement>> {
+            self.fetch_calls.fetch_add(1, Ordering::Relaxed);
+            let mut pages = self.pages.lock().await;
+            if pages.is_empty() {
+                Ok(Vec::new())
+            } else {
+                Ok(pages.remove(0))
+            }
+        }
+    }
+
+    fn make_keys() -> (SecretKey, PublicKey) {
+        let secp = Secp256k1::new();
+        let scan_priv = SecretKey::from_slice(&[7u8; 32]).unwrap();
+        let spend_priv = SecretKey::from_slice(&[11u8; 32]).unwrap();
+        let spend_pk = PublicKey::from_secret_key(&secp, &spend_priv);
+        (scan_priv, spend_pk)
+    }
+
+    fn announcement(round_id: &str, vtxo_id: &str, ephemeral_pubkey: &str) -> RoundAnnouncement {
+        RoundAnnouncement {
+            cursor: format!("{round_id}\n{vtxo_id}"),
+            round_id: round_id.into(),
+            vtxo_id: vtxo_id.into(),
+            ephemeral_pubkey: ephemeral_pubkey.into(),
+        }
+    }
+
+    #[test]
+    fn checkpoint_roundtrips_through_encode_decode() {
+        let cp = ScannerCheckpoint {
+            round_id: "round-001".into(),
+            vtxo_id: "txa:0".into(),
+        };
+        let decoded = ScannerCheckpoint::decode(&cp.encode()).unwrap();
+        assert_eq!(cp, decoded);
+    }
+
+    #[test]
+    fn scan_announcement_matches_when_ephemeral_equals_spend_pk_hex() {
+        let (scan_priv, spend_pk) = make_keys();
+        let pk_hex = hex::encode(spend_pk.serialize());
+
+        let hit = announcement("round-001", "tx:0", &pk_hex);
+        let miss = announcement("round-001", "tx:1", "deadbeef");
+
+        let m = scan_announcement(&scan_priv, &spend_pk, &hit).unwrap();
+        assert_eq!(m.vtxo_id, "tx:0");
+        assert_eq!(m.round_id, "round-001");
+        assert!(scan_announcement(&scan_priv, &spend_pk, &miss).is_none());
+    }
+
+    #[tokio::test]
+    async fn scanner_discovers_matching_vtxo_and_persists_it() {
+        let (scan_priv, spend_pk) = make_keys();
+        let pk_hex = hex::encode(spend_pk.serialize());
+
+        let source = Arc::new(FakeSource::with_pages(vec![
+            vec![
+                announcement("round-001", "tx:0", "decoy"),
+                announcement("round-001", "tx:1", &pk_hex),
+            ],
+            // Subsequent polls return nothing — the scanner sits idle.
+            vec![],
+        ]));
+        let store = InMemoryStore::new();
+
+        let scanner = StealthScanner::with_config(
+            scan_priv,
+            spend_pk,
+            source.clone(),
+            store.clone(),
+            ScannerConfig {
+                poll_interval: Duration::from_millis(10),
+                page_limit: 100,
+            },
+        );
+        let metrics = scanner.metrics();
+        let cancel = scanner.cancellation_token();
+        let handle = scanner.start();
+
+        // Wait until the scanner has consumed the scripted page.
+        for _ in 0..200 {
+            if metrics.matches_found() == 1 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        cancel.cancel();
+        handle.await.expect("scanner task panicked");
+
+        assert_eq!(metrics.matches_found(), 1);
+        assert_eq!(metrics.announcements_scanned(), 2);
+        assert!(source.calls() >= 1);
+        assert!(store.get_vtxo("tx:1").is_some(), "match must be persisted");
+    }
+
+    #[tokio::test]
+    async fn scanner_resumes_from_persisted_checkpoint_after_restart() {
+        let (scan_priv, spend_pk) = make_keys();
+
+        // Pre-seed the checkpoint as if a previous run had completed.
+        let store = InMemoryStore::new();
+        let prior = ScannerCheckpoint {
+            round_id: "round-007".into(),
+            vtxo_id: "tx:42".into(),
+        };
+        store.set_metadata(CHECKPOINT_METADATA_KEY, prior.encode());
+
+        let source = Arc::new(FakeSource::default());
+        let scanner = StealthScanner::new(scan_priv, spend_pk, source, store);
+
+        assert_eq!(scanner.checkpoint().await, prior);
+    }
+
+    #[tokio::test]
+    async fn scanner_advances_checkpoint_to_last_seen_announcement() {
+        let (scan_priv, spend_pk) = make_keys();
+        let store = InMemoryStore::new();
+        let source = Arc::new(FakeSource::with_pages(vec![vec![
+            announcement("round-001", "tx:0", "decoy-a"),
+            announcement("round-002", "tx:9", "decoy-b"),
+        ]]));
+
+        let scanner = StealthScanner::with_config(
+            scan_priv,
+            spend_pk,
+            source,
+            store.clone(),
+            ScannerConfig {
+                poll_interval: Duration::from_millis(10),
+                page_limit: 100,
+            },
+        );
+        let metrics = scanner.metrics();
+        let cancel = scanner.cancellation_token();
+        let checkpoint_handle = Arc::clone(&scanner.checkpoint);
+        let handle = scanner.start();
+
+        for _ in 0..200 {
+            if metrics.announcements_scanned() == 2 {
+                break;
+            }
+            tokio::time::sleep(Duration::from_millis(10)).await;
+        }
+
+        cancel.cancel();
+        handle.await.expect("scanner task panicked");
+
+        let final_cp = checkpoint_handle.lock().await.clone();
+        assert_eq!(final_cp.round_id, "round-002");
+        assert_eq!(final_cp.vtxo_id, "tx:9");
+        assert_eq!(
+            store.get_metadata(CHECKPOINT_METADATA_KEY).unwrap(),
+            final_cp.encode()
+        );
+    }
+
+    #[tokio::test]
+    async fn scanner_shuts_down_promptly_on_cancellation() {
+        let (scan_priv, spend_pk) = make_keys();
+        let source = Arc::new(FakeSource::default());
+        let scanner = StealthScanner::with_config(
+            scan_priv,
+            spend_pk,
+            source,
+            InMemoryStore::new(),
+            ScannerConfig {
+                // Long interval — if cancellation isn't honoured the test
+                // hangs on the join.
+                poll_interval: Duration::from_secs(60),
+                page_limit: 100,
+            },
+        );
+
+        let cancel = scanner.cancellation_token();
+        let handle = scanner.start();
+
+        // Give the loop one tick to enter sleep, then cancel.
+        tokio::time::sleep(Duration::from_millis(20)).await;
+        cancel.cancel();
+
+        tokio::time::timeout(Duration::from_secs(2), handle)
+            .await
+            .expect("scanner did not shut down within 2s")
+            .expect("scanner task panicked");
+    }
+}

--- a/crates/dark-client/tests/stealth_scan_grpc.rs
+++ b/crates/dark-client/tests/stealth_scan_grpc.rs
@@ -1,0 +1,364 @@
+//! Integration test: drive [`StealthScanner`] against a real in-process
+//! tonic gRPC server.
+//!
+//! The fake server implements only `get_round_announcements`; every other
+//! `ArkService` method panics. That is sufficient because the scanner only
+//! ever calls one RPC, and keeping the rest as `unimplemented!()` makes
+//! coverage gaps loud rather than silent.
+
+use std::pin::Pin;
+use std::sync::Arc;
+use std::time::Duration;
+
+use async_stream::stream;
+use bitcoin::secp256k1::{PublicKey, Secp256k1, SecretKey};
+use tokio::net::TcpListener;
+use tokio::sync::Mutex as TokioMutex;
+use tokio_stream::wrappers::TcpListenerStream;
+use tokio_stream::Stream;
+use tonic::transport::Server;
+use tonic::{Request, Response, Status};
+
+use dark_api::proto::ark_v1::ark_service_server::{ArkService, ArkServiceServer};
+use dark_api::proto::ark_v1::{
+    BurnAssetRequest, BurnAssetResponse, ConfirmRegistrationRequest, ConfirmRegistrationResponse,
+    DeleteIntentRequest, DeleteIntentResponse, EstimateIntentFeeRequest, EstimateIntentFeeResponse,
+    FinalizePendingTxsRequest, FinalizePendingTxsResponse, FinalizeTxRequest, FinalizeTxResponse,
+    GetEventStreamRequest, GetInfoRequest, GetInfoResponse, GetIntentRequest, GetIntentResponse,
+    GetPendingTxRequest, GetPendingTxResponse, GetRoundAnnouncementsRequest, GetRoundRequest,
+    GetRoundResponse, GetTransactionsStreamRequest, GetVtxosRequest, GetVtxosResponse,
+    IssueAssetRequest, IssueAssetResponse, ListRoundsRequest, ListRoundsResponse,
+    RedeemNotesRequest, RedeemNotesResponse, RegisterForRoundRequest, RegisterForRoundResponse,
+    RegisterIntentRequest, RegisterIntentResponse, ReissueAssetRequest, ReissueAssetResponse,
+    RequestExitRequest, RequestExitResponse, RoundAnnouncement as ProtoRoundAnnouncement,
+    RoundEvent, SubmitConfidentialTransactionRequest, SubmitConfidentialTransactionResponse,
+    SubmitSignedForfeitTxsRequest, SubmitSignedForfeitTxsResponse, SubmitTreeNoncesRequest,
+    SubmitTreeNoncesResponse, SubmitTreeSignaturesRequest, SubmitTreeSignaturesResponse,
+    SubmitTxRequest, SubmitTxResponse, TransactionEvent, UpdateStreamTopicsRequest,
+    UpdateStreamTopicsResponse,
+};
+
+use dark_client::client::ArkClient;
+use dark_client::stealth_scan::{
+    ArkClientSource, ScannerConfig, StealthScanner, CHECKPOINT_METADATA_KEY,
+};
+use dark_client::store::InMemoryStore;
+
+/// Stub gRPC service: only `get_round_announcements` is real; every other
+/// method panics so any unintended RPC surfaces immediately.
+struct AnnouncementOnlyService {
+    announcements: Vec<ProtoRoundAnnouncement>,
+}
+
+type AnnouncementStream =
+    Pin<Box<dyn Stream<Item = Result<ProtoRoundAnnouncement, Status>> + Send + 'static>>;
+type EventStream = Pin<Box<dyn Stream<Item = Result<RoundEvent, Status>> + Send + 'static>>;
+type TxStream = Pin<Box<dyn Stream<Item = Result<TransactionEvent, Status>> + Send + 'static>>;
+
+#[tonic::async_trait]
+impl ArkService for AnnouncementOnlyService {
+    type GetRoundAnnouncementsStream = AnnouncementStream;
+    type GetEventStreamStream = EventStream;
+    type GetTransactionsStreamStream = TxStream;
+
+    async fn get_round_announcements(
+        &self,
+        request: Request<GetRoundAnnouncementsRequest>,
+    ) -> Result<Response<Self::GetRoundAnnouncementsStream>, Status> {
+        let req = request.into_inner();
+        // Honour the cursor so repeated polls don't re-emit the same items
+        // — mirrors the real server's exclusive-cursor semantics.
+        let cursor = req
+            .cursor
+            .split_once('\n')
+            .map(|(r, v)| (r.to_string(), v.to_string()));
+        let filtered: Vec<ProtoRoundAnnouncement> = self
+            .announcements
+            .iter()
+            .filter(|ann| match &cursor {
+                Some((r, v)) => {
+                    (ann.round_id.as_str(), ann.vtxo_id.as_str()) > (r.as_str(), v.as_str())
+                }
+                None => true,
+            })
+            .cloned()
+            .collect();
+        let output = stream! {
+            for ann in filtered {
+                yield Ok(ann);
+            }
+        };
+        Ok(Response::new(Box::pin(output)))
+    }
+
+    async fn get_event_stream(
+        &self,
+        _request: Request<GetEventStreamRequest>,
+    ) -> Result<Response<Self::GetEventStreamStream>, Status> {
+        unimplemented!("get_event_stream is not stubbed");
+    }
+
+    async fn get_transactions_stream(
+        &self,
+        _request: Request<GetTransactionsStreamRequest>,
+    ) -> Result<Response<Self::GetTransactionsStreamStream>, Status> {
+        unimplemented!("get_transactions_stream is not stubbed");
+    }
+
+    async fn get_info(
+        &self,
+        _request: Request<GetInfoRequest>,
+    ) -> Result<Response<GetInfoResponse>, Status> {
+        unimplemented!("get_info is not stubbed");
+    }
+
+    async fn register_intent(
+        &self,
+        _request: Request<RegisterIntentRequest>,
+    ) -> Result<Response<RegisterIntentResponse>, Status> {
+        unimplemented!("register_intent is not stubbed");
+    }
+
+    async fn confirm_registration(
+        &self,
+        _request: Request<ConfirmRegistrationRequest>,
+    ) -> Result<Response<ConfirmRegistrationResponse>, Status> {
+        unimplemented!("confirm_registration is not stubbed");
+    }
+
+    async fn get_intent(
+        &self,
+        _request: Request<GetIntentRequest>,
+    ) -> Result<Response<GetIntentResponse>, Status> {
+        unimplemented!("get_intent is not stubbed");
+    }
+
+    async fn submit_tree_nonces(
+        &self,
+        _request: Request<SubmitTreeNoncesRequest>,
+    ) -> Result<Response<SubmitTreeNoncesResponse>, Status> {
+        unimplemented!("submit_tree_nonces is not stubbed");
+    }
+
+    async fn submit_tree_signatures(
+        &self,
+        _request: Request<SubmitTreeSignaturesRequest>,
+    ) -> Result<Response<SubmitTreeSignaturesResponse>, Status> {
+        unimplemented!("submit_tree_signatures is not stubbed");
+    }
+
+    async fn submit_signed_forfeit_txs(
+        &self,
+        _request: Request<SubmitSignedForfeitTxsRequest>,
+    ) -> Result<Response<SubmitSignedForfeitTxsResponse>, Status> {
+        unimplemented!("submit_signed_forfeit_txs is not stubbed");
+    }
+
+    async fn register_for_round(
+        &self,
+        _request: Request<RegisterForRoundRequest>,
+    ) -> Result<Response<RegisterForRoundResponse>, Status> {
+        unimplemented!("register_for_round is not stubbed");
+    }
+
+    async fn request_exit(
+        &self,
+        _request: Request<RequestExitRequest>,
+    ) -> Result<Response<RequestExitResponse>, Status> {
+        unimplemented!("request_exit is not stubbed");
+    }
+
+    async fn get_vtxos(
+        &self,
+        _request: Request<GetVtxosRequest>,
+    ) -> Result<Response<GetVtxosResponse>, Status> {
+        unimplemented!("get_vtxos is not stubbed");
+    }
+
+    async fn list_rounds(
+        &self,
+        _request: Request<ListRoundsRequest>,
+    ) -> Result<Response<ListRoundsResponse>, Status> {
+        unimplemented!("list_rounds is not stubbed");
+    }
+
+    async fn get_round(
+        &self,
+        _request: Request<GetRoundRequest>,
+    ) -> Result<Response<GetRoundResponse>, Status> {
+        unimplemented!("get_round is not stubbed");
+    }
+
+    async fn update_stream_topics(
+        &self,
+        _request: Request<UpdateStreamTopicsRequest>,
+    ) -> Result<Response<UpdateStreamTopicsResponse>, Status> {
+        unimplemented!("update_stream_topics is not stubbed");
+    }
+
+    async fn estimate_intent_fee(
+        &self,
+        _request: Request<EstimateIntentFeeRequest>,
+    ) -> Result<Response<EstimateIntentFeeResponse>, Status> {
+        unimplemented!("estimate_intent_fee is not stubbed");
+    }
+
+    async fn delete_intent(
+        &self,
+        _request: Request<DeleteIntentRequest>,
+    ) -> Result<Response<DeleteIntentResponse>, Status> {
+        unimplemented!("delete_intent is not stubbed");
+    }
+
+    async fn submit_tx(
+        &self,
+        _request: Request<SubmitTxRequest>,
+    ) -> Result<Response<SubmitTxResponse>, Status> {
+        unimplemented!("submit_tx is not stubbed");
+    }
+
+    async fn submit_confidential_transaction(
+        &self,
+        _request: Request<SubmitConfidentialTransactionRequest>,
+    ) -> Result<Response<SubmitConfidentialTransactionResponse>, Status> {
+        unimplemented!("submit_confidential_transaction is not stubbed");
+    }
+
+    async fn finalize_tx(
+        &self,
+        _request: Request<FinalizeTxRequest>,
+    ) -> Result<Response<FinalizeTxResponse>, Status> {
+        unimplemented!("finalize_tx is not stubbed");
+    }
+
+    async fn get_pending_tx(
+        &self,
+        _request: Request<GetPendingTxRequest>,
+    ) -> Result<Response<GetPendingTxResponse>, Status> {
+        unimplemented!("get_pending_tx is not stubbed");
+    }
+
+    async fn finalize_pending_txs(
+        &self,
+        _request: Request<FinalizePendingTxsRequest>,
+    ) -> Result<Response<FinalizePendingTxsResponse>, Status> {
+        unimplemented!("finalize_pending_txs is not stubbed");
+    }
+
+    async fn issue_asset(
+        &self,
+        _request: Request<IssueAssetRequest>,
+    ) -> Result<Response<IssueAssetResponse>, Status> {
+        unimplemented!("issue_asset is not stubbed");
+    }
+
+    async fn reissue_asset(
+        &self,
+        _request: Request<ReissueAssetRequest>,
+    ) -> Result<Response<ReissueAssetResponse>, Status> {
+        unimplemented!("reissue_asset is not stubbed");
+    }
+
+    async fn burn_asset(
+        &self,
+        _request: Request<BurnAssetRequest>,
+    ) -> Result<Response<BurnAssetResponse>, Status> {
+        unimplemented!("burn_asset is not stubbed");
+    }
+
+    async fn redeem_notes(
+        &self,
+        _request: Request<RedeemNotesRequest>,
+    ) -> Result<Response<RedeemNotesResponse>, Status> {
+        unimplemented!("redeem_notes is not stubbed");
+    }
+}
+
+async fn spawn_fake_server(announcements: Vec<ProtoRoundAnnouncement>) -> String {
+    let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let svc = ArkServiceServer::new(AnnouncementOnlyService { announcements });
+
+    tokio::spawn(async move {
+        Server::builder()
+            .add_service(svc)
+            .serve_with_incoming(TcpListenerStream::new(listener))
+            .await
+            .unwrap();
+    });
+
+    // Brief breathing room for the listener to start accepting.
+    tokio::time::sleep(Duration::from_millis(50)).await;
+    format!("http://{addr}")
+}
+
+fn make_keys() -> (SecretKey, PublicKey) {
+    let secp = Secp256k1::new();
+    let scan_priv = SecretKey::from_slice(&[7u8; 32]).unwrap();
+    let spend_priv = SecretKey::from_slice(&[11u8; 32]).unwrap();
+    let spend_pk = PublicKey::from_secret_key(&secp, &spend_priv);
+    (scan_priv, spend_pk)
+}
+
+#[tokio::test]
+async fn scanner_discovers_match_through_real_grpc_server() {
+    let (scan_priv, spend_pk) = make_keys();
+    let pk_hex = hex::encode(spend_pk.serialize());
+
+    let canned = vec![
+        ProtoRoundAnnouncement {
+            cursor: "round-001\ntx:0".into(),
+            round_id: "round-001".into(),
+            vtxo_id: "tx:0".into(),
+            ephemeral_pubkey: "decoy".into(),
+        },
+        ProtoRoundAnnouncement {
+            cursor: "round-001\ntx:1".into(),
+            round_id: "round-001".into(),
+            vtxo_id: "tx:1".into(),
+            ephemeral_pubkey: pk_hex,
+        },
+    ];
+
+    let server_url = spawn_fake_server(canned).await;
+
+    let mut client = ArkClient::new(server_url);
+    client.connect().await.expect("client must connect");
+
+    let store = InMemoryStore::new();
+    let source = Arc::new(ArkClientSource::new(Arc::new(TokioMutex::new(client))));
+
+    let scanner = StealthScanner::with_config(
+        scan_priv,
+        spend_pk,
+        source,
+        store.clone(),
+        ScannerConfig {
+            poll_interval: Duration::from_millis(20),
+            page_limit: 100,
+        },
+    );
+    let metrics = scanner.metrics();
+    let cancel = scanner.cancellation_token();
+    let handle = scanner.start();
+
+    for _ in 0..200 {
+        if metrics.matches_found() == 1 {
+            break;
+        }
+        tokio::time::sleep(Duration::from_millis(20)).await;
+    }
+
+    cancel.cancel();
+    handle.await.expect("scanner task panicked");
+
+    assert_eq!(metrics.matches_found(), 1, "scanner must find the match");
+    assert!(
+        store.get_vtxo("tx:1").is_some(),
+        "matched VTXO must be persisted"
+    );
+    let cp = store
+        .get_metadata(CHECKPOINT_METADATA_KEY)
+        .expect("checkpoint must be persisted");
+    assert!(cp.starts_with("round-001\n"));
+}


### PR DESCRIPTION
Closes #558. StealthScanner + AnnouncementSource trait + ArkClientSource + ScannerCheckpoint + ScannerMetrics. In-process tonic integration test. scan_announcement and fetch_vtxo are stubbed (TODO #555/#558) for rebase after those land.