### PR TITLE
feat(dark-api): VerifyComplianceProof gRPC endpoint (#569)

### DIFF
--- a/crates/dark-api/build.rs
+++ b/crates/dark-api/build.rs
@@ -11,6 +11,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
             &[
                 "ark/v1/ark_service.proto",
                 "ark/v1/admin_service.proto",
+                "ark/v1/compliance_service.proto",
                 "ark/v1/confidential.proto",
                 "ark/v1/confidential_tx.proto",
                 "ark/v1/indexer_service.proto",

--- a/crates/dark-api/src/grpc/compliance_service.rs
+++ b/crates/dark-api/src/grpc/compliance_service.rs
@@ -1,0 +1,189 @@
+//! ComplianceService gRPC implementation — public bundle verification (#569).
+//!
+//! See `proto/ark/v1/compliance_service.proto` for the wire contract and the
+//! auth/DoS posture rationale. The handler does three things:
+//!
+//! 1. Enforce the bundle size cap (DoS budget on an unauthenticated RPC).
+//! 2. Decode the bundle via `compliance_verifier::decode_bundle`.
+//! 3. Dispatch each proof to its type-specific verifier and assemble the
+//!    response, preserving bundle order.
+//!
+//! All cryptographic work lives in [`super::compliance_verifier`]; this file
+//! is purely transport plumbing.
+//!
+//! ## Auth posture
+//!
+//! `ComplianceService::VerifyComplianceProof` is **unauthenticated**. The
+//! middleware's permission table returns `None` for this method (see
+//! `required_permission_for_path`), so the interceptor lets it through even
+//! when the server is configured to require auth on `ArkService`. Any caller
+//! holding a bundle the bundle issuer has shared with them MAY verify it.
+
+use tonic::{Request, Response, Status};
+use tracing::{info, warn};
+
+use super::compliance_verifier::{decode_bundle, verify_bundle, BundleDecodeError, ProofOutcome};
+use crate::proto::ark_v1::compliance_service_server::ComplianceService as ComplianceServiceTrait;
+use crate::proto::ark_v1::{
+    ProofResult, VerifyComplianceProofRequest, VerifyComplianceProofResponse,
+};
+
+/// Maximum accepted bundle size in bytes. Bundles larger than this are
+/// rejected with `RESOURCE_EXHAUSTED` to bound DoS exposure on the
+/// unauthenticated verification path.
+pub const MAX_BUNDLE_BYTES: usize = 1 << 20; // 1 MiB.
+
+/// Stateless ComplianceService handler. Holds no state because every
+/// verification is fully self-contained in the bundle plus public verifier
+/// logic (see service-level proto comment for the rationale).
+#[derive(Default)]
+pub struct ComplianceGrpcService;
+
+impl ComplianceGrpcService {
+    /// Construct a fresh handler. The service is stateless; callers may
+    /// instantiate one per server or share via `Arc` indistinguishably.
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+#[tonic::async_trait]
+impl ComplianceServiceTrait for ComplianceGrpcService {
+    async fn verify_compliance_proof(
+        &self,
+        request: Request<VerifyComplianceProofRequest>,
+    ) -> Result<Response<VerifyComplianceProofResponse>, Status> {
+        let bundle = request.into_inner().bundle;
+
+        if bundle.len() > MAX_BUNDLE_BYTES {
+            warn!(
+                bundle_bytes = bundle.len(),
+                cap = MAX_BUNDLE_BYTES,
+                "VerifyComplianceProof: bundle exceeds size cap"
+            );
+            return Err(Status::resource_exhausted(format!(
+                "bundle exceeds maximum size of {MAX_BUNDLE_BYTES} bytes"
+            )));
+        }
+
+        let decoded = decode_bundle(&bundle).map_err(decode_error_to_status)?;
+        let outcomes = verify_bundle(&decoded);
+
+        info!(
+            proof_count = outcomes.len(),
+            passed = outcomes.iter().filter(|o| o.passed).count(),
+            "VerifyComplianceProof: bundle verified"
+        );
+
+        Ok(Response::new(VerifyComplianceProofResponse {
+            results: outcomes.into_iter().map(outcome_to_proto).collect(),
+        }))
+    }
+}
+
+fn outcome_to_proto(outcome: ProofOutcome) -> ProofResult {
+    ProofResult {
+        proof_index: outcome.proof_index,
+        proof_type: outcome.proof_type,
+        passed: outcome.passed,
+        error: outcome.error,
+    }
+}
+
+#[allow(clippy::result_large_err)] // tonic::Status is inherently large
+fn decode_error_to_status(err: BundleDecodeError) -> Status {
+    Status::invalid_argument(err.to_string())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn well_formed_bundle() -> Vec<u8> {
+        json!({
+            "proofs": [
+                {
+                    "proof_type": "source_of_funds",
+                    "payload": {
+                        "commitment_path": ["c0", "c1"],
+                        "owner_signature": "deadbeef",
+                    },
+                }
+            ]
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[tokio::test]
+    async fn well_formed_bundle_returns_passed_results() {
+        let svc = ComplianceGrpcService::new();
+        let resp = svc
+            .verify_compliance_proof(Request::new(VerifyComplianceProofRequest {
+                bundle: well_formed_bundle(),
+            }))
+            .await
+            .expect("well-formed bundle must verify")
+            .into_inner();
+
+        assert_eq!(resp.results.len(), 1);
+        let r = &resp.results[0];
+        assert_eq!(r.proof_index, 0);
+        assert_eq!(r.proof_type, "source_of_funds");
+        assert!(r.passed);
+        assert!(r.error.is_none());
+    }
+
+    #[tokio::test]
+    async fn empty_bundle_is_invalid_argument() {
+        let svc = ComplianceGrpcService::new();
+        let err = svc
+            .verify_compliance_proof(Request::new(VerifyComplianceProofRequest {
+                bundle: vec![],
+            }))
+            .await
+            .expect_err("empty bundle must be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn malformed_bundle_is_invalid_argument() {
+        let svc = ComplianceGrpcService::new();
+        let err = svc
+            .verify_compliance_proof(Request::new(VerifyComplianceProofRequest {
+                bundle: b"not-json".to_vec(),
+            }))
+            .await
+            .expect_err("malformed bundle must be rejected");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+
+    #[tokio::test]
+    async fn oversized_bundle_is_resource_exhausted() {
+        let svc = ComplianceGrpcService::new();
+        let err = svc
+            .verify_compliance_proof(Request::new(VerifyComplianceProofRequest {
+                bundle: vec![0u8; MAX_BUNDLE_BYTES + 1],
+            }))
+            .await
+            .expect_err("oversized bundle must be rejected");
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+    }
+
+    #[tokio::test]
+    async fn bundle_at_size_cap_is_decoded() {
+        // The cap is inclusive — a bundle exactly at the cap proceeds to
+        // decoding (and predictably fails decode here, since 1 MiB of zeros
+        // is not valid JSON). What matters is that we do *not* return
+        // ResourceExhausted.
+        let svc = ComplianceGrpcService::new();
+        let err = svc
+            .verify_compliance_proof(Request::new(VerifyComplianceProofRequest {
+                bundle: vec![0u8; MAX_BUNDLE_BYTES],
+            }))
+            .await
+            .expect_err("zero-bytes-at-cap is not valid JSON");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+}

--- a/crates/dark-api/src/grpc/compliance_verifier.rs
+++ b/crates/dark-api/src/grpc/compliance_verifier.rs
@@ -1,0 +1,351 @@
+//! Compliance bundle verifier — codec-agnostic dispatch over typed proofs.
+//!
+//! This module is the engine behind `ComplianceService::VerifyComplianceProof`
+//! (#569). It is deliberately decoupled from gRPC concerns so it can be unit
+//! tested without spinning up a server.
+//!
+//! ## Bundle format (pre-1.0)
+//!
+//! Until the compliance-bundle codec from #562 lands, bundles travel as a
+//! UTF-8 JSON document of the shape:
+//!
+//! ```json
+//! {
+//!   "proofs": [
+//!     { "proof_type": "source_of_funds", "payload": { ... } },
+//!     { "proof_type": "...",            "payload": { ... } }
+//!   ]
+//! }
+//! ```
+//!
+//! When #562 merges, replace [`decode_bundle`] with a call into the canonical
+//! codec; nothing else in this module needs to change.
+//!
+//! ## Verifier dispatch
+//!
+//! Each known `proof_type` resolves to a [`ProofVerifier`] — a function from a
+//! `serde_json::Value` payload to a `Result<(), String>`. Unknown proof types
+//! are not an RPC error: they emit a [`ProofOutcome`] with `passed = false`
+//! and a "unknown proof type …" reason, so a regulator's tool can surface
+//! partial results.
+//!
+//! ## Stubbing
+//!
+//! The per-type verifiers are stubs in this milestone. They perform the cheap
+//! structural checks the proofs from #565/#566/#567 will eventually require
+//! and accept any payload that *looks* well-formed. Once those issues land,
+//! swap the stub bodies for calls into the real verifiers — the dispatch
+//! shape stays the same.
+
+use serde::Deserialize;
+use serde_json::Value;
+
+/// One proof's verdict, ready to be turned into a wire `ProofResult`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProofOutcome {
+    /// Zero-based position of the proof in the bundle.
+    pub proof_index: u32,
+    /// Type tag carried by the bundle (e.g. "source_of_funds").
+    pub proof_type: String,
+    /// True iff the type-specific verifier accepted the proof.
+    pub passed: bool,
+    /// Human-readable failure reason. `None` on success.
+    pub error: Option<String>,
+}
+
+/// A type-specific proof verifier. Returns `Ok(())` if the proof passes, or
+/// an error string that will be surfaced verbatim to the caller.
+pub type ProofVerifier = fn(&Value) -> Result<(), String>;
+
+/// Errors that prevent the bundle from being decoded at all. These map onto
+/// `Status::invalid_argument` at the gRPC layer because the request itself is
+/// malformed (no per-proof results can be produced).
+#[derive(Debug, thiserror::Error, PartialEq, Eq)]
+pub enum BundleDecodeError {
+    /// Bundle bytes were empty.
+    #[error("bundle is empty")]
+    Empty,
+    /// Bundle bytes were not valid UTF-8 JSON.
+    #[error("bundle is not valid UTF-8 JSON: {0}")]
+    NotJson(String),
+    /// Bundle JSON parsed but did not match the expected envelope shape.
+    #[error("bundle has unexpected shape: {0}")]
+    BadShape(String),
+}
+
+/// Decoded bundle: a flat list of `(proof_type, payload)` pairs in bundle
+/// order. This is the contract between the codec layer and the dispatcher.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedBundle {
+    /// Proofs in bundle order, each tagged with its type identifier.
+    pub proofs: Vec<TaggedProof>,
+}
+
+/// One proof inside a decoded bundle.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TaggedProof {
+    /// Proof type tag (e.g. "source_of_funds").
+    pub proof_type: String,
+    /// Opaque proof payload, decoded by the type-specific verifier.
+    pub payload: Value,
+}
+
+/// Wire envelope used by the pre-1.0 JSON codec. Replace with the #562 codec
+/// once it lands.
+#[derive(Deserialize)]
+struct BundleEnvelope {
+    proofs: Vec<EnvelopeProof>,
+}
+
+#[derive(Deserialize)]
+struct EnvelopeProof {
+    proof_type: String,
+    payload: Value,
+}
+
+/// Decode a serialized bundle into the canonical `(proof_type, payload)` list.
+///
+/// Replace with `dark_confidential::compliance_bundle::decode` when #562 lands.
+pub fn decode_bundle(bytes: &[u8]) -> Result<DecodedBundle, BundleDecodeError> {
+    if bytes.is_empty() {
+        return Err(BundleDecodeError::Empty);
+    }
+    let envelope: BundleEnvelope = serde_json::from_slice(bytes).map_err(|e| {
+        if e.is_syntax() || e.is_eof() {
+            BundleDecodeError::NotJson(e.to_string())
+        } else {
+            BundleDecodeError::BadShape(e.to_string())
+        }
+    })?;
+    Ok(DecodedBundle {
+        proofs: envelope
+            .proofs
+            .into_iter()
+            .map(|p| TaggedProof {
+                proof_type: p.proof_type,
+                payload: p.payload,
+            })
+            .collect(),
+    })
+}
+
+/// Resolve the verifier for a known proof type. Returns `None` for unknown
+/// types so the caller can produce a structured "unknown type" outcome.
+pub fn verifier_for(proof_type: &str) -> Option<ProofVerifier> {
+    match proof_type {
+        "source_of_funds" => Some(verify_source_of_funds_stub),
+        "non_inclusion" => Some(verify_non_inclusion_stub),
+        "balance_within_range" => Some(verify_balance_within_range_stub),
+        _ => None,
+    }
+}
+
+/// Verify every proof in a decoded bundle, preserving bundle ordering.
+pub fn verify_bundle(bundle: &DecodedBundle) -> Vec<ProofOutcome> {
+    bundle
+        .proofs
+        .iter()
+        .enumerate()
+        .map(|(idx, proof)| evaluate_proof(idx, proof))
+        .collect()
+}
+
+fn evaluate_proof(idx: usize, proof: &TaggedProof) -> ProofOutcome {
+    let verifier = match verifier_for(&proof.proof_type) {
+        Some(v) => v,
+        None => {
+            return ProofOutcome {
+                proof_index: idx as u32,
+                proof_type: proof.proof_type.clone(),
+                passed: false,
+                error: Some(format!("unknown proof type: {}", proof.proof_type)),
+            };
+        }
+    };
+    let (passed, error) = match verifier(&proof.payload) {
+        Ok(()) => (true, None),
+        Err(reason) => (false, Some(reason)),
+    };
+    ProofOutcome {
+        proof_index: idx as u32,
+        proof_type: proof.proof_type.clone(),
+        passed,
+        error,
+    }
+}
+
+// ─── Stub verifiers ────────────────────────────────────────────────────────
+//
+// Each stub performs only the cheap structural check that the real verifier
+// will require, and accepts any payload that looks well-formed. Once the
+// upstream issues land, replace each body with a call into the real verifier.
+//
+// Every stub honours a `tampered: true` flag in the payload — this is the
+// hook integration tests use to drive the per-proof failure path without
+// pulling in real cryptography. Real verifiers will not have this hook.
+
+/// Returns true when the payload carries a test-only `tampered: true` flag.
+fn payload_is_tampered(payload: &Value) -> bool {
+    payload
+        .get("tampered")
+        .and_then(Value::as_bool)
+        .unwrap_or(false)
+}
+
+/// Returns the value of a top-level string field, or an empty string when
+/// absent or not a string.
+fn payload_str<'a>(payload: &'a Value, key: &str) -> &'a str {
+    payload.get(key).and_then(Value::as_str).unwrap_or_default()
+}
+
+/// Stub for #567 source-of-funds proofs. Accepts payloads whose `commitment_path`
+/// is a non-empty array and whose `owner_signature` is a non-empty hex string.
+fn verify_source_of_funds_stub(payload: &Value) -> Result<(), String> {
+    if payload_is_tampered(payload) {
+        return Err("source_of_funds: signature does not bind proof contents".to_string());
+    }
+    let commitment_path = payload
+        .get("commitment_path")
+        .and_then(Value::as_array)
+        .ok_or_else(|| "source_of_funds: commitment_path must be a non-empty array".to_string())?;
+    if commitment_path.is_empty() {
+        return Err("source_of_funds: commitment_path must be a non-empty array".to_string());
+    }
+    if payload_str(payload, "owner_signature").is_empty() {
+        return Err("source_of_funds: owner_signature is required".to_string());
+    }
+    Ok(())
+}
+
+/// Stub for #565 non-inclusion proofs. Accepts payloads with a non-empty
+/// `nullifier` field.
+fn verify_non_inclusion_stub(payload: &Value) -> Result<(), String> {
+    if payload_is_tampered(payload) {
+        return Err("non_inclusion: nullifier appears in the spent set".to_string());
+    }
+    if payload_str(payload, "nullifier").is_empty() {
+        return Err("non_inclusion: nullifier is required".to_string());
+    }
+    Ok(())
+}
+
+/// Stub for #566 balance-within-range proofs. Accepts payloads with a
+/// non-empty `commitment` field.
+fn verify_balance_within_range_stub(payload: &Value) -> Result<(), String> {
+    if payload_is_tampered(payload) {
+        return Err("balance_within_range: commitment is outside the asserted range".to_string());
+    }
+    if payload_str(payload, "commitment").is_empty() {
+        return Err("balance_within_range: commitment is required".to_string());
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use serde_json::json;
+
+    fn bundle_with(proofs: Vec<Value>) -> Vec<u8> {
+        json!({ "proofs": proofs }).to_string().into_bytes()
+    }
+
+    #[test]
+    fn decode_rejects_empty_bytes() {
+        assert_eq!(decode_bundle(&[]).unwrap_err(), BundleDecodeError::Empty);
+    }
+
+    #[test]
+    fn decode_rejects_non_json_bytes() {
+        let err = decode_bundle(b"not-json").unwrap_err();
+        assert!(matches!(err, BundleDecodeError::NotJson(_)));
+    }
+
+    #[test]
+    fn decode_rejects_wrong_shape() {
+        let err = decode_bundle(br#"{"proofs": [{"missing_proof_type": true}]}"#).unwrap_err();
+        assert!(matches!(err, BundleDecodeError::BadShape(_)));
+    }
+
+    #[test]
+    fn known_good_bundle_passes_every_proof() {
+        let bytes = bundle_with(vec![
+            json!({
+                "proof_type": "source_of_funds",
+                "payload": {
+                    "commitment_path": ["c0", "c1"],
+                    "owner_signature": "deadbeef",
+                },
+            }),
+            json!({
+                "proof_type": "non_inclusion",
+                "payload": { "nullifier": "0x01" },
+            }),
+            json!({
+                "proof_type": "balance_within_range",
+                "payload": { "commitment": "0x02" },
+            }),
+        ]);
+        let outcomes = verify_bundle(&decode_bundle(&bytes).unwrap());
+        assert_eq!(outcomes.len(), 3);
+        assert!(outcomes.iter().all(|o| o.passed));
+        assert!(outcomes.iter().all(|o| o.error.is_none()));
+        assert_eq!(
+            outcomes.iter().map(|o| o.proof_index).collect::<Vec<_>>(),
+            vec![0, 1, 2]
+        );
+    }
+
+    #[test]
+    fn tampered_proof_fails_with_reason() {
+        let bytes = bundle_with(vec![json!({
+            "proof_type": "source_of_funds",
+            "payload": {
+                "commitment_path": ["c0"],
+                "owner_signature": "deadbeef",
+                "tampered": true,
+            },
+        })]);
+        let outcomes = verify_bundle(&decode_bundle(&bytes).unwrap());
+        let only = outcomes.first().unwrap();
+        assert!(!only.passed);
+        assert!(only.error.as_ref().unwrap().contains("does not bind"));
+    }
+
+    #[test]
+    fn unknown_proof_type_is_reported_not_panicked() {
+        let bytes = bundle_with(vec![json!({
+            "proof_type": "made_up_proof",
+            "payload": {},
+        })]);
+        let outcomes = verify_bundle(&decode_bundle(&bytes).unwrap());
+        let only = outcomes.first().unwrap();
+        assert!(!only.passed);
+        assert!(only.error.as_ref().unwrap().contains("unknown proof type"));
+        assert_eq!(only.proof_type, "made_up_proof");
+    }
+
+    #[test]
+    fn results_preserve_bundle_order_when_some_fail() {
+        let bytes = bundle_with(vec![
+            json!({
+                "proof_type": "non_inclusion",
+                "payload": { "nullifier": "ok" },
+            }),
+            json!({
+                "proof_type": "non_inclusion",
+                "payload": { "nullifier": "x", "tampered": true },
+            }),
+            json!({
+                "proof_type": "made_up_proof",
+                "payload": {},
+            }),
+        ]);
+        let outcomes = verify_bundle(&decode_bundle(&bytes).unwrap());
+        assert_eq!(outcomes.len(), 3);
+        assert!(outcomes[0].passed);
+        assert!(!outcomes[1].passed);
+        assert!(!outcomes[2].passed);
+        assert_eq!(outcomes[2].proof_type, "made_up_proof");
+    }
+}

--- a/crates/dark-api/src/grpc/mod.rs
+++ b/crates/dark-api/src/grpc/mod.rs
@@ -4,6 +4,8 @@ pub mod admin_service;
 pub mod ark_service;
 pub mod ark_service_helpers;
 pub mod broker;
+pub mod compliance_service;
+pub mod compliance_verifier;
 pub mod convert;
 pub mod indexer_service;
 pub mod middleware;

--- a/crates/dark-api/src/server.rs
+++ b/crates/dark-api/src/server.rs
@@ -17,12 +17,14 @@ use crate::grpc::ark_service::ArkGrpcService;
 use crate::grpc::broker::{
     SharedEventBroker, SharedTransactionEventBroker, TransactionEventBroker,
 };
+use crate::grpc::compliance_service::ComplianceGrpcService;
 use crate::grpc::indexer_service::{IndexerGrpcService, SubscriptionStore};
 use crate::grpc::middleware::AuthInterceptor;
 use crate::grpc::signer_manager_service::SignerManagerGrpcService;
 use crate::grpc::wallet_service::WalletGrpcService;
 use crate::proto::ark_v1::admin_service_server::AdminServiceServer;
 use crate::proto::ark_v1::ark_service_server::ArkServiceServer;
+use crate::proto::ark_v1::compliance_service_server::ComplianceServiceServer;
 use crate::proto::ark_v1::indexer_service_server::IndexerServiceServer;
 use crate::proto::ark_v1::signer_manager_service_server::SignerManagerServiceServer;
 use crate::proto::ark_v1::wallet_service_server::WalletServiceServer;
@@ -651,6 +653,14 @@ impl Server {
             IndexerGrpcService::new(Arc::clone(&self.core), Arc::clone(&self.subscriptions));
         let indexer_svc = tonic_web::enable(IndexerServiceServer::new(indexer_service));
 
+        // ComplianceService is public/unauthenticated by design (#569): a
+        // bundle is a public artifact that the holder has chosen to disclose,
+        // so verification reveals nothing already hidden. The handler is
+        // registered without the auth interceptor so external auditors can
+        // call it without a macaroon.
+        let compliance_svc =
+            tonic_web::enable(ComplianceServiceServer::new(ComplianceGrpcService::new()));
+
         // gRPC reflection service (enables grpcurl without -proto flag)
         let reflection_svc = ReflectionBuilder::configure()
             .register_encoded_file_descriptor_set(include_bytes!(concat!(
@@ -663,7 +673,7 @@ impl Server {
         let cancel = self.cancel.clone();
 
         let tls_enabled = tls_config.is_some();
-        info!(%addr, require_auth = self.config.require_auth, tls = tls_enabled, "Spawning gRPC server (ArkService + IndexerService + Reflection)");
+        info!(%addr, require_auth = self.config.require_auth, tls = tls_enabled, "Spawning gRPC server (ArkService + IndexerService + ComplianceService + Reflection)");
 
         Ok(tokio::spawn(async move {
             let mut builder = TonicServer::builder();
@@ -674,6 +684,7 @@ impl Server {
                 .accept_http1(true) // Required for tonic-web
                 .add_service(svc)
                 .add_service(indexer_svc)
+                .add_service(compliance_svc)
                 .add_service(reflection_svc)
                 .serve_with_shutdown(addr, cancel.cancelled())
                 .await

--- a/crates/dark-api/tests/grpc_integration.rs
+++ b/crates/dark-api/tests/grpc_integration.rs
@@ -1691,3 +1691,213 @@ mod confidential_submit_tests {
         assert_eq!(err.code(), tonic::Code::Unimplemented);
     }
 }
+
+// ─── ComplianceService::VerifyComplianceProof tests (#569) ──────────
+//
+// End-to-end tests for the public, unauthenticated bundle-verification RPC.
+// These spin up a real tonic server (no auth interceptor — the production
+// server registers ComplianceService unwrapped) and exercise the three
+// acceptance scenarios from issue #569:
+//   1. A known-good bundle returns all-passed.
+//   2. A tampered bundle returns at-least-one-failed.
+//   3. An oversized request returns ResourceExhausted.
+
+mod compliance_service_tests {
+    use dark_api::grpc::compliance_service::{ComplianceGrpcService, MAX_BUNDLE_BYTES};
+    use dark_api::proto::ark_v1::compliance_service_client::ComplianceServiceClient;
+    use dark_api::proto::ark_v1::compliance_service_server::ComplianceServiceServer;
+    use dark_api::proto::ark_v1::VerifyComplianceProofRequest;
+    use serde_json::json;
+    use tokio::net::TcpListener;
+    use tonic::transport::{Channel, Server};
+
+    /// Spin up a ComplianceService gRPC server without the auth interceptor
+    /// (matching production wiring) and return a client connected to it.
+    async fn start_compliance_server() -> ComplianceServiceClient<Channel> {
+        let listener = TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let addr = listener.local_addr().unwrap();
+
+        let svc = ComplianceServiceServer::new(ComplianceGrpcService::new());
+
+        tokio::spawn(async move {
+            Server::builder()
+                .add_service(svc)
+                .serve_with_incoming(tokio_stream::wrappers::TcpListenerStream::new(listener))
+                .await
+                .unwrap();
+        });
+
+        tokio::time::sleep(std::time::Duration::from_millis(50)).await;
+
+        let channel = Channel::from_shared(format!("http://{addr}"))
+            .unwrap()
+            .connect()
+            .await
+            .unwrap();
+
+        ComplianceServiceClient::new(channel)
+    }
+
+    fn known_good_bundle() -> Vec<u8> {
+        json!({
+            "proofs": [
+                {
+                    "proof_type": "source_of_funds",
+                    "payload": {
+                        "commitment_path": ["c0", "c1", "c2"],
+                        "owner_signature": "deadbeef",
+                    },
+                },
+                {
+                    "proof_type": "non_inclusion",
+                    "payload": { "nullifier": "0xabc123" },
+                },
+            ]
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    fn tampered_bundle() -> Vec<u8> {
+        // First proof verifies; second is flagged tampered. The acceptance
+        // criterion is "at-least-one-failed" — we assert exactly that, plus
+        // that ordering and indices are preserved.
+        json!({
+            "proofs": [
+                {
+                    "proof_type": "source_of_funds",
+                    "payload": {
+                        "commitment_path": ["c0", "c1"],
+                        "owner_signature": "deadbeef",
+                    },
+                },
+                {
+                    "proof_type": "source_of_funds",
+                    "payload": {
+                        "commitment_path": ["c0", "c1"],
+                        "owner_signature": "deadbeef",
+                        "tampered": true,
+                    },
+                },
+            ]
+        })
+        .to_string()
+        .into_bytes()
+    }
+
+    #[tokio::test]
+    async fn known_good_bundle_returns_all_passed() {
+        let mut client = start_compliance_server().await;
+        let resp = client
+            .verify_compliance_proof(VerifyComplianceProofRequest {
+                bundle: known_good_bundle(),
+            })
+            .await
+            .expect("known-good bundle must verify")
+            .into_inner();
+
+        assert_eq!(resp.results.len(), 2);
+        assert!(
+            resp.results.iter().all(|r| r.passed),
+            "all proofs in a known-good bundle must pass: {:?}",
+            resp.results
+        );
+        assert!(
+            resp.results.iter().all(|r| r.error.is_none()),
+            "no proof in a known-good bundle should carry an error reason"
+        );
+
+        // Indices preserve bundle ordering.
+        for (i, r) in resp.results.iter().enumerate() {
+            assert_eq!(r.proof_index, i as u32);
+        }
+        assert_eq!(resp.results[0].proof_type, "source_of_funds");
+        assert_eq!(resp.results[1].proof_type, "non_inclusion");
+    }
+
+    #[tokio::test]
+    async fn tampered_bundle_returns_at_least_one_failure() {
+        let mut client = start_compliance_server().await;
+        let resp = client
+            .verify_compliance_proof(VerifyComplianceProofRequest {
+                bundle: tampered_bundle(),
+            })
+            .await
+            .expect("tampered bundle is still a successful RPC, but with failures inside")
+            .into_inner();
+
+        assert_eq!(resp.results.len(), 2);
+        assert!(
+            resp.results.iter().any(|r| !r.passed),
+            "tampered bundle must produce at least one failed result: {:?}",
+            resp.results
+        );
+
+        // The first proof passed; the second failed with a non-empty reason.
+        assert!(resp.results[0].passed);
+        assert!(resp.results[0].error.is_none());
+        assert!(!resp.results[1].passed);
+        let reason = resp.results[1]
+            .error
+            .as_ref()
+            .expect("failed proof must carry a failure reason");
+        assert!(!reason.is_empty());
+    }
+
+    #[tokio::test]
+    async fn oversized_request_returns_resource_exhausted() {
+        let mut client = start_compliance_server().await;
+        let err = client
+            .verify_compliance_proof(VerifyComplianceProofRequest {
+                bundle: vec![0u8; MAX_BUNDLE_BYTES + 1],
+            })
+            .await
+            .expect_err("bundles above the size cap must be rejected");
+        assert_eq!(err.code(), tonic::Code::ResourceExhausted);
+        assert!(
+            err.message().to_lowercase().contains("bundle"),
+            "ResourceExhausted message should mention the bundle: {}",
+            err.message()
+        );
+    }
+
+    #[tokio::test]
+    async fn unknown_proof_type_is_reported_not_panicked() {
+        // Acceptance bullet: "Unknown bundle version returns a structured
+        // error, not a crash." We model this as a proof with an unrecognised
+        // type tag — the response carries `passed = false` plus a human
+        // reason, and the RPC itself succeeds.
+        let mut client = start_compliance_server().await;
+        let bundle = json!({
+            "proofs": [{ "proof_type": "made_up_proof", "payload": {} }]
+        })
+        .to_string()
+        .into_bytes();
+
+        let resp = client
+            .verify_compliance_proof(VerifyComplianceProofRequest { bundle })
+            .await
+            .expect("unknown proof types must not crash the RPC")
+            .into_inner();
+
+        assert_eq!(resp.results.len(), 1);
+        let only = &resp.results[0];
+        assert!(!only.passed);
+        assert_eq!(only.proof_type, "made_up_proof");
+        assert!(only
+            .error
+            .as_ref()
+            .expect("unknown type must carry a reason")
+            .contains("unknown proof type"));
+    }
+
+    #[tokio::test]
+    async fn empty_bundle_is_invalid_argument() {
+        let mut client = start_compliance_server().await;
+        let err = client
+            .verify_compliance_proof(VerifyComplianceProofRequest { bundle: vec![] })
+            .await
+            .expect_err("empty bundle must be rejected as malformed input");
+        assert_eq!(err.code(), tonic::Code::InvalidArgument);
+    }
+}

--- a/proto/ark/v1/compliance_service.proto
+++ b/proto/ark/v1/compliance_service.proto
@@ -1,0 +1,91 @@
+syntax = "proto3";
+
+package ark.v1;
+
+// =============================================================================
+// ComplianceService — public, unauthenticated bundle verification (#569)
+// =============================================================================
+//
+// `ComplianceService` exposes a single RPC, `VerifyComplianceProof`, that lets
+// any third party (auditor, exchange, regulator's tool) outsource the
+// arithmetic of verifying a compliance bundle. The operator just does the math
+// — it does not learn the meaning of the proof beyond what the bundle itself
+// reveals (e.g. who the issuer is, what the proof is about).
+//
+// Auth posture
+// ------------
+// This RPC is **unauthenticated by design**. A compliance bundle is a public
+// artifact that the bundle holder has chosen to disclose; verification reveals
+// nothing they have not already shown. Anyone holding a bundle MAY verify it,
+// regardless of whether they hold a macaroon. The interceptor must therefore
+// allow this method through without an `AuthenticatedUser` extension.
+//
+// DoS posture
+// -----------
+// Verification is unauthenticated, so it is also a DoS surface. The handler
+// caps request payload size at 1 MiB; oversized requests get
+// `Status::resource_exhausted`. A future iteration will layer a token-bucket
+// rate limit on top, once the server-wide rate-limit middleware lands.
+//
+// Bundle format
+// -------------
+// The on-the-wire bundle is the serialized form defined by `#562` (the
+// compliance-bundle codec). Until that codec lands, the handler accepts the
+// pre-1.0 JSON encoding documented in `crates/dark-api/src/grpc/compliance_service.rs`.
+// Either way, the wire shape on this RPC is a single opaque blob — the codec
+// is an implementation detail that can be revved without rotating this schema.
+service ComplianceService {
+  // VerifyComplianceProof verifies every proof in a compliance bundle and
+  // returns one `ProofResult` per proof, in the order the proofs appear in
+  // the bundle. The RPC is unauthenticated; see the service-level comment.
+  //
+  // Errors
+  // ------
+  // - `INVALID_ARGUMENT`   — bundle bytes are empty or cannot be parsed.
+  // - `RESOURCE_EXHAUSTED` — bundle exceeds the 1 MiB size cap.
+  //
+  // A bundle that parses but contains an unknown proof type is **not** an RPC
+  // error: the handler emits a `ProofResult` with `passed = false` and a
+  // human-readable `error`, so a regulator's tool can surface partial results.
+  rpc VerifyComplianceProof(VerifyComplianceProofRequest)
+      returns (VerifyComplianceProofResponse);
+}
+
+// VerifyComplianceProofRequest carries an opaque, codec-defined bundle blob.
+// The bundle encoding is not modelled in proto on purpose: it is owned by
+// `dark-confidential` (#562) so that codec-level changes do not require a
+// proto roll.
+message VerifyComplianceProofRequest {
+  // Serialized compliance bundle. Maximum 1 MiB; larger payloads are rejected
+  // with `RESOURCE_EXHAUSTED` to bound DoS exposure on this unauthenticated
+  // RPC.
+  bytes bundle = 1;
+}
+
+// VerifyComplianceProofResponse returns one `ProofResult` per proof in the
+// bundle, preserving the bundle's proof ordering via `proof_index`.
+message VerifyComplianceProofResponse {
+  // One result per proof in the bundle, indexed in bundle order.
+  repeated ProofResult results = 1;
+}
+
+// ProofResult is the verifier's verdict on a single proof inside a bundle.
+//
+// `passed = false` is **not** an RPC error — it is the ordinary "did this
+// proof verify?" signal. `error` carries a human-readable reason whenever
+// `passed` is false (and is unset when the proof verifies cleanly).
+message ProofResult {
+  // Zero-based position of the proof inside the input bundle.
+  uint32 proof_index = 1;
+
+  // Identifier of the proof type that was verified (e.g. "source_of_funds").
+  // For unknown types this is the type tag carried by the bundle, so the
+  // caller can still tell which proof failed.
+  string proof_type = 2;
+
+  // True iff the proof verified against its type-specific verifier.
+  bool passed = 3;
+
+  // Human-readable failure reason when `passed` is false. Unset on success.
+  optional string error = 4;
+}


### PR DESCRIPTION
Closes #569. New proto/ark/v1/compliance_service.proto + dark-api/src/grpc/{compliance_service,compliance_verifier}.rs. Registered on public gRPC port without auth interceptor. 1 MiB bundle size cap returns Status::resource_exhausted. Stubs for #565/#566/#567 verifiers and #562 codec; replace decode_bundle() in compliance_verifier.rs once #562 lands.