### PR TITLE
feat(dark-client,ark-cli): confidential-aware balance and history (#575)

### DIFF
--- a/crates/ark-cli/src/balance.rs
+++ b/crates/ark-cli/src/balance.rs
@@ -1,0 +1,67 @@
+//! `ark-cli balance` — print confidential-aware spendable balance.
+//!
+//! Sums plaintext amounts the wallet has openings for. Confidential
+//! VTXOs the wallet only observed (no opening) cannot contribute.
+//!
+//! ## Cache wiring — TODO(#574)
+//!
+//! The real implementation will pull owned VTXOs from the local
+//! confidential cache (#574). Until that lands on main, this command
+//! returns `0` from an empty in-memory source, and emits a
+//! `note: cache not available` line so users understand why.
+//!
+//! ## Closes #575
+
+use anyhow::Result;
+use dark_client::{balance, InMemoryOwnedVtxos, OwnedVtxoSource};
+
+/// Note shown to humans whenever the underlying source is empty —
+/// callers should be aware the `0` may simply mean "cache not wired".
+const EMPTY_SOURCE_NOTE: &str = "no owned VTXOs cached locally (TODO(#574): wire cache)";
+
+pub fn handle(json: bool) -> Result<()> {
+    let source = owned_vtxo_source();
+    print_balance(&source, json)
+}
+
+fn owned_vtxo_source() -> impl OwnedVtxoSource {
+    // TODO(#574): swap for the real confidential cache once available.
+    InMemoryOwnedVtxos::new()
+}
+
+fn print_balance<S: OwnedVtxoSource>(source: &S, json: bool) -> Result<()> {
+    let total = balance(source);
+    let owned_count = source.owned_vtxos().len();
+
+    if json {
+        let mut out = serde_json::json!({
+            "balance_sats": total,
+            "owned_vtxo_count": owned_count,
+        });
+        if owned_count == 0 {
+            out["note"] = serde_json::Value::String(EMPTY_SOURCE_NOTE.into());
+        }
+        println!("{}", serde_json::to_string_pretty(&out)?);
+    } else {
+        println!("Balance: {} sats", total);
+        if owned_count == 0 {
+            println!("  ({})", EMPTY_SOURCE_NOTE);
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_does_not_panic_for_text_output() {
+        handle(false).expect("text output should succeed");
+    }
+
+    #[test]
+    fn handle_does_not_panic_for_json_output() {
+        handle(true).expect("json output should succeed");
+    }
+}

--- a/crates/ark-cli/src/history.rs
+++ b/crates/ark-cli/src/history.rs
@@ -1,0 +1,120 @@
+//! `ark-cli history` — print confidential-aware activity history.
+//!
+//! Each entry shows the plaintext amount when known, otherwise the
+//! literal string `confidential` (see
+//! [`dark_client::CONFIDENTIAL_AMOUNT_LABEL`]).
+//!
+//! ## Cache wiring — TODO(#574)
+//!
+//! The real implementation will pull owned and observed VTXOs from
+//! the confidential cache (#574). Until that lands, this command runs
+//! against empty in-memory sources and emits a `note: cache not
+//! available` line.
+//!
+//! ## Closes #575
+
+use anyhow::Result;
+use dark_client::{
+    history, HistoryEntry, InMemoryObservedVtxos, InMemoryOwnedVtxos, ObservedVtxoSource,
+    OwnedVtxoSource,
+};
+
+const EMPTY_SOURCES_NOTE: &str = "no VTXOs cached locally (TODO(#574): wire confidential cache)";
+
+pub fn handle(json: bool) -> Result<()> {
+    let owned = owned_vtxo_source();
+    let observed = observed_vtxo_source();
+    print_history(&owned, &observed, json)
+}
+
+fn owned_vtxo_source() -> impl OwnedVtxoSource {
+    // TODO(#574): swap for the real confidential cache once available.
+    InMemoryOwnedVtxos::new()
+}
+
+fn observed_vtxo_source() -> impl ObservedVtxoSource {
+    // TODO(#574): swap for the real confidential cache once available.
+    InMemoryObservedVtxos::new()
+}
+
+fn print_history<O, X>(owned: &O, observed: &X, json: bool) -> Result<()>
+where
+    O: OwnedVtxoSource,
+    X: ObservedVtxoSource,
+{
+    let entries = history(owned, observed);
+
+    if json {
+        print_json(&entries)?;
+        return Ok(());
+    }
+
+    if entries.is_empty() {
+        println!("No history entries.");
+        println!("  ({})", EMPTY_SOURCES_NOTE);
+        return Ok(());
+    }
+
+    print_table(&entries);
+    Ok(())
+}
+
+fn print_json(entries: &[HistoryEntry]) -> Result<()> {
+    let mut out = serde_json::json!({ "entries": entries });
+    if entries.is_empty() {
+        out["note"] = serde_json::Value::String(EMPTY_SOURCES_NOTE.into());
+    }
+    println!("{}", serde_json::to_string_pretty(&out)?);
+    Ok(())
+}
+
+fn print_table(entries: &[HistoryEntry]) {
+    println!("  VTXO                     KIND     AMOUNT         STATUS     TIMESTAMP");
+    let separator = "-".repeat(72);
+    println!("  {separator}");
+    for entry in entries {
+        println!(
+            "  {:<24} {:<8} {:<14} {:<10} {}",
+            truncate(&entry.vtxo_id, 24),
+            format!("{:?}", entry.kind).to_lowercase(),
+            entry.amount_display(),
+            format!("{:?}", entry.status).to_lowercase(),
+            entry.timestamp,
+        );
+    }
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    if s.len() <= max {
+        s.to_string()
+    } else {
+        format!("{}...", &s[..max.saturating_sub(3)])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn handle_does_not_panic_for_text_output() {
+        handle(false).expect("text output should succeed");
+    }
+
+    #[test]
+    fn handle_does_not_panic_for_json_output() {
+        handle(true).expect("json output should succeed");
+    }
+
+    #[test]
+    fn truncate_keeps_short_strings_intact() {
+        assert_eq!(truncate("short", 24), "short");
+    }
+
+    #[test]
+    fn truncate_shortens_long_strings_with_ellipsis() {
+        let truncated = truncate("0123456789012345678901234567890", 10);
+        assert!(truncated.ends_with("..."));
+        assert_eq!(truncated.len(), 10);
+    }
+}

--- a/crates/ark-cli/src/main.rs
+++ b/crates/ark-cli/src/main.rs
@@ -1,6 +1,8 @@
+mod balance;
 mod confidential;
 mod confidential_tx_stub;
 mod disclose;
+mod history;
 mod stealth;
 mod wallet_config;
 
@@ -120,6 +122,17 @@ pub enum Commands {
     /// Reads from `--in <path>` or stdin and exits non-zero if any
     /// contained proof fails to verify.
     Verify(VerifyArgs),
+    /// Show confidential-aware spendable balance.
+    ///
+    /// Sums plaintext amounts from the local confidential VTXO cache
+    /// (gated on #574). Confidential VTXOs without a known opening
+    /// cannot contribute to the balance.
+    Balance,
+    /// Show confidential-aware activity history.
+    ///
+    /// Each entry shows the plaintext amount if known, otherwise the
+    /// literal string `confidential`.
+    History,
 }
 
 #[derive(Subcommand, Debug)]
@@ -311,6 +324,8 @@ fn is_local_only(command: &Commands) -> bool {
             | Commands::Config { .. }
             | Commands::Disclose(_)
             | Commands::Verify(_)
+            | Commands::Balance
+            | Commands::History
             | Commands::Send(_) // send routes through the stub for now
     )
 }
@@ -410,6 +425,8 @@ async fn handle_command(cli: &Cli) -> Result<()> {
         Commands::Stealth { action } => stealth::handle(action, cli.json)?,
         Commands::Disclose(args) => disclose::handle_disclose(args)?,
         Commands::Verify(args) => disclose::handle_verify(args)?,
+        Commands::Balance => balance::handle(cli.json)?,
+        Commands::History => history::handle(cli.json)?,
     }
     Ok(())
 }
@@ -790,5 +807,17 @@ mod tests {
         // assert the function returns Ok and that the address is
         // derivable.
         confidential::handle_receive(&reloaded, /*json*/ true).expect("receive renders");
+    }
+
+    #[test]
+    fn test_cli_balance_command_parses() {
+        let cli = Cli::parse_from(["ark-cli", "balance"]);
+        assert!(matches!(cli.command, Commands::Balance));
+    }
+
+    #[test]
+    fn test_cli_history_command_parses() {
+        let cli = Cli::parse_from(["ark-cli", "history"]);
+        assert!(matches!(cli.command, Commands::History));
     }
 }

--- a/crates/dark-client/src/balance.rs
+++ b/crates/dark-client/src/balance.rs
@@ -1,0 +1,187 @@
+//! Confidential-aware spendable balance.
+//!
+//! For confidential VTXOs we only know the plaintext amount of the ones
+//! the wallet actually owns (the openings sit in the local cache). For
+//! everything else — VTXOs the wallet has *observed* on the network but
+//! cannot open — the amount is hidden, so it cannot contribute to the
+//! local spendable balance.
+//!
+//! [`balance`] simply sums the plaintext amounts of the locally-owned,
+//! still-spendable VTXOs returned by an [`OwnedVtxoSource`].
+//!
+//! ## Cache trait — TODO(#574)
+//!
+//! Issue #574 ("local VTXO cache for confidential openings") defines the
+//! authoritative cache trait. Until that lands on main, this module
+//! exposes a minimal [`OwnedVtxoSource`] surface with the single method
+//! [`OwnedVtxoSource::owned_vtxos`]. When #574 merges, this trait should
+//! be replaced by — or made an alias for — its richer cache trait.
+//!
+//! ## Closes #575
+//! Used by `ark-cli balance` and by [`crate::history`](mod@crate::history) to
+//! resolve plaintext amounts.
+
+use crate::types::Vtxo;
+
+/// A locally-known VTXO opening — i.e. one we own and have plaintext for.
+///
+/// The `amount` field is the cleartext value in satoshis recovered from
+/// the Pedersen commitment opening; this is what makes the VTXO
+/// "non-confidential to us".
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OwnedVtxo {
+    /// Stable VTXO identifier (matches [`Vtxo::id`]).
+    pub vtxo_id: String,
+    /// Plaintext amount in satoshis.
+    pub amount: u64,
+    /// Whether the VTXO has been spent locally or on the network.
+    pub is_spent: bool,
+    /// Whether the operator has swept the VTXO post-expiry.
+    pub is_swept: bool,
+}
+
+impl OwnedVtxo {
+    /// True when the VTXO is still spendable: not spent, not swept.
+    pub fn is_spendable(&self) -> bool {
+        !self.is_spent && !self.is_swept
+    }
+}
+
+/// Source of locally-owned VTXO openings.
+///
+/// TODO(#574): replace with the canonical confidential-cache trait
+/// introduced by issue #574. Until that lands, this minimal surface is
+/// what `balance` and `history` rely on.
+pub trait OwnedVtxoSource {
+    /// Return all VTXOs the wallet owns the plaintext opening for.
+    ///
+    /// Both spendable and already-spent entries should be returned;
+    /// callers (like [`balance`]) are responsible for filtering.
+    fn owned_vtxos(&self) -> Vec<OwnedVtxo>;
+}
+
+/// Sum the plaintext amounts of all spendable, locally-owned VTXOs.
+///
+/// VTXOs the wallet has merely *observed* but cannot open are
+/// confidential to us, so they cannot contribute — see [`history`] for
+/// how those surface in the activity log instead.
+///
+/// [`history`]: crate::history::history
+pub fn balance<S: OwnedVtxoSource + ?Sized>(source: &S) -> u64 {
+    source
+        .owned_vtxos()
+        .iter()
+        .filter(|vtxo| vtxo.is_spendable())
+        .map(|vtxo| vtxo.amount)
+        .sum()
+}
+
+/// Convenience helper for the common case where the caller already
+/// holds a slice of [`Vtxo`]s and wants to compute a confidential-aware
+/// balance over only the ones with known plaintext amounts.
+pub fn balance_from_vtxos(vtxos: &[Vtxo]) -> u64 {
+    vtxos
+        .iter()
+        .filter(|vtxo| !vtxo.is_spent && !vtxo.is_swept)
+        .map(|vtxo| vtxo.amount)
+        .sum()
+}
+
+/// In-memory placeholder source used by `ark-cli` and tests until the
+/// real confidential cache (#574) is on main.
+///
+/// TODO(#574): drop in favour of the cache impl once #574 lands.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryOwnedVtxos {
+    vtxos: Vec<OwnedVtxo>,
+}
+
+impl InMemoryOwnedVtxos {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder-style insert; returns `self` for chaining.
+    pub fn with(mut self, vtxo: OwnedVtxo) -> Self {
+        self.vtxos.push(vtxo);
+        self
+    }
+
+    /// Direct insert.
+    pub fn push(&mut self, vtxo: OwnedVtxo) {
+        self.vtxos.push(vtxo);
+    }
+}
+
+impl OwnedVtxoSource for InMemoryOwnedVtxos {
+    fn owned_vtxos(&self) -> Vec<OwnedVtxo> {
+        self.vtxos.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn owned(id: &str, amount: u64) -> OwnedVtxo {
+        OwnedVtxo {
+            vtxo_id: id.into(),
+            amount,
+            is_spent: false,
+            is_swept: false,
+        }
+    }
+
+    #[test]
+    fn empty_source_yields_zero_balance() {
+        let source = InMemoryOwnedVtxos::new();
+        assert_eq!(balance(&source), 0);
+    }
+
+    #[test]
+    fn balance_sums_only_spendable_vtxos() {
+        let mut spent = owned("v2", 5_000);
+        spent.is_spent = true;
+
+        let mut swept = owned("v3", 7_000);
+        swept.is_swept = true;
+
+        let source = InMemoryOwnedVtxos::new()
+            .with(owned("v1", 10_000))
+            .with(spent)
+            .with(swept)
+            .with(owned("v4", 3_000));
+
+        assert_eq!(balance(&source), 13_000);
+    }
+
+    #[test]
+    fn balance_from_vtxos_skips_spent_and_swept() {
+        fn vtxo(id: &str, amount: u64, is_spent: bool, is_swept: bool) -> Vtxo {
+            Vtxo {
+                id: id.into(),
+                txid: id.into(),
+                vout: 0,
+                amount,
+                script: String::new(),
+                created_at: 0,
+                expires_at: 0,
+                is_spent,
+                is_swept,
+                is_unrolled: false,
+                spent_by: String::new(),
+                ark_txid: String::new(),
+                assets: vec![],
+            }
+        }
+
+        let vtxos = vec![
+            vtxo("a", 1_000, false, false),
+            vtxo("b", 2_000, true, false),
+            vtxo("c", 4_000, false, true),
+            vtxo("d", 8_000, false, false),
+        ];
+
+        assert_eq!(balance_from_vtxos(&vtxos), 9_000);
+    }
+}

--- a/crates/dark-client/src/history.rs
+++ b/crates/dark-client/src/history.rs
@@ -1,0 +1,296 @@
+//! Confidential-aware activity history.
+//!
+//! For confidential VTXOs the wallet shows plaintext amounts only for
+//! the ones it actually owns; observed-but-not-owned VTXOs surface as
+//! entries with [`HistoryEntry::amount`] == `None`, which CLIs render
+//! as the literal string `confidential` (see
+//! [`HistoryEntry::amount_display`]).
+//!
+//! ## Stubbed cache trait — TODO(#574)
+//!
+//! The local VTXO cache (#574) is the source of plaintext amounts.
+//! While that issue is in flight, this module relies on the minimal
+//! [`crate::balance::OwnedVtxoSource`] trait defined in the
+//! [`crate::balance`](mod@crate::balance) module. The observed-but-not-owned set is supplied
+//! through [`ObservedVtxoSource`] — a deliberately tiny shim so tests
+//! and CLIs can stand it up in-memory.
+//!
+//! ## Closes #575
+
+use serde::{Deserialize, Serialize};
+
+use crate::balance::{OwnedVtxo, OwnedVtxoSource};
+
+/// What this history entry represents.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryEntryKind {
+    /// VTXO landed in our wallet (incoming).
+    Receive,
+    /// VTXO left our wallet (outgoing).
+    Send,
+    /// VTXO observed in a settlement round (counterparty traffic).
+    Round,
+    /// Operator-driven sweep of an expired VTXO.
+    Sweep,
+}
+
+/// Lifecycle status of the underlying VTXO at the time of report.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum HistoryStatus {
+    /// VTXO is still spendable.
+    Spendable,
+    /// VTXO has been spent.
+    Spent,
+    /// VTXO has been swept by the operator after expiry.
+    Swept,
+}
+
+/// A single entry in the wallet's activity history.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct HistoryEntry {
+    /// VTXO this entry is about.
+    pub vtxo_id: String,
+    /// What kind of activity this entry records.
+    pub kind: HistoryEntryKind,
+    /// Plaintext amount in satoshis if known, `None` for confidential VTXOs.
+    pub amount: Option<u64>,
+    /// Unix timestamp the entry was observed at.
+    pub timestamp: i64,
+    /// Lifecycle status at report time.
+    pub status: HistoryStatus,
+}
+
+/// Literal string used by CLIs/UIs when an amount is hidden.
+pub const CONFIDENTIAL_AMOUNT_LABEL: &str = "confidential";
+
+impl HistoryEntry {
+    /// Render the amount for human consumption: digits if known,
+    /// otherwise the literal `"confidential"`.
+    pub fn amount_display(&self) -> String {
+        match self.amount {
+            Some(sats) => sats.to_string(),
+            None => CONFIDENTIAL_AMOUNT_LABEL.to_string(),
+        }
+    }
+}
+
+/// A VTXO the wallet has observed on-network but cannot open.
+///
+/// This is the deliberately-small surface needed to render history
+/// entries; richer metadata (round id, ephemeral pubkey, etc.) would
+/// live alongside it in the real cache once #574 lands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ObservedVtxo {
+    pub vtxo_id: String,
+    pub kind: HistoryEntryKind,
+    pub timestamp: i64,
+    pub status: HistoryStatus,
+}
+
+/// Source of observed-but-not-owned VTXOs.
+///
+/// TODO(#574): fold into the canonical cache trait once #574 is on main.
+pub trait ObservedVtxoSource {
+    fn observed_vtxos(&self) -> Vec<ObservedVtxo>;
+}
+
+/// Build the wallet's activity history.
+///
+/// Owned VTXOs (from `owned`) yield entries with concrete plaintext
+/// amounts; observed-only VTXOs (from `observed`) yield entries with
+/// `amount = None`, which downstream renderers print as
+/// [`CONFIDENTIAL_AMOUNT_LABEL`].
+///
+/// Entries are returned newest-first by timestamp; ties are broken by
+/// `vtxo_id` for deterministic ordering. If both sources include the
+/// same `vtxo_id`, the owned entry wins (we have the plaintext).
+pub fn history<O, X>(owned: &O, observed: &X) -> Vec<HistoryEntry>
+where
+    O: OwnedVtxoSource + ?Sized,
+    X: ObservedVtxoSource + ?Sized,
+{
+    let owned_entries = owned.owned_vtxos().into_iter().map(owned_to_entry);
+    let known_ids: std::collections::HashSet<String> =
+        owned.owned_vtxos().into_iter().map(|v| v.vtxo_id).collect();
+    let observed_entries = observed
+        .observed_vtxos()
+        .into_iter()
+        .filter(|v| !known_ids.contains(&v.vtxo_id))
+        .map(observed_to_entry);
+
+    let mut entries: Vec<HistoryEntry> = owned_entries.chain(observed_entries).collect();
+    entries.sort_by(|a, b| {
+        b.timestamp
+            .cmp(&a.timestamp)
+            .then_with(|| a.vtxo_id.cmp(&b.vtxo_id))
+    });
+    entries
+}
+
+fn owned_to_entry(vtxo: OwnedVtxo) -> HistoryEntry {
+    let status = if vtxo.is_swept {
+        HistoryStatus::Swept
+    } else if vtxo.is_spent {
+        HistoryStatus::Spent
+    } else {
+        HistoryStatus::Spendable
+    };
+    let kind = match status {
+        HistoryStatus::Spendable => HistoryEntryKind::Receive,
+        HistoryStatus::Spent => HistoryEntryKind::Send,
+        HistoryStatus::Swept => HistoryEntryKind::Sweep,
+    };
+    HistoryEntry {
+        vtxo_id: vtxo.vtxo_id,
+        kind,
+        amount: Some(vtxo.amount),
+        timestamp: 0,
+        status,
+    }
+}
+
+fn observed_to_entry(vtxo: ObservedVtxo) -> HistoryEntry {
+    HistoryEntry {
+        vtxo_id: vtxo.vtxo_id,
+        kind: vtxo.kind,
+        amount: None,
+        timestamp: vtxo.timestamp,
+        status: vtxo.status,
+    }
+}
+
+/// In-memory placeholder source used by `ark-cli` and tests until the
+/// real confidential cache (#574) is on main.
+///
+/// TODO(#574): drop in favour of the cache impl once #574 lands.
+#[derive(Debug, Default, Clone)]
+pub struct InMemoryObservedVtxos {
+    vtxos: Vec<ObservedVtxo>,
+}
+
+impl InMemoryObservedVtxos {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Builder-style insert; returns `self` for chaining.
+    pub fn with(mut self, vtxo: ObservedVtxo) -> Self {
+        self.vtxos.push(vtxo);
+        self
+    }
+
+    /// Direct insert.
+    pub fn push(&mut self, vtxo: ObservedVtxo) {
+        self.vtxos.push(vtxo);
+    }
+}
+
+impl ObservedVtxoSource for InMemoryObservedVtxos {
+    fn observed_vtxos(&self) -> Vec<ObservedVtxo> {
+        self.vtxos.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::balance::{InMemoryOwnedVtxos, OwnedVtxo};
+
+    fn owned(id: &str, amount: u64) -> OwnedVtxo {
+        OwnedVtxo {
+            vtxo_id: id.into(),
+            amount,
+            is_spent: false,
+            is_swept: false,
+        }
+    }
+
+    fn observed(id: &str, kind: HistoryEntryKind, ts: i64) -> ObservedVtxo {
+        ObservedVtxo {
+            vtxo_id: id.into(),
+            kind,
+            timestamp: ts,
+            status: HistoryStatus::Spendable,
+        }
+    }
+
+    #[test]
+    fn empty_sources_yield_empty_history() {
+        let owned = InMemoryOwnedVtxos::new();
+        let observed = InMemoryObservedVtxos::new();
+        assert!(history(&owned, &observed).is_empty());
+    }
+
+    #[test]
+    fn owned_vtxos_carry_plaintext_amount() {
+        let owned = InMemoryOwnedVtxos::new().with(owned("v1", 12_345));
+        let observed = InMemoryObservedVtxos::new();
+
+        let entries = history(&owned, &observed);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].amount, Some(12_345));
+        assert_eq!(entries[0].amount_display(), "12345");
+        assert_eq!(entries[0].kind, HistoryEntryKind::Receive);
+    }
+
+    #[test]
+    fn observed_only_vtxos_render_as_confidential() {
+        let owned = InMemoryOwnedVtxos::new();
+        let observed =
+            InMemoryObservedVtxos::new().with(observed("v9", HistoryEntryKind::Round, 100));
+
+        let entries = history(&owned, &observed);
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].amount.is_none());
+        assert_eq!(entries[0].amount_display(), CONFIDENTIAL_AMOUNT_LABEL);
+        assert_eq!(entries[0].kind, HistoryEntryKind::Round);
+    }
+
+    #[test]
+    fn owned_entry_wins_when_id_appears_in_both_sources() {
+        let owned = InMemoryOwnedVtxos::new().with(owned("dup", 9_000));
+        let observed =
+            InMemoryObservedVtxos::new().with(observed("dup", HistoryEntryKind::Round, 50));
+
+        let entries = history(&owned, &observed);
+        assert_eq!(entries.len(), 1);
+        assert_eq!(entries[0].amount, Some(9_000));
+    }
+
+    #[test]
+    fn entries_are_sorted_newest_first() {
+        let owned = InMemoryOwnedVtxos::new();
+        let observed = InMemoryObservedVtxos::new()
+            .with(observed("a", HistoryEntryKind::Round, 100))
+            .with(observed("b", HistoryEntryKind::Round, 300))
+            .with(observed("c", HistoryEntryKind::Round, 200));
+
+        let entries = history(&owned, &observed);
+        let timestamps: Vec<i64> = entries.iter().map(|e| e.timestamp).collect();
+        assert_eq!(timestamps, vec![300, 200, 100]);
+    }
+
+    #[test]
+    fn spent_owned_vtxo_records_send_kind() {
+        let mut spent = owned("v1", 1_000);
+        spent.is_spent = true;
+        let owned_src = InMemoryOwnedVtxos::new().with(spent);
+
+        let entries = history(&owned_src, &InMemoryObservedVtxos::new());
+        assert_eq!(entries[0].kind, HistoryEntryKind::Send);
+        assert_eq!(entries[0].status, HistoryStatus::Spent);
+    }
+
+    #[test]
+    fn swept_owned_vtxo_records_sweep_kind() {
+        let mut swept = owned("v1", 1_000);
+        swept.is_swept = true;
+        let owned_src = InMemoryOwnedVtxos::new().with(swept);
+
+        let entries = history(&owned_src, &InMemoryObservedVtxos::new());
+        assert_eq!(entries[0].kind, HistoryEntryKind::Sweep);
+        assert_eq!(entries[0].status, HistoryStatus::Swept);
+    }
+}

--- a/crates/dark-client/src/lib.rs
+++ b/crates/dark-client/src/lib.rs
@@ -50,6 +50,7 @@
 //! }
 //! ```
 
+pub mod balance;
 pub mod batch;
 pub mod client;
 pub mod confidential;
@@ -57,6 +58,7 @@ pub mod confidential_exit;
 pub mod confidential_tx;
 pub mod error;
 pub mod explorer;
+pub mod history;
 pub mod owned_vtxos;
 pub mod restore;
 pub mod sdk;
@@ -65,6 +67,7 @@ pub mod store;
 pub mod types;
 pub mod wallet;
 
+pub use balance::{balance, balance_from_vtxos, InMemoryOwnedVtxos, OwnedVtxoSource};
 pub use batch::VtxoInput;
 pub use client::{ArkClient, BoardingUtxo, OffchainTxResult, RedeemBranch};
 pub use confidential_exit::{
@@ -76,6 +79,10 @@ pub use confidential_tx::{
     WalletSeed, SCHEMA_VERSION,
 };
 pub use error::{ClientError, ClientResult};
+pub use history::{
+    history, HistoryEntry, HistoryEntryKind, HistoryStatus, InMemoryObservedVtxos, ObservedVtxo,
+    ObservedVtxoSource, CONFIDENTIAL_AMOUNT_LABEL,
+};
 pub use owned_vtxos::{
     EncryptedFileOwnedVtxoStore, InMemoryOwnedVtxoStore, OwnedConfidentialVtxo, OwnedVtxoError,
     OwnedVtxoStore, ScopeMetadata, SecretBytes,


### PR DESCRIPTION
Closes #575. dark_client::balance() / history() with HistoryEntryKind {Receive, Send, Round, Sweep} and Option<u64> amount (None displays as confidential via CONFIDENTIAL_AMOUNT_LABEL). ark-cli balance and history subcommands. OwnedVtxoSource/ObservedVtxoSource traits stub the #574 cache (TODO).