### PR TITLE
docs(sdk,migration,security): integrator guide + migration + threat model (#577)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ See [`config.example.toml`](config.example.toml) for a fully documented template
 - **[Light Mode](docs/light-mode.md)** — Simplified deployment without external dependencies
 - **[Operational Runbook](docs/runbook.md)** — Monitoring, maintenance, and troubleshooting
 
+### Confidential VTXOs
+
+- **[SDK: Confidential Transactions](docs/sdk/confidential-transactions.md)** — Step-by-step integrator guide for building confidential txs with `dark-client`
+- **[Migration: Transparent → Confidential](docs/migration/transparent-to-confidential.md)** — What changes for existing wallet integrations; backwards-compatibility guarantees
+- **[Confidential Threat Model](docs/security/confidential-threat-model.md)** — What is hidden, from whom, under which assumptions; adversary models
+
 ---
 
 ## Resources

--- a/docs/migration/transparent-to-confidential.md
+++ b/docs/migration/transparent-to-confidential.md
@@ -1,0 +1,325 @@
+# Migration: Transparent VTXOs → Confidential VTXOs
+
+- **Audience:** maintainers of existing wallet integrations against the transparent Ark protocol who want to opt their users into Confidential VTXOs without breaking spendability of existing balances.
+- **Scope:** what changes for the wallet, what does **not** change, the new SDK surface, and the backwards-compatibility guarantees the protocol gives you.
+- **Companion documents:**
+  - [Confidential Transactions: SDK Integrator Guide](../sdk/confidential-transactions.md)
+  - [Confidential Threat Model](../security/confidential-threat-model.md)
+
+---
+
+## 1. TL;DR
+
+- Existing transparent VTXOs **stay valid forever**. They remain spendable at face value with no re-batching, no migration round, and no operator coordination required (#541, #520 parity gate).
+- A wallet opts in to confidential sends per call (or globally, via a new `default_confidential` flag described in §4 below). Receiving confidentially additionally requires the wallet to publish a stealth meta-address; until it does, senders cannot reach it confidentially.
+- Mixed transparent/confidential rounds are first-class. There is no "confidential round" vs. "transparent round" — a single round batches both, and the round-tree root is byte-identical to today's Go-`arkd` root for any transparent-only leaf set (#540, the Go-parity gate).
+- Wallet-store schema gains a `confidential_vtxos` namespace for cleartext openings, encrypted at rest under the existing AES-256-GCM scheme (#574). The `transparent_vtxos` namespace is unchanged.
+
+The migration is **additive**. No transparent-side schema changes, no consensus changes, no Bitcoin script changes. If you do nothing, your wallet keeps working exactly as it does today.
+
+---
+
+## 2. What does NOT change
+
+This section is the load-bearing one. Internalise it before reading anything else.
+
+### 2.1 Existing transparent VTXOs remain spendable
+
+A VTXO created before the confidential rollout is a `LeafV1` in the round tree. Its leaf hash preimage is byte-identical to the Go `arkd` preimage. The Rust `dark-core` round-tree builder dispatches on variant:
+
+```text
+tree_leaf_hash(vtxo: &Vtxo) -> [u8; 32] {
+    match vtxo {
+        Transparent(t)  => leaf_v1_hash(t),  // byte-identical to Go arkd
+        Confidential(c) => leaf_v2_hash(c),  // distinct domain prefix
+    }
+}
+```
+
+Per #540 acceptance criteria, the Rust root for any transparent-only leaf set must equal the Go `arkd` root byte-for-byte, with a regression fixture committed. A user who upgrades their wallet but never sends confidentially sees zero change.
+
+### 2.2 Forfeit / exit / unilateral-exit semantics
+
+Forfeit transactions and exit semantics for transparent VTXOs are unchanged. The vendored Go `arkd` E2E suite passes unchanged on transparent-only rounds — that is a non-negotiable acceptance criterion of #540 and #541. If your integration relies on the Go test vectors, they continue to apply.
+
+The unilateral-exit path for confidential VTXOs is the new code path (`crates/dark-client/src/confidential_exit.rs`, ADR-0005). The witness format is different — `(amount, blinding, signature)` for confidential vs. just `(signature)` for transparent — but the trigger flow (round-tree leaf broadcast, CSV maturing, claim) is the same shape.
+
+### 2.3 gRPC surface
+
+The operator's gRPC surface (`ArkService`, `IndexerService`, `WalletService`, `SignerManagerService`) is **additive**:
+
+- `GetRoundAnnouncements` is a new stream. Existing clients that do not subscribe see no behaviour change.
+- `VerifyComplianceProof` is a new endpoint (#569). Existing clients never need to call it.
+- Existing methods (`GetInfo`, `ListVtxos`, `Settle`, `Send`, `RedeemNotes`, `CollaborativeExit`, etc.) are unchanged in signature and semantics on transparent VTXOs.
+
+### 2.4 Wallet derivation for transparent funds
+
+The transparent wallet derivation path (`m/86'/{coin}'/0'/{0,1}/{idx}`) is unchanged. `SingleKeyWallet::generate` / `from_wif` / `from_secret_bytes` continue to work and produce the same on-chain addresses they did before. The stealth scan / spend / view keys live under disjoint BIP-32 regions per ADR-M5-DD; deriving them does not perturb the transparent path.
+
+---
+
+## 3. What does change for the wallet
+
+### 3.1 New keys to derive at wallet bring-up
+
+A confidential-aware wallet derives three additional keys per account from the same BIP-39 seed:
+
+| Key | Purpose | Visibility | Derivation path | Type |
+| --- | --- | --- | --- | --- |
+| `scan_sk` | detect inbound VTXOs | read-only credential | `scan_path(account_index)` (ADR-M5-DD) | `dark_confidential::stealth::ScanKey` |
+| `spend_sk` | authorise spend | full spending authority | `spend_path(account_index)` (ADR-M5-DD) | `dark_confidential::stealth::SpendKey` |
+| `view_sk` | decrypt past memos under a scope | read-only audit credential | `view_path(account_index)` (ADR-M5-DD) | `dark_confidential::viewing::ViewingKey` |
+
+All three are wrapped types with `Zeroize` on drop and no `Copy` / `Clone` / `Debug`. Bytes leave the wrappers only via `expose_secret()` — that name is the audit anchor.
+
+```rust,ignore
+use dark_confidential::stealth::{MetaAddress, StealthNetwork, StealthSecrets};
+use dark_confidential::viewing::ViewingKey;
+
+let (meta, StealthSecrets { scan_key, spend_key }) =
+    MetaAddress::from_seed(&seed, account_index, StealthNetwork::Mainnet)?;
+
+let view_key = ViewingKey::from_seed(&seed, account_index)?;
+```
+
+The published `MetaAddress` (bech32m `darks1...`) replaces the bare 33-byte compressed pubkey as the recipient identifier for confidential sends. The bare pubkey is still valid for transparent sends; see §4 below.
+
+### 3.2 New on-disk state to persist (#574)
+
+For each owned confidential VTXO, the wallet persists a row in the `confidential_vtxos` namespace:
+
+```text
+(vtxo_id, amount, blinding, one_time_sk)
+```
+
+`vtxo_id` is the canonical 36-byte `txid || vout` per ADR-0002. `amount` and `blinding` are the Pedersen opening — required to spend, and required to keep encrypted at rest. `one_time_sk` is the per-VTXO spend secret derived from `(spend_sk, ephemeral_pk, scan_sk)` ECDH.
+
+Encryption-at-rest reuses the wallet's existing AES-256-GCM scheme (passphrase-derived KDF). Writes are atomic — no torn state on crash mid-write. The `transparent_vtxos` namespace is unchanged.
+
+> Acceptance criterion from #574: a hex dump of the wallet store must not contain the plaintext amount of any owned VTXO. Verify this with a marker-amount test (`amount = 0xCAFE_BABE_DEAD_BEEF`) before shipping.
+
+### 3.3 New background task: stealth scanner (#558)
+
+To detect inbound confidential VTXOs the wallet runs a background task that streams `GetRoundAnnouncements`, scans each against `(scan_sk, spend_pk)`, decrypts the memo on a match, and persists the opening:
+
+```rust,ignore
+use dark_client::stealth_scan::{StealthScanner, DEFAULT_POLL_INTERVAL};
+use tokio_util::sync::CancellationToken;
+
+let cancel = CancellationToken::new();
+let scanner_task = StealthScanner::new(scan_sk, spend_pk, source, store, cancel.clone())
+    .with_poll_interval(DEFAULT_POLL_INTERVAL)
+    .start();
+```
+
+Checkpointing under `CHECKPOINT_METADATA_KEY = "stealth_scan:checkpoint"` lets the scanner resume after restart without re-scanning. Backoff and reconnect on transport errors are built in. See `crates/dark-client/src/stealth_scan.rs` and ADR-M5-DD.
+
+A wallet that does not run the scanner cannot detect inbound confidential VTXOs. Transparent inbound payments still surface via `ListVtxos` exactly as before.
+
+### 3.4 Restore from seed with stealth re-scan (#560)
+
+`restore_from_seed` now walks the operator's historical announcements to rediscover every confidential VTXO. It reuses the same scanner page-handling code so live scanning and restore stay byte-consistent.
+
+```rust,ignore
+use dark_client::restore::{restore_from_seed, RestoreConfig};
+
+let summary = restore_from_seed(
+    &seed,
+    RestoreConfig {
+        operator_url: "http://localhost:50051".into(),
+        birthday_height: Some(523_000),  // optional; skips ancient rounds
+        ..Default::default()
+    },
+).await?;
+
+println!("recovered {} confidential VTXOs", summary.recovered_confidential);
+```
+
+`birthday_height` is an opt-in optimisation. Without it, `restore_from_seed` walks the full archival horizon (operator-defined, see ADR-M5-DD-announcement-pruning) and surfaces a typed `BirthdayBeforeArchivalHorizon` error if the requested birthday is older than the operator's pruning window.
+
+A wallet upgrading from transparent-only to confidential restore should re-run the restore once after introducing stealth keys; otherwise no historical confidential VTXOs are visible until a fresh sync replays the announcement stream.
+
+---
+
+## 4. API differences
+
+### 4.1 Recipient identifier: `MetaAddress` vs. raw pubkey
+
+| Direction | Today (transparent) | After migration (confidential opt-in) |
+| --- | --- | --- |
+| Wire encoding | bare 33-byte compressed pubkey hex, optionally prefixed `ark:` | bech32m `darks1...` / `tdarks1...` / `rdarks1...` (mainnet/testnet/regtest) |
+| Type in SDK | `String` (pubkey hex) | `dark_confidential::stealth::MetaAddress` |
+| Detection | operator returns VTXOs by pubkey lookup | recipient scans announcement stream (§3.3) |
+| Versioning | none | explicit version byte inside the bech32m payload (currently `0x01`) |
+
+The transparent identifier (raw pubkey hex / `ark:<hex>`) continues to work for transparent sends. A wallet that publishes only its meta-address can still receive transparent payments at its pubkey, and a wallet that publishes only its pubkey can still receive transparent payments. The two namespaces coexist; the wallet decides per outgoing payment which to use.
+
+### 4.2 `default_confidential` flag
+
+The SDK gains a wallet-level boolean that controls the default for outgoing payments:
+
+- `default_confidential = false` (default): `send_offchain(to_address, amount)` continues to send transparently. To send confidentially, call the confidential send path explicitly with a `MetaAddress`.
+- `default_confidential = true`: `send_offchain` upgrades to confidential when the destination is a `MetaAddress`. If the destination is a bare pubkey, the SDK either falls back to transparent or rejects with a typed error — wallets choose which behaviour at construction time.
+
+Wallets that want a hard "confidential only" stance set the flag, set the fallback to "reject", and refuse to construct sends to bare pubkeys.
+
+This flag is **policy**, not protocol. The operator does not see it. It only changes which SDK send path the wallet selects.
+
+### 4.3 New SDK methods
+
+| Method | Crate path | Status |
+| --- | --- | --- |
+| `MetaAddress::from_seed` | `dark_confidential::stealth` | shipped |
+| `MetaAddress::from_bech32m` / `to_bech32m` | `dark_confidential::stealth` | shipped |
+| `ViewingKey::from_seed` / `scope_to` | `dark_confidential::viewing` | shipped |
+| `derive_nullifier` | `dark_confidential::nullifier` | shipped |
+| `PedersenCommitment::commit` | `dark_confidential::commitment` | shipped |
+| `RangeProof::prove` / `prove_aggregated` | `dark_confidential::range_proof` | shipped |
+| `prove_balance` / `verify_balance` | `dark_confidential::balance_proof` | shipped |
+| `prove_selective_reveal` / `verify_selective_reveal` | `dark_confidential::disclosure::selective_reveal` | shipped (#565) |
+| `prove_bounded_range` / `verify_bounded_range` | `dark_confidential::disclosure::bounded_range` | shipped (#566) |
+| `prove_source_of_funds` / `verify_source_of_funds` | `dark_confidential::disclosure::source_of_funds` | shipped (#567) |
+| `StealthScanner::start` / `restore_from_seed` | `dark_client::stealth_scan` / `dark_client::restore` | shipped (#558, #560) |
+| `unilateral_exit_confidential` | `dark_client::confidential_exit` | shipped (#548) |
+| `create_confidential_tx` / `send_confidential` | `dark_client` | pending #572 (CV-M7) |
+
+The `create_confidential_tx` builder in #572 is the integration point most wallets will reach for. Until it lands on `main`, integrators can compose the primitive APIs directly — see §2 of the [SDK guide](../sdk/confidential-transactions.md). The signatures of the primitives are stable; #572 only adds a builder around them.
+
+### 4.4 New CLI subcommands
+
+`ark-cli` (`crates/ark-cli/`) gains:
+
+| Subcommand | Purpose |
+| --- | --- |
+| `stealth address` | print wallet's meta-address (TODO #553 follow-up: needs key management wiring) |
+| `stealth encode <scan_pk> <spend_pk> [--network ...]` | encode a meta-address from explicit pubkeys |
+| `stealth decode darks1...` | decode a meta-address, print scan/spend hex |
+| `disclose` (with `--selective-reveal`, `--lower N --upper M`, or `--source-of-funds <root>`) | assemble a compliance bundle |
+| `verify --in bundle.json` | verify every proof in a bundle, exit non-zero if any fails |
+
+Existing transparent subcommands (`info`, `round`, `vtxo`, `board`, `send`, `receive`, `list-vtxos`, `exit`) are unchanged.
+
+### 4.5 New error variants
+
+`ConfidentialError` (in `dark-confidential`) is a separate error type from `ClientError` so callers can match on confidential-specific failures without flattening them into the existing transparent error space:
+
+```rust,ignore
+pub enum ConfidentialError {
+    InvalidEncoding(&'static str),
+    InvalidInput(&'static str),
+    Stealth(&'static str),
+    Viewing(&'static str),
+    // ... see crates/dark-confidential/src/errors.rs
+}
+```
+
+`DisclosureError` (`dark_confidential::disclosure::DisclosureError`) is a further-narrowed flavour for selective-disclosure-specific failures (`OpeningMismatch`, `AmountOutOfRange`, `RangeNotCertified`, `TranscriptMismatch`, ...).
+
+`RestoreError` adds `BirthdayBeforeArchivalHorizon` for the case where the operator's archival horizon has advanced past the requested birthday.
+
+---
+
+## 5. Backwards-compatibility guarantees
+
+These are the contracts the protocol commits to. Each is the controlling text for its scope; if you find a conflict between code and this section, file an issue.
+
+### 5.1 Transparent VTXOs are spendable forever
+
+There is no flag day. There is no expiry. A transparent VTXO created today can be spent or settled into a round 10 years from now. The round tree continues to dispatch on variant; `LeafV1` continues to use the byte-identical Go `arkd` preimage; the operator continues to honour transparent forfeit signatures. The acceptance criterion at #541 ("vendored Go `arkd` E2E suite passes unchanged on a transparent-only round") is enforced in CI and will not be relaxed.
+
+### 5.2 No required rotation, no migration round
+
+A wallet that holds only transparent VTXOs never has to "migrate". It can consolidate, send, and exit them without ever publishing a meta-address or running a stealth scanner.
+
+A wallet that wants to start using confidential VTXOs does so by publishing a meta-address and starting a scanner — without changing any of its existing transparent VTXOs.
+
+### 5.3 Mixed rounds (#541)
+
+Round batching accepts transparent and confidential transactions in a single batch. The operator's batching logic does not segregate by variant — segregating would leak which users are "using the private feature". Per-round counts are emitted as `round_confidential_tx_count` / `round_transparent_tx_count` metrics without leaking owner info.
+
+### 5.4 Mainnet / testnet / regtest separation
+
+Stealth meta-addresses carry their network in the bech32m HRP (`darks` / `tdarks` / `rdarks`). Cross-network decode is rejected at parse time. A mainnet meta-address cannot be silently consumed on testnet, and vice versa. See `crates/dark-confidential/src/stealth/network.rs`.
+
+Existing transparent network handling (taproot HRP, bitcoin `Network` discriminator) is unchanged.
+
+### 5.5 Versioning
+
+Two versioning surfaces matter for migration:
+
+- **Meta-address payload:** version byte sits inside the bech32m payload. Decoder rejects unknown versions explicitly. Adding `v2` reuses the same HRP. (`META_ADDRESS_VERSION_V1 = 0x01`.)
+- **Nullifier construction:** version byte sits inside the HMAC input, not on the wire output. Migrating to a new primitive mints a new version byte but does not widen stored nullifier columns. (`NULLIFIER_VERSION_V1 = 0x01`.)
+
+Memo encryption and selective-disclosure transcripts each carry their own DST (domain-separation tag) that includes a version. ADR-0003 and ADR-M6-DD-disclosure-types are the controlling texts.
+
+### 5.6 Wallet seed phrases do not change
+
+A BIP-39 mnemonic that backs a transparent-only wallet today is the same mnemonic that backs the confidential-aware wallet after upgrade. The transparent path keys are unchanged. The stealth keys derive from the same seed under disjoint BIP-32 regions. No re-mnemonic, no re-seed.
+
+---
+
+## 6. Step-by-step migration recipe
+
+A typical wallet upgrade looks like this. Each step is independently shippable.
+
+1. **Add the dependency.** Pull `dark-confidential` into the wallet's crate graph alongside `dark-client`.
+2. **Derive stealth keys at wallet open.** On every wallet load, derive `(MetaAddress, StealthSecrets)` and a `ViewingKey` from the existing seed. Persist nothing new yet.
+3. **Add a new wallet-store namespace.** Introduce `confidential_vtxos` alongside `transparent_vtxos`. Do not touch `transparent_vtxos`. Encrypt-at-rest under the same passphrase-derived AES-256-GCM key (#574).
+4. **Run the stealth scanner.** Spawn `StealthScanner` against the operator. Wallets without an always-online scanner can run it on wallet open and on user-initiated refresh; this is fine for low-frequency wallets, but high-volume wallets should keep it persistent.
+5. **Add a confidential-receive UI.** Display the bech32m meta-address as a QR code alongside the existing transparent address. Allow the user to share either or both.
+6. **Add a confidential-send code path.** Compose the primitive APIs (or wait for #572 and call `create_confidential_tx`). Default the `default_confidential` flag to `false` until you have run the round-trip on regtest.
+7. **Integrate the unilateral-exit confidential flow.** `unilateral_exit_confidential` covers the new witness format. The existing transparent unilateral-exit code path remains for `LeafV1` VTXOs.
+8. **(Optional) Wire selective disclosure.** If your users will need compliance disclosure (institutional / exchange flows), surface `disclose` and `verify` from `ark-cli` or call the disclosure APIs directly.
+9. **Run regtest E2E.** A round with mixed transparent + confidential VTXOs must settle. Verify against the operator's mixed-round acceptance test (#541).
+10. **Flip `default_confidential = true`** for users who opt in. Ship.
+
+---
+
+## 7. FAQ
+
+**Q: Do my users need to rotate their keys?**
+
+No. The same BIP-39 seed produces the same transparent keys it did before, plus a disjoint set of stealth and viewing keys. Old VTXOs remain spendable under the old keys.
+
+**Q: Can a transparent wallet pay a confidential meta-address?**
+
+Yes — the *sender* uses the same `dark-confidential` primitives whether or not the sender's own funds are confidential. A wallet that holds only transparent VTXOs can spend them as confidential outputs. The reverse also holds: a wallet that holds confidential VTXOs can spend them to a transparent recipient (the spend authorises the input nullifier; the output side is where confidentiality lives).
+
+**Q: What happens if the operator does not support confidential rounds?**
+
+Confidential sends fail with a typed error. Transparent sends continue to work. The wallet should detect operator capability via `GetInfo` and gate the confidential UI accordingly.
+
+**Q: What if the user loses their passphrase?**
+
+Same as today: the seed phrase recovers the wallet. Re-running `restore_from_seed` (now with stealth re-scan) recovers all VTXOs, transparent and confidential. The wallet store on disk is opaque without the passphrase, but the seed is the source of truth.
+
+**Q: Can I keep using `SingleKeyWallet` for everything?**
+
+`SingleKeyWallet` covers the transparent path. For confidential, you also need `MetaAddress` + `StealthSecrets` + `ViewingKey`. They sit alongside `SingleKeyWallet`, not replacing it.
+
+**Q: Are there any consensus changes?**
+
+No. Confidential VTXOs ride on existing Bitcoin script. ADR-0005 covers the confidential exit script (a tapscript leaf, not a soft fork). The on-chain anchor transaction is unchanged.
+
+---
+
+## 8. ADR cross-reference
+
+| ADR | Why it matters for migration |
+| --- | --- |
+| [ADR-0001](../adr/0001-secp256k1-zkp-integration.md) | New crate dependency (`secp256k1-zkp = 0.11`). Pulled in by `dark-confidential`. |
+| [ADR-0002](../adr/0002-nullifier-derivation.md) | Nullifier wire format. Wallet must encode `vtxo_id` as 36 bytes (`txid || vout BE`). |
+| [ADR-0003](../adr/0003-confidential-memo-format.md) | Memo encryption scheme. Wallet decrypts via the recipient's scan key. |
+| [ADR-0004](../adr/0004-confidential-fee-handling.md) | Fee programs and how fees feed into the balance proof. Read before changing fee policy. |
+| [ADR-0005](../adr/0005-confidential-exit-script.md) | Unilateral-exit witness format. Required for `unilateral_exit_confidential`. |
+| [ADR-M5-DD-stealth-derivation](../adr/m5-dd-stealth-derivation.md) | BIP-32 paths for scan / spend / view keys. Required to derive new keys correctly. |
+| [ADR-M5-DD-announcement-pruning](../adr/m5-dd-announcement-pruning.md) | Operator's archival horizon. Determines max viable `birthday_height`. |
+| [ADR-M6-DD-disclosure-types](../adr/m6-dd-disclosure-types.md) | Disclosure surface for compliance flows. |
+| [ADR-M6-DD-compliance-bundle-format](../adr/m6-dd-compliance-bundle-format.md) | Wire format of `disclose` / `verify` bundles. |
+| [ADR-M6-DD-viewing-key-scope](../adr/m6-dd-viewing-key-scope.md) | Viewing-key scoping. Required for time-bounded audit relationships. |
+
+---
+
+## 9. Where to file follow-ups
+
+If your integration runs into a sharp edge that the protocol could smooth, file an issue against `lobbyclawy/dark` with the `client` + `confidential-vtxos` + `migration-feedback` labels. The migration acceptance criterion at #577 includes "at least one external integrator spot-reviews the migration guide" — feedback shapes the next revision.

--- a/docs/sdk/confidential-transactions.md
+++ b/docs/sdk/confidential-transactions.md
@@ -1,0 +1,385 @@
+# Confidential Transactions: SDK Integrator Guide
+
+- **Audience:** wallet authors, custodial integrators, exchange engineers, and anyone building on top of `dark-client` who needs to send or receive Confidential VTXOs.
+- **Scope:** end-to-end walkthrough of building a confidential payment with the Rust SDK, from wallet creation to broadcast. Includes how range proofs, balance proofs, and nullifiers compose, and which fields are encrypted on disk.
+- **Status:** living document; tracks main. Functions called out as "shipping in #572" are part of the `create_confidential_tx` work item that lands at the same milestone (CV-M7) as this guide.
+- **Companion documents:**
+  - [Migration: Transparent → Confidential](../migration/transparent-to-confidential.md)
+  - [Confidential Threat Model](../security/confidential-threat-model.md)
+
+---
+
+## 1. Mental model
+
+A confidential VTXO replaces three pieces of public data on a transparent VTXO with cryptographic stand-ins:
+
+| Public on a transparent VTXO | Hidden on a confidential VTXO | How it is hidden |
+| --- | --- | --- |
+| Amount in satoshis | Pedersen commitment `C = amount·G + blinding·H` | `PedersenCommitment::commit`, see ADR-0001 |
+| Owner pubkey | Stealth one-time output key derived per-payment | `MetaAddress` + sender ECDH, see ADR-M5-DD |
+| Spend linkage by outpoint | Nullifier (one-way, owner-derived) | `derive_nullifier`, see ADR-0002 |
+
+Three additional pieces of data ride on every confidential output so that the operator can verify the round without seeing amounts:
+
+- **Range proof.** Each confidential output proves its committed amount lies in `[0, 2^63 − 1]`. Without this, a malicious sender could commit to a field-wrapped negative amount and inflate supply. See ADR-0001.
+- **Balance proof.** The whole transaction proves `Σ C_in − Σ C_out − fee·G = excess·H` for an excess scalar the sender knows. The operator checks balance homomorphically without ever learning amounts.
+- **Encrypted memo.** The recipient needs the cleartext `(amount, blinding)` to spend the VTXO later. The sender ECDH's against the recipient's scan key, derives an AEAD key, and packs the opening into a 72-byte plaintext that only the recipient can decrypt. See ADR-0003.
+
+Everything else — round-tree placement, exit script, gRPC envelope — works exactly the same as for transparent VTXOs. Mixed transparent/confidential rounds are a first-class case (see #541 and the transparent-only Go-`arkd` parity gate at #520, both honoured by the round tree at #540).
+
+---
+
+## 2. Hello world: send a confidential payment
+
+The end-to-end flow has six steps. Steps 1–2 are wallet bring-up; 3–4 are address exchange; 5–6 are the actual send.
+
+```rust,no_run
+use bitcoin::Network;
+use dark_client::sdk::ArkSdk;
+use dark_client::wallet::SingleKeyWallet;
+use dark_confidential::stealth::{MetaAddress, StealthNetwork};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // (1) Bring up an SDK instance against a regtest operator.
+    let mut sdk = ArkSdk::generate(
+        "http://localhost:50051",      // gRPC operator
+        "http://localhost:3000",       // Esplora-compatible explorer
+        Network::Regtest,
+    );
+    sdk.init().await?;
+
+    // (2) Derive the stealth meta-address. In practice this comes
+    //     from the same BIP-39 mnemonic that fed the SingleKeyWallet.
+    let seed: [u8; 32] = /* from BIP-39 seed */ [0u8; 32];
+    let (meta, secrets) = MetaAddress::from_seed(
+        &seed,
+        /*account_index=*/0,
+        StealthNetwork::Regtest,
+    )?;
+
+    // (3) Print the meta-address so the recipient can paste it in.
+    //     Format: bech32m, e.g. "rdarks1...". See ADR-M5-DD.
+    println!("my meta-address: {}", meta.to_bech32m());
+
+    // (4) Receive a meta-address from the counterparty.
+    let recipient = MetaAddress::from_bech32m(
+        "rdarks1qfgr...your-counterparty...",
+    )?;
+
+    // (5) Build & submit a confidential payment. (Function name
+    //     pending #572 — see "Send path: APIs that ship in #572".)
+    let amount_sats: u64 = 50_000;
+    let fee_sats:    u64 =    250;
+
+    // sdk.send_confidential(&recipient, amount_sats, fee_sats).await?;
+
+    // (6) Display balance.
+    let balance = sdk.balance().await?;
+    println!("offchain balance: {} sats", balance.offchain.total);
+
+    Ok(())
+}
+```
+
+The `SingleKeyWallet` already shipping in `dark-client` (`crates/dark-client/src/wallet.rs`) is the transparent half: it generates the secp256k1 keypair used for taproot key-path signing and BIP-322 ownership proofs. The stealth half (scan key + spend key + viewing key) comes from `dark-confidential` and lives next to the transparent key under disjoint BIP-32 derivation paths, per ADR-M5-DD.
+
+### What `MetaAddress::from_seed` produces
+
+`MetaAddress::from_seed(seed, account_index, network)` returns a tuple `(MetaAddress, StealthSecrets)` where:
+
+- `MetaAddress` is the **publishable** half: two compressed secp256k1 public keys plus a network discriminator, encoded as bech32m with HRP `darks` / `tdarks` / `rdarks`. The bech32m payload is `[ version: u8 ][ scan_pk: 33 ][ spend_pk: 33 ]` (ADR-M5-DD).
+- `StealthSecrets { scan_key, spend_key }` is the **secret** half. `ScanKey` and `SpendKey` are `Zeroize`-on-drop wrappers and intentionally do **not** implement `Copy`, `Clone`, or `Debug` — see `crates/dark-confidential/src/stealth/keys.rs`. The only way to get the bytes out is `expose_secret()`, which is the audit anchor (`grep expose_secret` finds every disclosure site).
+
+> The scan key is read-only. Anyone holding it can detect every incoming VTXO addressed to the meta-address but cannot spend. The spend key is full spending authority. Treat the spend key with the same care you treat the wallet's main private key today.
+
+### Send path: APIs that ship in #572
+
+The high-level send call is `dark_client::create_confidential_tx`, gated on issue **#572** (Confidential transaction builder in `dark-client`). Its signature is fixed:
+
+```text
+create_confidential_tx(
+    inputs:  &[OwnedVtxo],
+    outputs: &[(MetaAddress, u64)],
+    fee:     u64,
+) -> Result<ConfidentialTransaction>
+```
+
+Internally it executes the steps below. Each step is callable today as a primitive, so integrators with custom batching needs can wire them up directly against `dark-confidential`:
+
+| Step | Primitive | Crate location |
+| --- | --- | --- |
+| Compute nullifiers for inputs | `nullifier::derive_nullifier` | `dark-confidential::nullifier` |
+| Derive output blindings | wallet-deterministic, seed + vtxo index | wallet code |
+| Derive stealth one-time keys | `stealth::sender::derive_one_time_output` | `dark-confidential::stealth::sender` |
+| Build Pedersen commitments | `commitment::PedersenCommitment::commit` | `dark-confidential::commitment` |
+| Aggregated range proof | `range_proof::RangeProof::prove_aggregated` | `dark-confidential::range_proof` |
+| Balance proof | `balance_proof::prove_balance` | `dark-confidential::balance_proof` |
+| Encrypt memo per output | `crate::confidential_memo::encrypt` | per ADR-0003 |
+
+Until #572 lands on `main`, integrators can compose the primitives directly. The pseudocode below walks through it; every function name is real.
+
+```rust,ignore
+use dark_confidential::commitment::PedersenCommitment;
+use dark_confidential::nullifier::{derive_nullifier, VtxoId};
+use dark_confidential::stealth::{MetaAddress, sender::derive_one_time_output};
+
+// Per input: derive nullifier from the spend secret + VTXO id (ADR-0002).
+for input in &inputs {
+    let nullifier = derive_nullifier(&input.spend_secret, &VtxoId::from(input.outpoint));
+    // attach to the spend descriptor
+}
+
+// Per output: derive a one-time output key, then commit to the amount.
+for (recipient_meta, amount) in &outputs {
+    let stealth_out = derive_one_time_output(recipient_meta, &fresh_ephemeral_sk);
+    let commitment  = PedersenCommitment::commit(*amount, &fresh_blinding)?;
+    // attach (stealth_out.one_time_pk, commitment, range_proof, encrypted_memo)
+}
+```
+
+The transaction-level balance proof and aggregated range proof are produced once across all outputs (see §3 below). The full result is a `ConfidentialTransaction` that the SDK submits via the existing batch-round protocol — the operator's gRPC surface is the same one transparent VTXOs already use.
+
+---
+
+## 3. How range, balance, and nullifier proofs compose
+
+Three proof types travel with every confidential transaction. They are independent primitives but they bind to the same transaction transcript so that no proof can be lifted out and replayed.
+
+### 3.1 Range proof per output (ADR-0001)
+
+Each Pedersen-committed amount must be provably in `[0, MAX_PROVABLE_AMOUNT]` where `MAX_PROVABLE_AMOUNT = 2^63 − 1` (Bitcoin's total supply ≈ 2^51, four orders of magnitude under the cap). Without a range proof, a malicious sender could commit to a wrap-around "negative" and balance it against a legitimate output, inflating supply.
+
+The construction delegates to the audited Back-Maxwell rangeproofs in `secp256k1-zkp = 0.11`. ADR-0001 fixes the dependency and re-scopes the original Bulletproofs ask to "production-grade bounded-value range proofs on secp256k1" — Bulletproofs migration is tracked as follow-up `FU-BP`. The wire layout is opaque on purpose so `FU-BP` can land as an internal change.
+
+API entry points (`crates/dark-confidential/src/range_proof.rs`):
+
+- `RangeProof::prove(commitment, amount, blinding)` — single output.
+- `RangeProof::prove_aggregated(commitments, amounts, blindings)` — N outputs in one framed blob. Saves `N - 3` bytes of framing vs. N singles; full log-size aggregation is gated on `FU-BP`.
+- `verify_range(proof, commitment) -> bool`.
+- `verify_range_aggregated(proof, commitments) -> bool`.
+
+The verifier never reads amounts or blindings. Secret-data side-channels are confined to the prover.
+
+### 3.2 Balance proof per transaction (#526)
+
+Given inputs and outputs:
+
+```text
+Σ C_in − Σ C_out − commit(fee, 0) = commit(0, r_excess)
+```
+
+The amount legs cancel only when `Σ v_in − Σ v_out − fee = 0`, leaving `E = r_excess·H` of which the sender knows the discrete log. The balance proof is a textbook Schnorr signature over `H` (not `G`, so BIP-340 cannot be reused) attesting to that knowledge, plus a transcript binding the transaction so the signature is not portable to a different spend.
+
+```text
+prove:  k = H1(nonce_tag, r_excess, tx_hash)
+        R = k·H
+        e = H2(challenge_tag, R, E, tx_hash)  (mod n)
+        s = k + e·r_excess                     (mod n)
+verify: s·H == R + e·E
+```
+
+`H1` and `H2` are BIP-340-style tagged SHA-256 with distinct tags so the nonce derivation cannot collide with the challenge hash. Proof bytes are 65 (a 33-byte compressed `R` followed by a 32-byte canonical scalar `s`). See `crates/dark-confidential/src/balance_proof.rs`.
+
+The balance proof binds the **whole** commitment set plus the fee plus the tx hash. Any post-hoc tamper of inputs, outputs, or fee flips the challenge `e` and the signature fails.
+
+### 3.3 Nullifier per input (ADR-0002)
+
+Each spent VTXO emits a nullifier that the operator stores in a global set. A second spend with the same nullifier is rejected — that is the double-spend prevention layer for confidential VTXOs.
+
+```text
+nullifier = HMAC-SHA256(
+    key = secret_key_bytes,
+    msg = "dark-confidential/nullifier" || 0x00 || version || vtxo_id_bytes,
+)
+```
+
+`vtxo_id_bytes` is the canonical 36-byte encoding `32-byte txid || 4-byte big-endian vout`. Use `VtxoId::from(outpoint)` to produce it — never invent ad-hoc encodings. A different encoding silently changes which nullifier maps to which VTXO.
+
+`version = 0x01` is hard-baked into the HMAC input, not the wire output. A future primitive change mints a new version byte but does not widen stored nullifier columns.
+
+Nullifiers are deterministic given `(spend_secret, vtxo_id)`. If the spend secret never leaves the wallet, only the wallet can produce the nullifier — the operator cannot pre-compute it nor link two unspent VTXOs as belonging to the same wallet. (Once the VTXO is **spent**, the nullifier is published and is linkable forever; this is the "graph" in the threat model.)
+
+### 3.4 How the three compose
+
+The three proofs are independent but bind to the same `tx_hash`:
+
+```text
+                          ┌────────────────────────────────────┐
+inputs  ─ nullifiers ─┐   │  tx_hash =                         │
+                      ├──▶│    H(version || nullifiers ||      │
+outputs ┐             │   │      output_commitments ||         │
+        ├ commitments ┘   │      output_pubkeys || fee || ...) │
+        ├ stealth pks ─── │                                    │
+        └ memos       ─── └────────────────────────────────────┘
+                                            │
+              ┌─────────────────────────────┼─────────────────┐
+              ▼                             ▼                 ▼
+       Range proof per           Balance proof for      Operator-side
+       output (binds            the whole tx (binds     nullifier set
+       commitments)             tx_hash)                membership check
+```
+
+A doctored output amount flips its commitment, which flips the balance-proof challenge, which makes verification fail. A reused nullifier is rejected by the global set check before any cryptography runs. A swapped memo fails AEAD authentication on the recipient side. There is no failure mode where one proof "passes" and another "covers" for it.
+
+---
+
+## 4. Receive path: scan, decrypt, store
+
+A confidential VTXO destined for your meta-address shows up in the operator's announcement stream as a `(round_id, vtxo_id, ephemeral_pubkey, encrypted_memo, ...)` record. To pick out yours and recover the cleartext `(amount, blinding)`:
+
+1. **Subscribe** to `GetRoundAnnouncements` via `ArkClient::get_round_announcements` (wrapped behind the `AnnouncementSource` trait at `crates/dark-client/src/stealth_scan.rs`). The background `StealthScanner` already does this; for custom flows, drive the trait directly.
+2. **Scan** each announcement against your `(scan_key, spend_pk)`. The current placeholder `scan_announcement` in `crates/dark-confidential/src/stealth/scan.rs` returns a match if and only if the announcement's `ephemeral_pubkey` would re-derive your one-time output pubkey under your scan secret — see #555 for the full ECDH scan.
+3. **Decrypt** the memo. The sender's per-output ephemeral keypair is the input to ECDH, then HKDF-SHA256 to a 32-byte ChaCha20-Poly1305 key + 12-byte nonce, then AEAD-decrypt the 72-byte plaintext bound to `(version || ephemeral_pk || one_time_pk)` as associated data. See ADR-0003.
+4. **Persist** the opening locally. The wallet stores `(vtxo_id, amount, blinding, one_time_sk)` per owned confidential VTXO. Encryption-at-rest is mandatory; see §5 below.
+
+The `StealthScanner` exposes this loop with checkpointing (`CHECKPOINT_METADATA_KEY = "stealth_scan:checkpoint"`), backoff on transport errors, and pause/resume via `tokio_util::sync::CancellationToken`. Wallet restore from seed (`crates/dark-client/src/restore.rs`, issue #560) replays the same loop from genesis or from a `birthday_height` to recover all historical VTXOs without operator help.
+
+---
+
+## 5. What is encrypted at rest (#574)
+
+The wallet stores plaintext openings for every confidential VTXO it owns. Persistence is encrypted at rest using the wallet's existing AES-256-GCM scheme with a key derived from the user's passphrase. Per #574, the on-disk record per owned confidential VTXO holds:
+
+| Field | Sensitivity | Why it must be encrypted |
+| --- | --- | --- |
+| `vtxo_id` (txid + vout) | Public on-chain | Encrypted alongside the rest so that, even read together, no row leaks ownership |
+| `amount` (u64 sats) | **Secret** | The whole point of confidentiality |
+| `blinding` (32-byte scalar) | **Secret** | Disclosure of `blinding` opens `commitment` retroactively |
+| `one_time_sk` (per-VTXO spend secret) | **Critical secret** | Disclosure is loss of funds |
+
+Writes are atomic — no torn state on crash mid-write. A passphrase rotation re-encrypts the rows under a new KDF-derived key without re-running the round protocol. Migration from a wallet that previously held only transparent VTXOs preserves all transparent state and adds a `confidential_vtxos` namespace alongside it.
+
+The acceptance test "encrypted at rest verified: on-disk bytes show no amounts" (#574) means: a hex dump of the wallet's confidential-store file must not contain the plaintext amount of any owned VTXO. This is verified by inserting a marker amount and grepping the file.
+
+The viewing-key family (ADR-M6-DD) deliberately does **not** sit in the wallet store. A scoped viewing key is derived on demand from the master viewing key in memory, handed to the auditor, and dropped — the auditor's copy is what persists, on whatever medium the audit relationship requires.
+
+---
+
+## 6. Selective disclosure: opening one VTXO without opening the wallet
+
+Three disclosure shapes ship in CV-M6 (ADR-M6-DD). All three are signed assertions about a single VTXO that a holder can ship to an auditor without giving up any other privacy.
+
+### 6.1 Selective reveal (#565)
+
+Open `(amount, blinding)` for one VTXO. Any third party can verify `commit(amount, blinding) == stored_commitment`. The proof is signed by the holder so recipients can attribute it.
+
+```rust,ignore
+use dark_confidential::{prove_selective_reveal, verify_selective_reveal,
+                         DisclosedFields, SelectiveReveal};
+
+let proof: SelectiveReveal = prove_selective_reveal(
+    &vtxo,
+    &opening,
+    DisclosedFields::default()
+        .with_exit_delay(144)
+        .with_memo(b"audit-tag-Q3-2026".to_vec()),
+    &spend_secret,
+)?;
+
+assert!(verify_selective_reveal(&proof, &commitment).is_ok());
+```
+
+Revealing one VTXO does **not** reveal related VTXOs or the graph. The proof binds to the VTXO's outpoint and owner pubkey via a tagged-hash transcript (DST `SELECTIVE_REVEAL_DST`). Wrong blinding fails verification cleanly.
+
+### 6.2 Bounded-range proof (#566)
+
+Prove the cleartext amount lies in `[lower, upper]` without revealing the exact value. Useful for "the amount was below threshold X" attestations under MiCA / Travel Rule.
+
+```rust,ignore
+use dark_confidential::disclosure::bounded_range::{prove_bounded_range,
+                                                    verify_bounded_range};
+
+let proof = prove_bounded_range(&value_commitment, amount, &blinding,
+                                lower, upper)?;
+assert!(verify_bounded_range(&proof, &value_commitment, lower, upper));
+```
+
+Note the convention split: bounded-range disclosure rides on `range_proof::ValueCommitment` (`amount·H + blinding·G`, ADR-0001), **not** on `commitment::PedersenCommitment` (`amount·G + blinding·H`). The two are not byte-compatible. Selective reveal binds to the standard commitment; bounded-range binds to `ValueCommitment`. See `crates/dark-confidential/src/disclosure/mod.rs` for the rationale.
+
+### 6.3 Source-of-funds proof (#567)
+
+Prove "this VTXO traces back N hops to a stated source set" without revealing intermediate hop amounts or recipients.
+
+```rust,ignore
+use dark_confidential::{prove_source_of_funds, verify_source_of_funds,
+                         SourceLink, VtxoOutpoint};
+
+let proof = prove_source_of_funds(
+    &subject_vtxo,
+    &opening_chain,    // [(VtxoOutpoint, PedersenOpening); >= 2]
+    &allowed_roots,    // &[SourceLink]
+    &signer_secrets,   // one per hop
+)?;
+
+verify_source_of_funds(&proof, &subject_vtxo, &allowed_roots)?;
+```
+
+The chain anchors at one of `allowed_roots` and terminates at the subject VTXO's outpoint. Each hop carries a Schnorr signature from its owner. Amounts at each hop are **not** revealed — only the graph shape and that each opening reconstructs a known commitment. See ADR-M6-DD §"Disclosure types" and `crates/dark-confidential/src/disclosure/source_of_funds.rs`.
+
+### 6.4 Viewing key issuance (ADR-M6-DD)
+
+Viewing keys grant ongoing post-hoc decryption authority for a bounded round window. The naive "hand over master `scan_sk`" approach is rejected by the ADR because it exposes the full meta-address history forever. Instead:
+
+```text
+   tweak    = HMAC-SHA512(master_secret_bytes,
+                          SCOPE_DST || start_be8 || end_be8)[..32]
+   k_scoped = (k_master + tweak) mod n
+```
+
+The scoped key decrypts only memos whose round id falls in `[start, end]`. The membership check in `RoundWindow::contains_ct` is constant-time over the bounds. See `crates/dark-confidential/src/viewing/`. ADR-M6-DD has the full threat model and the rationale for why scope lives in derivation, not in software policy.
+
+---
+
+## 7. CLI: `ark-cli` shortcuts
+
+For day-to-day testing, `ark-cli` (in `crates/ark-cli/`) wraps the SDK with subcommands that exist today:
+
+```bash
+ark-cli stealth address                  # print wallet meta-address (TODO #553 follow-up)
+ark-cli stealth encode <scan_pk> <spend_pk> --network mainnet
+ark-cli stealth decode darks1...
+ark-cli disclose --selective-reveal --vtxo <id> --out bundle.json
+ark-cli verify --in bundle.json
+```
+
+`disclose` packs one or more disclosure types (selective reveal, bounded range, source-of-funds) into a compliance bundle. `verify` reads a bundle and exits non-zero if any contained proof fails to verify. See `crates/ark-cli/src/disclose.rs` and `crates/ark-cli/src/stealth.rs` for the option surface.
+
+---
+
+## 8. Operational checklist for integrators
+
+Before shipping a wallet that supports confidential VTXOs:
+
+- [ ] Verify the operator advertises mixed-round support (#541) — if not, confidential sends will not settle in the same round as transparent sends.
+- [ ] Test wallet restore from seed against a regtest operator with > 1 round of historical VTXOs (#560).
+- [ ] Confirm `birthday_height` propagation: a wallet that supplies a birthday must not silently re-scan from genesis.
+- [ ] Verify encryption-at-rest with a marker-amount test: write a known plaintext amount to the store, hex-dump the on-disk file, assert the marker is absent (#574).
+- [ ] Exercise the unilateral-exit confidential flow on a live regtest (`crate::confidential_exit::unilateral_exit_confidential`). The CLI surfaces progress as `LeafExitSigned → LeafExitBroadcast → CSV maturing → claimable`.
+- [ ] If you support compliance disclosure, run the full `ark-cli disclose | ark-cli verify` round-trip and pin a fixture bundle in your tests.
+
+---
+
+## 9. ADR cross-reference
+
+| ADR | What it pins | When you read it |
+| --- | --- | --- |
+| [ADR-0001](../adr/0001-secp256k1-zkp-integration.md) | `secp256k1-zkp` dependency, range-proof primitive, commitment convention, FU-BP roadmap | Working with range proofs or commitments |
+| [ADR-0002](../adr/0002-nullifier-derivation.md) | Nullifier scheme, version byte, `vtxo_id` 36-byte encoding | Spending a VTXO; auditing double-spend defence |
+| [ADR-0003](../adr/0003-confidential-memo-format.md) | Memo wire format, ECDH+HKDF+ChaCha20-Poly1305, 72-byte plaintext | Encrypting or decrypting memos |
+| [ADR-0004](../adr/0004-confidential-fee-handling.md) | How fees compose with the balance proof | Fee programs, light-mode fee paths |
+| [ADR-0005](../adr/0005-confidential-exit-script.md) | Confidential exit tapscript, witness layout `(amount, blinding, sig)` | Unilateral-exit flows |
+| [ADR-M5-DD-stealth-derivation](../adr/m5-dd-stealth-derivation.md) | BIP-32 paths for scan / spend / view keys, multi-device flow | Wallet bring-up, restore, multi-device split |
+| [ADR-M5-DD-announcement-pruning](../adr/m5-dd-announcement-pruning.md) | Operator's archival horizon, pruning policy | Restore from seed older than horizon |
+| [ADR-M6-DD-disclosure-types](../adr/m6-dd-disclosure-types.md) | Disclosure shapes, transcript layout, attribution | Building auditor-facing flows |
+| [ADR-M6-DD-compliance-bundle-format](../adr/m6-dd-compliance-bundle-format.md) | Wire format of the `disclose` / `verify` bundle | Persisting / shipping disclosure proofs |
+| [ADR-M6-DD-viewing-key-scope](../adr/m6-dd-viewing-key-scope.md) | Viewing-key scoping by round window, scope tweak | Issuing a viewing key to an auditor |
+
+---
+
+## 10. Where to ask questions
+
+- Bug reports: GitHub issues against `lobbyclawy/dark`. Tag `client` + `confidential-vtxos`.
+- API surface questions: rustdoc at the canonical paths (`crates/dark-client/src/lib.rs`, `crates/dark-confidential/src/lib.rs`).
+- Threat-model questions: see the [Confidential Threat Model](../security/confidential-threat-model.md).
+- Migration from a transparent-only wallet: see the [migration guide](../migration/transparent-to-confidential.md).

--- a/docs/security/confidential-threat-model.md
+++ b/docs/security/confidential-threat-model.md
@@ -1,0 +1,377 @@
+# Confidential VTXO Threat Model
+
+- **Audience:** wallet authors, operators, security reviewers, and crypto-sign-off owners deciding whether the confidential design is fit for their deployment.
+- **Scope:** what is hidden, from whom, under which assumptions; what is **not** hidden; consequences of compromise of each secret; adversary models for passive operator, malicious operator, compromised wallet, and compromised memo encryption key.
+- **Status:** living document; ADRs cited are the controlling texts when this document is silent or ambiguous.
+- **Companion documents:**
+  - [Confidential Transactions: SDK Integrator Guide](../sdk/confidential-transactions.md)
+  - [Migration: Transparent → Confidential](../migration/transparent-to-confidential.md)
+
+---
+
+## 1. Asset list
+
+The objects we are protecting (or deliberately not protecting):
+
+| Object | Sensitivity | Where it lives |
+| --- | --- | --- |
+| `amount` (per VTXO) | secret | wallet store (encrypted at rest); cleartext only inside the owner's process |
+| `blinding` (per VTXO Pedersen scalar) | secret | wallet store (encrypted at rest); never leaves the owner's machine in cleartext |
+| `one_time_sk` (per VTXO spend secret) | critical secret | wallet store (encrypted at rest); disclosure = loss of funds |
+| `spend_sk` (master spend key) | critical secret | wallet keystore; disclosure = loss of funds |
+| `scan_sk` (master scan key) | secret | scanning host (may be a different host than the spend host) |
+| `view_sk` (master viewing key) | secret | wallet keystore; disclosure = retroactive decryption of all memos |
+| Scoped viewing key (per audit window) | secret-to-auditor | auditor's host for the duration of the audit |
+| `MetaAddress` (bech32m) | public | wherever recipients publish it |
+| `nullifier` (per spent VTXO) | public after spend | global on-chain set |
+| `commitment` (per VTXO) | public | round tree, on-chain anchor |
+| `encrypted_memo` (per VTXO) | opaque ciphertext | round tree |
+| `range_proof`, `balance_proof` | public | round tree |
+| Tx existence and timing | public | operator logs, on-chain timing |
+
+The cleartext quadruple `(vtxo_id, amount, blinding, one_time_sk)` is the wallet's confidential state, persisted under AES-256-GCM (#574).
+
+---
+
+## 2. What is hidden
+
+Confidential VTXOs hide three pieces of data that are public on transparent VTXOs.
+
+### 2.1 Amount
+
+The on-chain commitment is `C = amount·G + blinding·H` (ADR-0001 convention). `H` is a deterministically-derived secp256k1 generator with no known discrete-log relationship to `G`. Recovering `amount` from `C` requires either:
+
+- knowing `blinding` (so the verifier can subtract `blinding·H` and read off `amount·G`); or
+- breaking discrete log on secp256k1.
+
+Range proofs (ADR-0001) prove the committed amount lies in `[0, 2^63 − 1]` without revealing it. The verifier only sees the commitment and the proof — no amount, no blinding.
+
+The aggregated view: an operator that holds the round tree and every commitment cannot read any individual amount. Pedersen commitments are perfectly hiding given a uniformly-random blinding factor; they leak nothing about the underlying value to a computationally-bounded adversary. The blinding-factor reuse caveat is in §6.1 below.
+
+### 2.2 Recipient identity
+
+Every confidential output is locked to a **one-time public key** that the sender derives per-output via ECDH against the recipient's published meta-address. The output pubkey on-chain has no statistical relationship to the meta-address — recovering the meta-address from a one-time pubkey requires the recipient's `scan_sk`.
+
+The recipient runs the scanning loop (#558) to identify their own outputs. An observer without `scan_sk` sees a stream of unrelated one-time pubkeys.
+
+This is the "stealth" half of the privacy guarantee. ADR-M5-DD covers the BIP-32 derivation, the read-only / spending-authority key separation, and the multi-device flow (mobile scanner + cold-storage signer).
+
+### 2.3 Graph linkability beyond what nullifiers reveal
+
+The nullifier set is a one-way function of the spend secret and the VTXO id. Two unspent VTXOs owned by the same wallet have **no** publicly-derivable link — an operator that observes only commitments, one-time pubkeys, and memos cannot tell that two VTXOs belong to the same wallet without scanning them, which it cannot do without `scan_sk`.
+
+Once a VTXO is **spent**, its nullifier is published. The spend graph (which inputs feed which outputs) becomes public. This is deliberate: it is the double-spend defence layer. See §3.3 for the consequences.
+
+---
+
+## 3. What is NOT hidden
+
+Confidentiality is bounded. Several public facts remain visible to the operator and to anyone with on-chain access. Integrators MUST internalise these before claiming any privacy property to end users.
+
+### 3.1 Transaction existence
+
+The operator sees that a confidential transaction occurred: a set of nullifiers was consumed, a set of commitments was created, a fee was paid, range and balance proofs were posted, and memos were forwarded.
+
+There is no "private mempool". An observer with operator-level access knows a confidential transaction happened and at what time.
+
+### 3.2 Transaction timing
+
+The operator timestamps every transaction it batches. Round cadence is public. A user who sends a payment immediately after receiving one creates a timing correlation that the operator can record even though it cannot read either amount.
+
+Tor at the transport layer hides the user's network identity from the operator (and the operator's network identity from the user) but does **not** hide the timing of the events themselves.
+
+### 3.3 Spend graph (after spend)
+
+When a VTXO is spent, its nullifier is published. If the same wallet later spends another VTXO that pays the same recipient, the recipient's incoming nullifiers form a graph that links the two spends as having a common destination — even though the amounts and the recipient's identity stay hidden.
+
+In particular, the graph reveals:
+
+- That two outputs went to the same one-time pubkey if (somehow) two outputs reused a one-time pubkey. The protocol does not reuse one-time pubkeys, so this is hypothetical, but bears stating.
+- That a chain of spends exists: `nullifier_A` was consumed in tx-1, which produced `commitment_X`, which was consumed (after some time) producing `nullifier_X`, etc. The graph shape is public; amounts and recipients along it are not (modulo stealth scanning).
+
+Source-of-funds proofs (#567) deliberately use this linkable-graph property: a holder can prove "this VTXO traces back N hops to a stated source" without revealing intermediate hop amounts. The graph is already public; the proof just signs over a specific path through it.
+
+### 3.4 Fee amounts
+
+Fees are committed in the clear (`commit(fee, 0)` per ADR-0004). They feed into the balance proof identity. Fee amounts are public per transaction.
+
+This is intentional: fee programs (CEL-based) need to evaluate fees at the operator and at validation, both of which are public-data computations. ADR-0004 covers the rationale and the alternatives considered.
+
+### 3.5 Operator-known metadata
+
+The operator knows, per its own logs:
+
+- The IP address that submitted each transaction (mitigated by Tor).
+- The `MetaAddress` that any user published to its operator-side address book, if it operates such a book. (The protocol does not require the operator to know the meta-address — the user is free to share it out-of-band.)
+- The macaroon / auth token associated with each request, where macaroon auth is in use.
+- The session ids of long-lived gRPC streams.
+
+A "passive" operator (§4.1) records this metadata. A "malicious" operator (§4.2) selectively withholds, reorders, or fabricates announcements to manipulate the user's view.
+
+### 3.6 Round-tree leaf type
+
+`LeafV1` (transparent) and `LeafV2` (confidential) carry a distinct domain-separation tag in their leaf-hash preimage (#540). An on-chain observer can tell which leaves are transparent and which are confidential. They cannot tell the *amount* of a confidential leaf, only that it is confidential.
+
+This is unavoidable given the parity gate (the transparent preimage must remain byte-identical to Go `arkd`'s preimage, so the confidential preimage cannot disguise itself as transparent). Per #541's anti-segregation rationale, mixed rounds prevent the operator-level signal "this user is using the private feature", but a chain observer still sees confidential-vs-transparent at the leaf level.
+
+### 3.7 Exit timing and exit script structure
+
+The unilateral-exit confidential flow (ADR-0005) broadcasts a tapscript leaf transaction that an on-chain observer can identify as an Ark exit. The CSV delay and the witness layout are public. The committed amount in the witness (`(amount, blinding, signature)`) becomes public when the exit broadcasts — this is "exit leakage": the confidentiality of a VTXO is partially revoked when it unilaterally exits.
+
+Cooperative exits (`collaborative_exit`) do not have this leakage — the operator coordinates the exit and only the on-chain destination amount is visible, not the prior VTXO amount.
+
+---
+
+## 4. Adversary models
+
+Four canonical adversaries. The model determines what the wallet must defend against and what guarantees the operator can promise.
+
+### 4.1 Passive operator
+
+**Capability:** sees every gRPC request, every round-tree leaf, every nullifier, every commitment, every memo ciphertext. Logs everything. Does not deviate from protocol.
+
+**Defended:**
+- Cannot read VTXO amounts (Pedersen + range proofs).
+- Cannot read VTXO recipients (stealth one-time pubkeys, ECDH-derived).
+- Cannot decrypt memos (AEAD with recipient-only key, ADR-0003).
+- Cannot link two unspent VTXOs of the same wallet (no public ownership signal).
+- Cannot forge nullifiers without the spend secret.
+
+**Not defended:**
+- Sees all transaction existence and timing (§3.1, §3.2).
+- Sees the spend graph after each spend (§3.3).
+- Sees fees in cleartext (§3.4).
+- Sees IP addresses and auth metadata (§3.5).
+- Sees confidential-vs-transparent leaf type (§3.6).
+- Can correlate sessions across time using IP, macaroon, or stream ids.
+
+**Mitigations under user control:**
+- Tor for transport-layer privacy.
+- Macaroon rotation (operator-side feature; ask before relying on it).
+- Multiple meta-addresses per logical identity (the wallet decides the policy; the protocol does not constrain it).
+
+### 4.2 Malicious operator
+
+**Capability:** everything the passive operator can do, plus:
+- Withhold or reorder announcements selectively per user.
+- Refuse specific transactions.
+- Refuse to include specific spends in rounds.
+- Lie about the round-tree state to specific users.
+- Mount denial-of-service against specific users.
+
+**Defended:**
+- Cannot steal funds. Confidential VTXOs are locked to one-time pubkeys that only the holder of the corresponding spend secret can authorise.
+- Cannot inflate supply. The balance proof prevents net positive issuance; range proofs prevent wrap-around negatives.
+- Cannot replay or graft memos onto wrong VTXOs (memo AEAD binds to the one-time pubkey, ADR-0003).
+- Cannot tamper with proofs without invalidating them (every proof binds to the tx hash).
+- Cannot bypass the unilateral-exit path. A user who detects operator misbehaviour can broadcast their round-tree leaf and exit on-chain via ADR-0005.
+
+**Not defended:**
+- Can DoS specific users (refuse their transactions, withhold announcements). Mitigation: detect the failure, switch operator, exit unilaterally if needed.
+- Can selectively reorder transaction inclusion within a round, which can leak information in correlation with timing data.
+- Can lie to one user about what rounds exist; users should cross-check the on-chain anchor against an independent Bitcoin node.
+
+**Mitigations under user control:**
+- Run an independent Bitcoin node to verify on-chain anchors.
+- Use the unilateral-exit flow when the operator misbehaves.
+- Maintain hot/cold wallet split so the always-online scanning host cannot lose funds even if the operator coordinates with an attacker that compromises the scanning host.
+
+### 4.3 Compromised wallet (full-host compromise)
+
+**Capability:** attacker reads the wallet store, including the AES-256-GCM key (because they have host access and the user has unlocked the wallet at some point during the compromise window).
+
+**Outcome:**
+- Loss of funds (attacker has `spend_sk` and per-VTXO `one_time_sk`).
+- Retroactive de-anonymisation (attacker has `scan_sk` and `view_sk`, can decrypt past memos).
+- Future de-anonymisation (attacker has `scan_sk`, can scan the announcement stream and decrypt new memos until the user rotates the meta-address).
+
+**Mitigations:**
+- The `Zeroize` discipline on `ScanKey`, `SpendKey`, `ViewingKey`, `ScopedViewingKey` reduces the window during which secrets sit in process memory unmasked. It does not protect against an attacker who reads memory while the wallet is unlocked.
+- Multi-device key separation (ADR-M5-DD): a compromise of the always-online scanning host (which holds `scan_sk`) does not leak `spend_sk` if the spend host is offline. The attacker can de-anonymise but not steal.
+- Hardware wallet integration for `spend_sk` is a roadmap item; signed-on-device flow keeps `spend_sk` off the host even when the host is compromised.
+
+The compromise of `view_sk` is conceptually similar to compromise of `scan_sk` — the holder can decrypt past memos. ADR-M6-DD discusses why scoped viewing keys (`ScopedViewingKey`) reduce the blast radius vs. master `view_sk`.
+
+### 4.4 Compromised memo encryption key (per-VTXO)
+
+**Capability:** attacker recovers the AEAD key for a specific memo, by some means — side-channel, badly-seeded ephemeral keypair on the sender side, etc.
+
+**Outcome (single memo):**
+- Attacker reads `(amount, blinding, one_time_spend_tag)` for that one VTXO.
+- Attacker can spend that one VTXO if they can also forge the recipient's signature on the leaf script (which requires `spend_sk`, which they do not have from the memo alone).
+- Attacker cannot link this VTXO to other VTXOs of the same recipient — the memo carries only that VTXO's data.
+
+**Outcome (recipient's `scan_sk` compromised):**
+- Attacker can decrypt every past, present, and future memo addressed to the recipient's meta-address.
+- This is the §4.3 retroactive de-anonymisation outcome.
+
+**Outcome (sender's per-output ephemeral private key compromised, post-facto):**
+- Attacker can decrypt that one memo (the sender's ephemeral key + the recipient's `scan_pk` reproduce the ECDH shared secret).
+- Bound to that single output — ephemeral keypairs are fresh per output (ADR-0003).
+
+The memo design pins three forward-secrecy-ish properties:
+- Per-output ephemeral keypair: a leaked ephemeral key opens only one memo.
+- Cross-version safety: a v1 memo cannot be re-tagged as v2 without breaking authenticity (ADR-0003).
+- AEAD binding to the one-time pubkey: an attacker cannot graft a valid memo onto a different output.
+
+---
+
+## 5. Compromised viewing key consequences (ADR-M6-DD scope)
+
+The viewing key family has its own threat model because it grants ongoing read access to the recipient's memo stream. ADR-M6-DD-viewing-key-scope is the controlling text; this section is the integrator-facing summary.
+
+### 5.1 Master `view_sk`
+
+A holder of the master viewing key can decrypt **every** confidential memo addressed to the wallet's meta-address — past, present, and future, until the user rotates the meta-address (which costs them their published identifier and re-key with every counterparty).
+
+This is incompatible with institutional audit relationships where the auditor needs visibility into a bounded period only. ADR-M6-DD rejects "share `scan_sk`" and "share `view_sk` master" as the disclosure mechanism for exactly this reason.
+
+### 5.2 Scoped viewing key (`ScopedViewingKey`)
+
+A scoped viewing key is bound to an inclusive `RoundWindow { start_round, end_round }`. The scope is enforced via a deterministic, scope-bound tweak applied to the master scalar:
+
+```text
+tweak    = HMAC-SHA512(master_secret_bytes,
+                       SCOPE_DST || start_be8 || end_be8)[..32]
+k_scoped = (k_master + tweak) mod n
+```
+
+Because the tweak is keyed by the master secret, knowing a scoped key does not let the holder recover the master — inverting the tweak requires the master itself. A scoped key compromise is bounded to its window:
+
+| Compromise | Past memos in scope | Past memos out of scope | Future memos in scope | Future memos out of scope |
+| --- | --- | --- | --- | --- |
+| Scoped `view_sk` for `[100, 200]` | readable | not readable | readable | not readable |
+| Master `view_sk` | readable | readable | readable | readable |
+
+Decryption attempts are gated by `ScopedViewingKey::may_view`, which is **constant-time over the scope bounds** (`RoundWindow::contains_ct` reduces the ≤-comparison to a sign-bit extraction on a 128-bit subtraction, no `if`/`match` on secret-derived intermediates). The audit anchor is `expose_secret()` — every disclosure site is reachable via `grep expose_secret`.
+
+The viewing-scope ADR (#561, controlling text ADR-M6-DD-viewing-key-scope) is still being decided in detail; the current encoding is `[start_round, end_round]`. A future scope encoding (epoch- or time-based) ships under a new version byte without changing the public API of `dark_confidential::viewing`. The wire encoding lives behind `RoundWindow` so migration is a single-file change.
+
+### 5.3 Issuance hygiene
+
+When issuing a scoped viewing key:
+
+- Derive it just-in-time from `view_sk.scope_to(window)`. Do not persist the scoped key on the issuing wallet — the auditor's copy is the persistent form.
+- Use the narrowest window that satisfies the audit. A 24-hour audit covering a single transaction does not need a 90-day window.
+- Treat the channel to the auditor as adversarial: a TLS-pinned channel, a sealed envelope, a hardware token. Compromise of the channel = compromise of the key for that scope.
+- After the audit ends, the scoped key cannot be revoked (it is just a scalar). The recipient can rotate their master, which invalidates all future scoped keys derived from the old master. They cannot un-disclose past memos.
+
+The companion `m6-dd-disclosure-types` ADR covers the **one-shot** disclosure primitives (selective reveal, bounded range, source of funds). Those do not give ongoing decryption authority and are the preferred disclosure shape when the audit only needs a single-fact attestation.
+
+---
+
+## 6. Cryptographic-discipline failure modes
+
+The following are not adversary models but operational failure modes. They are listed here because misuse breaks the privacy guarantee even against a passive operator.
+
+### 6.1 Blinding-factor reuse
+
+If two distinct VTXOs commit to amounts under the same blinding scalar, the difference of their commitments collapses to `(v1 − v2)·G`. An observer who guesses `v1` can read off `v2 − v1`. Reusing a blinding factor across distinct amounts therefore leaks the delta.
+
+Mitigation: derive each output's blinding factor deterministically from `(seed, vtxo_index)` via a tagged KDF. The wallet implements this; `create_confidential_tx` (#572) wires the determinism in. Hand-rolled clients must follow the same discipline.
+
+`PedersenCommitment` rejects the zero scalar at construction (`scalar must be non-zero and within curve order`). It does not police uniqueness — that is the wallet's job.
+
+### 6.2 Nonce reuse in the range proof
+
+Each range proof draws a fresh nonce from the OS CSPRNG. Reusing a nonce across proofs that commit to the same value leaks the blinding factor; across different values it leaks the delta. The range-proof module documents this at the top of `crates/dark-confidential/src/range_proof.rs`.
+
+Issue #529 pins a deterministic, protocol-scoped KDF that will replace CSPRNG sampling in a future version. Until then, integrators must not stub `OsRng` with a deterministic source.
+
+### 6.3 Nonce reuse in the balance proof
+
+The balance-proof nonce `k` is derived deterministically from `(r_excess, tx_hash)` via a domain-separated tagged hash (`H1`). Re-signing the same `(r_excess, tx_hash)` produces identical bytes — a feature for audit reproducibility. Re-signing the same `r_excess` against a *different* `tx_hash` is safe (messages differ → challenges differ → s values differ → no key leak). The danger is re-using `r_excess = 0`, which collapses `E` to the identity and would let any `s` verify; the prover rejects this at sign time.
+
+### 6.4 Cross-protocol transcript reuse
+
+Every cryptographic transcript carries a domain-separation tag. Examples: `NULLIFIER_DST = "dark-confidential/nullifier"`, `PEDERSEN_H_DST = "dark-confidential/pedersen-h/v1"`, `SELECTIVE_REVEAL_DST`, `SOURCE_OF_FUNDS_DST`, `BOUNDED_RANGE_TRANSCRIPT_DST`, `SCOPE_DST = "dark-confidential viewing scope v1"`. Reusing a tag across protocols can collide hashes; minting a new tag per protocol is mandatory for any future primitive.
+
+### 6.5 Recipient pubkey substitution
+
+Memo AEAD binds to `(version || ephemeral_pubkey || one_time_pubkey)` as associated data. An operator that swaps the on-chain one-time pubkey but leaves the memo intact breaks AEAD authentication on the recipient side. Decryption fails cleanly — no silent corruption.
+
+Recipients who ignore an AEAD failure ("retry with different keys") undermine this. The scanner is required to treat AEAD failure as "not addressed to me" and continue scanning.
+
+### 6.6 Replay across networks
+
+Meta-addresses carry their network in the bech32m HRP. Cross-network decode is rejected at parse time. A mainnet meta-address will not silently decode on testnet, and vice versa. Wallets that paste user-supplied strings into `MetaAddress::from_bech32m` get this defence for free.
+
+The same discipline applies to `StealthNetwork` round trips: every encode reflects the network, every decode validates it.
+
+---
+
+## 7. What Tor adds, and what it does not
+
+Tor at the transport layer hides:
+
+- The user's IP address from the operator.
+- The operator's IP address from the user.
+- The fact that any specific user is talking to any specific operator (for a sufficiently large Tor user base — the standard caveat).
+
+Tor does **not** hide:
+
+- Transaction existence (the operator still sees the gRPC request).
+- Transaction timing (Tor adds latency but not cover traffic).
+- Per-session correlation (long-lived gRPC streams over Tor are still long-lived gRPC streams).
+- Operator-side metadata such as macaroons, session ids, or auth tokens that the user supplies regardless of transport.
+
+Wallets that claim "private payments" must clarify that Tor is a network-layer mitigation that complements protocol-level confidentiality, not a substitute. A Tor-less wallet still gets full Pedersen / stealth / nullifier privacy from the operator, but the operator learns the IP address of every transaction.
+
+---
+
+## 8. Limits of selective disclosure
+
+Selective disclosure (ADR-M6-DD-disclosure-types) is opt-in, signed, and bounded to a specific VTXO. The integrator-facing limits:
+
+- **Selective reveal** (#565) opens `(amount, blinding)` for one VTXO. It does not reveal anything about related VTXOs or the holder's other balances.
+- **Bounded range** (#566) proves the amount lies in `[lower, upper]`. Tighter bounds leak more (the verifier can narrow the bracket); broader bounds leak less. Bound choice is policy.
+- **Source of funds** (#567) reveals the graph shape from a stated source to the subject VTXO. The amounts at each hop are not revealed; the VTXO ids are. An auditor that knows the source set learns the graph shape — that is the point of the proof — but cannot derive amounts or recipient identities at the intermediate hops.
+- **Scoped viewing key** (ADR-M6-DD-viewing-key-scope) gives ongoing decryption authority within its window. It is the heaviest disclosure primitive and the one whose scope semantics are most load-bearing. Prefer one-shot proofs whenever possible.
+
+A user who issues both a scoped viewing key and a source-of-funds proof for the same VTXO has disclosed strictly more than either primitive in isolation. There is no mechanism to "redact" past disclosures.
+
+---
+
+## 9. Crypto sign-off checklist
+
+The acceptance criterion at #577 says "security model reviewed by whoever owns crypto sign-off". The reviewer is asked to confirm:
+
+- [ ] The asset list (§1) is complete.
+- [ ] What-is-hidden (§2) and what-is-not (§3) match the protocol's actual behaviour against `crates/dark-confidential/src/` and the cited ADRs.
+- [ ] Adversary models (§4) are exhaustive for the deployment in question; if the deployment includes a compromised-Bitcoin-node model or compromised-clock model, those are ADR'd separately.
+- [ ] Viewing-key blast-radius (§5) matches ADR-M6-DD-viewing-key-scope.
+- [ ] Operational failure modes (§6) are covered by the wallet's tests.
+- [ ] Tor scope (§7) is reflected in user-facing privacy claims.
+- [ ] Selective-disclosure limits (§8) are reflected in the wallet's disclosure UX.
+
+If any item fails, file an issue against `lobbyclawy/dark` with the `confidential-vtxos` + `security-critical` labels.
+
+---
+
+## 10. ADR cross-reference
+
+| ADR | Threat-model relevance |
+| --- | --- |
+| [ADR-0001](../adr/0001-secp256k1-zkp-integration.md) | Pedersen `H` derivation, range-proof construction, FU-BP roadmap, primitive constraints |
+| [ADR-0002](../adr/0002-nullifier-derivation.md) | Nullifier scheme, version byte, double-spend defence |
+| [ADR-0003](../adr/0003-confidential-memo-format.md) | Memo encryption, AEAD binding, cross-version safety |
+| [ADR-0004](../adr/0004-confidential-fee-handling.md) | Fee-cleartext rationale, balance-proof feed-in |
+| [ADR-0005](../adr/0005-confidential-exit-script.md) | Exit witness, exit leakage, unilateral-exit shape |
+| [ADR-M5-DD-stealth-derivation](../adr/m5-dd-stealth-derivation.md) | Read-only / spending-authority key separation, multi-device flow |
+| [ADR-M5-DD-announcement-pruning](../adr/m5-dd-announcement-pruning.md) | Operator's archival horizon, restore-from-seed limits |
+| [ADR-M6-DD-disclosure-types](../adr/m6-dd-disclosure-types.md) | One-shot disclosure primitives, transcript binding |
+| [ADR-M6-DD-compliance-bundle-format](../adr/m6-dd-compliance-bundle-format.md) | Bundle wire format, attribution |
+| [ADR-M6-DD-viewing-key-scope](../adr/m6-dd-viewing-key-scope.md) | Viewing-key scope, scoped-key blast-radius, constant-time membership |
+
+---
+
+## 11. Open questions
+
+These are tracked but not yet ADR'd. The threat-model implications change when they resolve.
+
+- **Hardware-wallet integration for `spend_sk`.** The blast radius of §4.3 (compromised wallet) shrinks substantially with HW signing, but the integration is not yet specified.
+- **Padding / cover traffic.** No protocol-level cover traffic exists today. A user who wants to defeat timing correlation against a passive operator must run their own padding scheme.
+- **Long-running gRPC stream correlation.** Sessions are correlated by stream id and macaroon. A reconnect / rotate cadence is operator policy; the protocol does not enforce one.
+- **Mempool-level operator-vs-Bitcoin-node split.** A future variant might separate the round-coordinating operator from the on-chain anchoring service. The threat model would gain a fifth adversary; this guide will be updated when that lands.
+
+The list is non-exhaustive. File issues for additional vectors.


### PR DESCRIPTION
Closes #577. Three new docs: docs/sdk/confidential-transactions.md (integrator hello-world + primitive composition + StealthScanner), docs/migration/transparent-to-confidential.md (additivity contract + 10-step recipe), docs/security/confidential-threat-model.md (four adversary models + scoped viewing-key blast radius). All API references verified against actual codebase.