### PR TITLE
🔖 chore(release): prepare v0.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,9 +7,97 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-27
+
+This release ships the **Confidential VTXO** subsystem on top of the v0.1.0 transparent baseline, completes the workspace split into focused crates, and brings the regtest suite to full Go-arkd E2E parity.
+
 ### Added
-- Architecture documentation (`docs/architecture.md`)
-- CHANGELOG.md for tracking releases
+
+#### Confidential VTXO subsystem
+- New `dark-confidential` crate: secp256k1 Pedersen commitments, Back-Maxwell range proofs (via `secp256k1-zkp`), Schnorr balance proofs, deterministic nullifier derivation, stealth addressing, viewing-key issuance with scoped access, and selective-disclosure helpers
+- `Vtxo::Confidential` domain variant in `dark-core` carrying commitment, range proof, owner / ephemeral pubkeys, encrypted memo, and nullifier
+- Additive `proto/ark/v1/confidential.proto` — `ConfidentialVtxo` payload behind a `vtxo_body` oneof on `Vtxo` and `IndexerVtxo`, with reserved field-number ranges for future extensions
+- SQLite + PostgreSQL migrations for confidential columns alongside the transparent rows; indexed nullifier lookups for VTXO resolution
+- Real Bitcoin tapscript builder for confidential VTXO unilateral exits; gRPC validator wired through the API path with dynamic `FeeManagerService`
+
+#### Confidential client + CLI
+- `dark-client` confidential transaction builder, encrypted local cache for owned confidential VTXOs, deterministic blinding derivation from seed, ChaCha20-Poly1305 memo AEAD per ADR-0003
+- Wallet restore with stealth VTXO re-scan
+- `ark-cli` confidential `send` / `receive` / `scan` commands; stealth-address commands; `disclose` / `verify` selective-disclosure commands
+- Confidential-aware balance and history
+
+#### Compliance and selective disclosure
+- VTXO selective reveal with commitment opening
+- Source-of-funds proofs over the linkable commitment graph
+- Bounded-range compliance proofs
+- `VerifyComplianceProof` gRPC endpoint on `dark-api`
+- Real CBOR bundle codec and proof verifiers wired through the API
+
+#### New workspace crates
+- `dark-client` — gRPC client library
+- `dark-confidential` — confidential VTXO primitives
+- `dark-fee-manager` — fee estimation (static + Bitcoin Core RPC + CEL programs)
+- `dark-live-store` — ephemeral round state (in-memory + Redis)
+- `dark-nostr` — Nostr event publishing for VTXO notifications
+- `dark-rest-client` — HTTP client for the REST wallet surface
+- `dark-scanner` — Esplora blockchain scanner for on-chain VTXO watching
+- `dark-scheduler` — time-based and block-height-based round schedulers
+- `dark-signer` — remote-signer crate (key isolation over gRPC)
+- `dark-wallet-bin` — standalone wallet binary entrypoint
+- `dark-wallet-rest` — REST + SSE wallet daemon
+- `ark-cli` — command-line client (transparent + confidential)
+
+#### Documentation
+- ADR-0001: secp256k1-zkp integration strategy
+- ADR-0002: nullifier derivation scheme
+- ADR-0003: confidential VTXO memo format and encryption scheme
+- ADR-0004: confidential fee handling
+- ADR-0005: confidential exit script
+- M5/M6 design docs: stealth derivation, announcement pruning, viewing-key scope, disclosure types, compliance bundle format
+- SDK integrator guide for confidential transactions
+- Migration guide: transparent → confidential
+- Confidential threat model
+- Selective-disclosure compliance guide (MiCA, FATF Travel Rule, GENIUS Act)
+- Source-of-funds proofs reference
+- Confidential VTXO protobuf schema reference
+- Confidential validation errors observability guide
+- Confidential primitives benchmarks baseline
+- REST API reference
+- Workspace conventions (async, errors, repositories, tracing, null objects)
+
+#### Testing
+- Property-based test suite for every confidential primitive
+- Criterion benchmarks for Pedersen commitments, range proofs, balance proofs, and nullifiers
+- End-to-end regtest tests covering confidential + compliance + exit flows
+- 3-way sharded Rust E2E suite (rust-cache)
+- 3-way sharded Go E2E suite by measured runtime
+- `poll_until` helper with deadline-clamp guard
+
+### Changed
+- **Renamed `arkd-*` crates to `dark-*`** across the workspace (#306); repository renamed `arkd-rs` → `dark` (#485)
+- Migrated TLS stack to `rustls-tls` across the workspace (#508)
+- Use ASP key-path Taproot for connector and forfeit scripts (#481)
+- Use per-node cosigners as `TreeTxReady` topic, eliminating Go client nonce patch (#460)
+- Apply CPFP child to graph after forfeit broadcast
+- Trim broadcast critical-path latency to fit Go E2E budget
+
+### Fixed
+- Full Go E2E parity: all 48 Go E2E tests passing (#488)
+- Proper PSBT finalization and fee estimation (#478)
+- Build and broadcast commitment transaction in round scheduler (#476)
+- Checkpoint tx broadcast and exit delay verification (#473)
+- Sweep transaction building and broadcast (#475)
+- Forfeit transaction structure validation in cosigning (#477)
+- Boarding UTXOs included in `send_offchain` coin selection (#474)
+- VTXO tree amount validation
+- MuSig2 key aggregation pubkey parity preserved
+- Indexed `find_by_nullifier` for VTXO resolver
+
+### Security
+- Wired real confidential-tx validator into gRPC handler
+- Stealth scan transcript aligned between sender and recipient
+- Real ViewingKeyIssuance proof type and verifier
+- Real ChaCha20-Poly1305 AEAD for memo encryption per ADR-0003
 
 ## [0.1.0] - 2026-03-21
 
@@ -91,5 +179,6 @@ dark is a full behavioral-parity Rust reimplementation of the [Go arkd](https://
 | Async model | Goroutines | tokio async/await |
 | Binary | Dynamic linking | Single static binary |
 
-[Unreleased]: https://github.com/lobbyclawy/dark/compare/v0.1.0...HEAD
+[Unreleased]: https://github.com/lobbyclawy/dark/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/lobbyclawy/dark/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/lobbyclawy/dark/releases/tag/v0.1.0

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ dependencies = [
 
 [[package]]
 name = "ark-cli"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1099,7 +1099,7 @@ dependencies = [
 
 [[package]]
 name = "dark"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1148,7 +1148,7 @@ dependencies = [
 
 [[package]]
 name = "dark-api"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -1183,7 +1183,7 @@ dependencies = [
 
 [[package]]
 name = "dark-bitcoin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1203,7 +1203,7 @@ dependencies = [
 
 [[package]]
 name = "dark-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1238,7 +1238,7 @@ dependencies = [
 
 [[package]]
 name = "dark-confidential"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bech32",
  "bitcoin",
@@ -1258,7 +1258,7 @@ dependencies = [
 
 [[package]]
 name = "dark-core"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1286,7 +1286,7 @@ dependencies = [
 
 [[package]]
 name = "dark-db"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1308,7 +1308,7 @@ dependencies = [
 
 [[package]]
 name = "dark-fee-manager"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "base64 0.22.1",
@@ -1323,7 +1323,7 @@ dependencies = [
 
 [[package]]
 name = "dark-live-store"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "criterion",
@@ -1338,7 +1338,7 @@ dependencies = [
 
 [[package]]
 name = "dark-nostr"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes",
  "anyhow",
@@ -1364,7 +1364,7 @@ dependencies = [
 
 [[package]]
 name = "dark-rest-client"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "bytes",
  "futures",
@@ -1378,7 +1378,7 @@ dependencies = [
 
 [[package]]
 name = "dark-scanner"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "bitcoin",
@@ -1395,7 +1395,7 @@ dependencies = [
 
 [[package]]
 name = "dark-scheduler"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "async-trait",
  "dark-core",
@@ -1407,7 +1407,7 @@ dependencies = [
 
 [[package]]
 name = "dark-signer"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "bitcoin",
@@ -1425,7 +1425,7 @@ dependencies = [
 
 [[package]]
 name = "dark-wallet"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1449,7 +1449,7 @@ dependencies = [
 
 [[package]]
 name = "dark-wallet-bin"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "aes-gcm",
  "anyhow",
@@ -1474,7 +1474,7 @@ dependencies = [
 
 [[package]]
 name = "dark-wallet-rest"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "async-stream",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Lobby <lobby.clawy@gmail.com>", "Andrea Carotti <ac.carotti@gmail.com>"]
 description = "Rust implementation of dark - Ark protocol server for Bitcoin Layer 2 scaling"

--- a/crates/ark-cli/Cargo.toml
+++ b/crates/ark-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ark-cli"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Command-line client for testing dark interactively"
 

--- a/crates/dark-api/Cargo.toml
+++ b/crates/dark-api/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-api"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "gRPC API layer for dark"
 license = "MIT"

--- a/crates/dark-api/src/monitoring.rs
+++ b/crates/dark-api/src/monitoring.rs
@@ -161,7 +161,7 @@ mod tests {
         assert_eq!(resp.status(), 200);
         let body: serde_json::Value = resp.json().await.unwrap();
         assert_eq!(body["status"], "ok");
-        assert_eq!(body["version"], "0.1.0");
+        assert_eq!(body["version"], dark_core::VERSION);
         assert!(body["uptime_secs"].is_number());
 
         cancel.cancel();

--- a/crates/dark-bitcoin/Cargo.toml
+++ b/crates/dark-bitcoin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-bitcoin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/dark-client/Cargo.toml
+++ b/crates/dark-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-client"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "gRPC client library for dark"
 

--- a/crates/dark-confidential/Cargo.toml
+++ b/crates/dark-confidential/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-confidential"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Lobby <lobby.clawy@gmail.com>", "Andrea Carotti <ac.carotti@gmail.com>"]
 description = "Confidential VTXO primitives and proofs for dark"

--- a/crates/dark-core/Cargo.toml
+++ b/crates/dark-core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-core"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Core domain models and business logic for Ark protocol"
 license = "MIT"

--- a/crates/dark-db/Cargo.toml
+++ b/crates/dark-db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-db"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Database layer for dark (PostgreSQL, SQLite, Redis)"
 license = "MIT"

--- a/crates/dark-fee-manager/Cargo.toml
+++ b/crates/dark-fee-manager/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-fee-manager"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Fee estimation implementations for Ark protocol (static + Bitcoin Core RPC)"
 license = "MIT"

--- a/crates/dark-live-store/Cargo.toml
+++ b/crates/dark-live-store/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-live-store"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Ephemeral live-store implementations (in-memory + Redis) for dark round state"
 license = "MIT"

--- a/crates/dark-nostr/Cargo.toml
+++ b/crates/dark-nostr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-nostr"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 
 [dependencies]

--- a/crates/dark-rest-client/Cargo.toml
+++ b/crates/dark-rest-client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-rest-client"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Lobby <lobby.clawy@gmail.com>", "Andrea Carotti <ac.carotti@gmail.com>"]
 description = "Typed Rust HTTP client for dark-wallet-rest"

--- a/crates/dark-scanner/Cargo.toml
+++ b/crates/dark-scanner/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-scanner"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Blockchain scanner implementations for on-chain VTXO watching"
 license = "MIT"

--- a/crates/dark-scheduler/Cargo.toml
+++ b/crates/dark-scheduler/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-scheduler"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Time-based and block-height-based schedulers for dark round triggers"
 license = "MIT"

--- a/crates/dark-signer/Cargo.toml
+++ b/crates/dark-signer/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-signer"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Standalone signer binary for dark — key isolation via gRPC SignerService"
 license = "MIT"

--- a/crates/dark-wallet-bin/Cargo.toml
+++ b/crates/dark-wallet-bin/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-wallet-bin"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Standalone gRPC wallet binary for dark with AES-256 seed encryption"
 license = "MIT"

--- a/crates/dark-wallet-rest/Cargo.toml
+++ b/crates/dark-wallet-rest/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-wallet-rest"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 authors = ["Lobby <lobby.clawy@gmail.com>", "Andrea Carotti <ac.carotti@gmail.com>"]
 description = "REST wallet daemon for dark — axum + utoipa on top of dark-client"

--- a/crates/dark-wallet-rest/openapi.json
+++ b/crates/dark-wallet-rest/openapi.json
@@ -11,7 +11,7 @@
       "name": "MIT",
       "identifier": "MIT"
     },
-    "version": "0.1.0"
+    "version": "0.2.0"
   },
   "paths": {
     "/ping": {

--- a/crates/dark-wallet/Cargo.toml
+++ b/crates/dark-wallet/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "dark-wallet"
-version = "0.1.0"
+version = "0.2.0"
 edition = "2021"
 description = "Bitcoin wallet service for dark (BDK-based)"
 license = "MIT"


### PR DESCRIPTION
Bump workspace version 0.1.0 → 0.2.0 across the root crate and all 17 workspace members; refresh Cargo.lock accordingly.

Replace the stale CHANGELOG `[Unreleased]` block with a full v0.2.0 section covering the confidential VTXO subsystem (dark-confidential crate, primitives, ADRs 0001-0005, proto schema, DB migrations, tx builder, ark-cli flow, tapscript exit), the M5/M6 compliance and selective-disclosure work, the workspace split into focused crates (dark-client, dark-rest-client, dark-signer, dark-wallet-rest, etc.), the rustls-tls migration, and the full Go E2E parity push.