### PR TITLE
🐛 fix(docker): copy benches/ into Dockerfile.prod build context

### DIFF
--- a/Dockerfile.prod
+++ b/Dockerfile.prod
@@ -18,6 +18,7 @@ COPY Cargo.toml Cargo.lock ./
 COPY crates/ crates/
 COPY src/ src/
 COPY proto/ proto/
+COPY benches/ benches/
 COPY crates/dark-db/migrations/ crates/dark-db/migrations/
 
 # Build the release binary


### PR DESCRIPTION
The release.yml Docker build was failing in `cargo build --bin dark` with:

    can't find `ark_benchmarks` bench at `benches/ark_benchmarks.rs`
    or `benches/ark_benchmarks/main.rs`

The root Cargo.toml declares `[[bench]] name = "ark_benchmarks"` with no explicit `path =`, so cargo auto-discovers `benches/ark_benchmarks.rs` during manifest parse — and refuses to parse if the file is missing. Dockerfile.prod was selectively copying Cargo.toml, crates/, src/, proto/, and the migrations dir but never benches/, so the file wasn't in the build context.

Add `COPY benches/ benches/`. The dev Dockerfile already does `COPY . .` so it's unaffected.