### PR TITLE
Phase 3: PSAR boarding (#666-#671)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,8 +1368,11 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
+ "dark-von",
+ "dark-von-musig2",
  "hex",
  "proptest",
+ "rand 0.8.6",
  "secp256k1 0.29.1",
  "serde",
  "serde_bytes",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,6 +1366,8 @@ dependencies = [
 name = "dark-psar"
 version = "0.1.0"
 dependencies = [
+ "bitcoin",
+ "bitcoincore-rpc",
  "hex",
  "proptest",
  "secp256k1 0.29.1",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1368,6 +1368,7 @@ version = "0.1.0"
 dependencies = [
  "hex",
  "proptest",
+ "secp256k1 0.29.1",
  "serde",
  "serde_bytes",
  "serde_json",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1363,6 +1363,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "dark-psar"
+version = "0.1.0"
+dependencies = [
+ "proptest",
+ "serde",
+ "serde_bytes",
+ "serde_json",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "dark-rest-client"
 version = "0.2.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1366,10 +1366,12 @@ dependencies = [
 name = "dark-psar"
 version = "0.1.0"
 dependencies = [
+ "hex",
  "proptest",
  "serde",
  "serde_bytes",
  "serde_json",
+ "sha2",
  "thiserror 2.0.18",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ members = [
     "crates/dark-confidential",
     "crates/dark-von",
     "crates/dark-von-musig2",
+    "crates/dark-psar",
 ]
 
 [dependencies]

--- a/crates/dark-psar/Cargo.toml
+++ b/crates/dark-psar/Cargo.toml
@@ -23,6 +23,9 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 sha2 = "0.10"
 secp256k1 = { version = "0.29", features = ["rand"] }
+rand = "0.8"
+dark-von = { path = "../dark-von" }
+dark-von-musig2 = { path = "../dark-von-musig2" }
 bitcoin = { version = "0.32", optional = true, features = ["rand", "serde"] }
 bitcoincore-rpc = { version = "0.19", optional = true }
 

--- a/crates/dark-psar/Cargo.toml
+++ b/crates/dark-psar/Cargo.toml
@@ -1,0 +1,27 @@
+[package]
+name = "dark-psar"
+version = "0.1.0"
+edition = "2021"
+authors = ["Lobby <lobby.clawy@gmail.com>", "Andrea Carotti <ac.carotti@gmail.com>"]
+description = "PSAR boarding-and-horizon protocol layer (cohorts, slot tree, attestations) for dark"
+license = "MIT"
+repository = "https://github.com/lobbyclawy/dark"
+
+[lints.rust]
+unsafe_code = "forbid"
+
+[features]
+default = []
+
+[dependencies]
+thiserror = "2.0"
+serde = { version = "1.0", features = ["derive"] }
+serde_bytes = "0.11"
+
+[dev-dependencies]
+proptest = "1.5"
+serde_json = "1.0"
+
+[lib]
+name = "dark_psar"
+path = "src/lib.rs"

--- a/crates/dark-psar/Cargo.toml
+++ b/crates/dark-psar/Cargo.toml
@@ -12,6 +12,10 @@ unsafe_code = "forbid"
 
 [features]
 default = []
+# Enables `publish::publish_slot_attest` and the
+# `tests/e2e_psar_regtest.rs` integration test. The default build does
+# not pull in the Bitcoin / RPC dependency stack.
+regtest = ["dep:bitcoin", "dep:bitcoincore-rpc"]
 
 [dependencies]
 thiserror = "2.0"
@@ -19,6 +23,8 @@ serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 sha2 = "0.10"
 secp256k1 = { version = "0.29", features = ["rand"] }
+bitcoin = { version = "0.32", optional = true, features = ["rand", "serde"] }
+bitcoincore-rpc = { version = "0.19", optional = true }
 
 [dev-dependencies]
 proptest = "1.5"

--- a/crates/dark-psar/Cargo.toml
+++ b/crates/dark-psar/Cargo.toml
@@ -17,10 +17,12 @@ default = []
 thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
+sha2 = "0.10"
 
 [dev-dependencies]
 proptest = "1.5"
 serde_json = "1.0"
+hex = "0.4"
 
 [lib]
 name = "dark_psar"

--- a/crates/dark-psar/Cargo.toml
+++ b/crates/dark-psar/Cargo.toml
@@ -18,6 +18,7 @@ thiserror = "2.0"
 serde = { version = "1.0", features = ["derive"] }
 serde_bytes = "0.11"
 sha2 = "0.10"
+secp256k1 = { version = "0.29", features = ["rand"] }
 
 [dev-dependencies]
 proptest = "1.5"

--- a/crates/dark-psar/src/attest.rs
+++ b/crates/dark-psar/src/attest.rs
@@ -1,0 +1,443 @@
+//! Slot attestation (issue #668).
+//!
+//! A [`SlotAttest`] is the ASP's BIP-340 Schnorr signature over a
+//! cohort's `slot_root` (#667) plus the cohort metadata that pins
+//! "which cohort, with which setup, for what horizon" the root belongs
+//! to. The signature commits the ASP to the slot allocation; downstream
+//! flows (#669 OP_RETURN publish, #670 user-side verify, #671 ASP-side
+//! orchestration) consume this struct.
+//!
+//! # Wire format
+//!
+//! - **Unsigned payload** ([`SlotAttestUnsigned::SIZE`] = 104 B):
+//!
+//!   ```text
+//!   |  32 B slot_root  |  32 B cohort_id  |  32 B setup_id  |  4 B n (LE u32)  |  4 B k (LE u32)  |
+//!   ```
+//!
+//! - **Signed payload** ([`SlotAttest::SIZE`] = 168 B): the unsigned
+//!   payload followed by the 64-byte BIP-340 Schnorr signature.
+//!
+//! The signature is computed over the BIP-340 tagged hash of the
+//! unsigned payload with tag [`SLOT_ATTEST_TAG`]
+//! (`b"DarkPsarSlotAttestV1"`).
+//!
+//! # OP_RETURN payload
+//!
+//! Issue #668 sets a target of ≤ 80 B "after Schnorr sig" so the
+//! attestation fits in a single OP_RETURN output. Publishing the full
+//! 168-byte signed payload requires the verifier to have the on-chain
+//! data only — but it overflows the standard 80 B `-datacarriersize`
+//! limit.
+//!
+//! [`SlotAttest::op_return_payload`] therefore emits a compact 68-byte
+//! form `[ "PSAR" magic | 64 B sig ]` (4 + 64). Verifying the on-chain
+//! commitment requires the verifier to have the unsigned payload from
+//! off-chain context (every cohort member already does, since they
+//! received it as part of boarding); the on-chain bytes are then a
+//! timestamped, third-party-non-repudiable commitment to that payload
+//! under the ASP's BIP-340 key.
+//!
+//! This deviates from issue #668's "single canonical encoding for both
+//! off-chain and OP_RETURN" wording — see PR notes.
+//!
+//! # Round-trip + tamper guarantees
+//!
+//! [`SlotAttest::to_bytes`] / [`SlotAttest::from_bytes`] are inverse
+//! pure functions of the struct contents. [`SlotAttest::verify`]
+//! returns `Err(SlotAttestError::InvalidSignature)` for any byte
+//! flipped in the unsigned payload or the signature: the signature is
+//! BIP-340-bound to the digest of the unsigned bytes.
+
+use secp256k1::schnorr::Signature;
+use secp256k1::{Keypair, Message, Secp256k1, XOnlyPublicKey};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+
+/// BIP-340 tagged-hash tag for the slot attestation digest.
+pub const SLOT_ATTEST_TAG: &[u8] = b"DarkPsarSlotAttestV1";
+
+/// 4-byte magic marking an on-chain slot-attestation OP_RETURN payload.
+pub const OP_RETURN_MAGIC: [u8; 4] = *b"PSAR";
+
+/// `SlotAttest` errors.
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum SlotAttestError {
+    #[error("malformed slot attest: got {got} bytes, expected {expected}")]
+    MalformedLength { got: usize, expected: usize },
+
+    #[error("invalid bip-340 signature on slot attest")]
+    InvalidSignature,
+
+    #[error("malformed signature bytes")]
+    MalformedSignature,
+}
+
+/// Unsigned attestation payload.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SlotAttestUnsigned {
+    pub slot_root: [u8; 32],
+    pub cohort_id: [u8; 32],
+    pub setup_id: [u8; 32],
+    pub n: u32,
+    pub k: u32,
+}
+
+impl SlotAttestUnsigned {
+    /// Serialised length of the unsigned payload.
+    pub const SIZE: usize = 32 + 32 + 32 + 4 + 4;
+
+    /// Canonical 104-byte serialisation.
+    pub fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut out = [0u8; Self::SIZE];
+        out[0..32].copy_from_slice(&self.slot_root);
+        out[32..64].copy_from_slice(&self.cohort_id);
+        out[64..96].copy_from_slice(&self.setup_id);
+        out[96..100].copy_from_slice(&self.n.to_le_bytes());
+        out[100..104].copy_from_slice(&self.k.to_le_bytes());
+        out
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SlotAttestError> {
+        if bytes.len() != Self::SIZE {
+            return Err(SlotAttestError::MalformedLength {
+                got: bytes.len(),
+                expected: Self::SIZE,
+            });
+        }
+        let mut slot_root = [0u8; 32];
+        slot_root.copy_from_slice(&bytes[0..32]);
+        let mut cohort_id = [0u8; 32];
+        cohort_id.copy_from_slice(&bytes[32..64]);
+        let mut setup_id = [0u8; 32];
+        setup_id.copy_from_slice(&bytes[64..96]);
+        let mut n_buf = [0u8; 4];
+        n_buf.copy_from_slice(&bytes[96..100]);
+        let mut k_buf = [0u8; 4];
+        k_buf.copy_from_slice(&bytes[100..104]);
+        Ok(Self {
+            slot_root,
+            cohort_id,
+            setup_id,
+            n: u32::from_le_bytes(n_buf),
+            k: u32::from_le_bytes(k_buf),
+        })
+    }
+
+    /// 32-byte BIP-340 tagged digest the ASP signs.
+    pub fn signing_digest(&self) -> [u8; 32] {
+        tagged_hash(SLOT_ATTEST_TAG, &self.to_bytes())
+    }
+
+    /// Sign with the ASP's BIP-340 keypair, producing a [`SlotAttest`].
+    pub fn sign<C: secp256k1::Signing>(&self, secp: &Secp256k1<C>, kp: &Keypair) -> SlotAttest {
+        let digest = self.signing_digest();
+        let msg = Message::from_digest(digest);
+        let sig = secp.sign_schnorr_no_aux_rand(&msg, kp);
+        SlotAttest {
+            unsigned: *self,
+            sig: sig.serialize(),
+        }
+    }
+}
+
+/// Signed slot attestation.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SlotAttest {
+    pub unsigned: SlotAttestUnsigned,
+    pub sig: [u8; 64],
+}
+
+impl SlotAttest {
+    /// Full canonical wire size = unsigned (104) + Schnorr (64).
+    pub const SIZE: usize = SlotAttestUnsigned::SIZE + 64;
+
+    /// On-chain OP_RETURN payload size: 4 B magic + 64 B sig.
+    pub const OP_RETURN_SIZE: usize = OP_RETURN_MAGIC.len() + 64;
+
+    pub fn to_bytes(&self) -> [u8; Self::SIZE] {
+        let mut out = [0u8; Self::SIZE];
+        out[..SlotAttestUnsigned::SIZE].copy_from_slice(&self.unsigned.to_bytes());
+        out[SlotAttestUnsigned::SIZE..].copy_from_slice(&self.sig);
+        out
+    }
+
+    pub fn from_bytes(bytes: &[u8]) -> Result<Self, SlotAttestError> {
+        if bytes.len() != Self::SIZE {
+            return Err(SlotAttestError::MalformedLength {
+                got: bytes.len(),
+                expected: Self::SIZE,
+            });
+        }
+        let unsigned = SlotAttestUnsigned::from_bytes(&bytes[..SlotAttestUnsigned::SIZE])?;
+        let mut sig = [0u8; 64];
+        sig.copy_from_slice(&bytes[SlotAttestUnsigned::SIZE..]);
+        Ok(Self { unsigned, sig })
+    }
+
+    /// Compact on-chain payload: magic prefix + sig. The verifier needs
+    /// the unsigned payload from off-chain context to fully verify.
+    pub fn op_return_payload(&self) -> [u8; Self::OP_RETURN_SIZE] {
+        let mut out = [0u8; Self::OP_RETURN_SIZE];
+        out[..4].copy_from_slice(&OP_RETURN_MAGIC);
+        out[4..].copy_from_slice(&self.sig);
+        out
+    }
+
+    /// Recover a `SlotAttest` from `op_return_payload` + an off-chain
+    /// unsigned payload. Validates the magic prefix and the signature.
+    pub fn from_op_return_with_unsigned(
+        op_return: &[u8],
+        unsigned: SlotAttestUnsigned,
+        pk_asp: &XOnlyPublicKey,
+    ) -> Result<Self, SlotAttestError> {
+        if op_return.len() != Self::OP_RETURN_SIZE {
+            return Err(SlotAttestError::MalformedLength {
+                got: op_return.len(),
+                expected: Self::OP_RETURN_SIZE,
+            });
+        }
+        if op_return[..4] != OP_RETURN_MAGIC {
+            return Err(SlotAttestError::MalformedSignature);
+        }
+        let mut sig = [0u8; 64];
+        sig.copy_from_slice(&op_return[4..]);
+        let attest = Self { unsigned, sig };
+        attest.verify(pk_asp)?;
+        Ok(attest)
+    }
+
+    /// Verify the signature against the ASP's BIP-340 x-only public key.
+    pub fn verify(&self, pk_asp: &XOnlyPublicKey) -> Result<(), SlotAttestError> {
+        let secp = Secp256k1::verification_only();
+        let sig =
+            Signature::from_slice(&self.sig).map_err(|_| SlotAttestError::MalformedSignature)?;
+        let digest = self.unsigned.signing_digest();
+        let msg = Message::from_digest(digest);
+        secp.verify_schnorr(&sig, &msg, pk_asp)
+            .map_err(|_| SlotAttestError::InvalidSignature)
+    }
+}
+
+fn tagged_hash(tag: &[u8], msg: &[u8]) -> [u8; 32] {
+    let tag_hash = Sha256::digest(tag);
+    let mut hasher = Sha256::new();
+    hasher.update(tag_hash);
+    hasher.update(tag_hash);
+    hasher.update(msg);
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use secp256k1::{Keypair, Secp256k1, SecretKey};
+
+    fn make_unsigned(seed: u8) -> SlotAttestUnsigned {
+        SlotAttestUnsigned {
+            slot_root: [seed; 32],
+            cohort_id: [seed.wrapping_add(1); 32],
+            setup_id: [seed.wrapping_add(2); 32],
+            n: 12,
+            k: 100,
+        }
+    }
+
+    fn fixed_keypair() -> Keypair {
+        let secp = Secp256k1::new();
+        let sk = SecretKey::from_slice(&[0xa7u8; 32]).unwrap();
+        Keypair::from_secret_key(&secp, &sk)
+    }
+
+    #[test]
+    fn pinned_constants() {
+        assert_eq!(SLOT_ATTEST_TAG, b"DarkPsarSlotAttestV1");
+        assert_eq!(OP_RETURN_MAGIC, *b"PSAR");
+        assert_eq!(SlotAttestUnsigned::SIZE, 104);
+        assert_eq!(SlotAttest::SIZE, 168);
+        assert_eq!(SlotAttest::OP_RETURN_SIZE, 68);
+    }
+
+    #[test]
+    fn unsigned_round_trip() {
+        let u = make_unsigned(0xab);
+        let bytes = u.to_bytes();
+        assert_eq!(bytes.len(), SlotAttestUnsigned::SIZE);
+        let parsed = SlotAttestUnsigned::from_bytes(&bytes).unwrap();
+        assert_eq!(parsed, u);
+    }
+
+    #[test]
+    fn unsigned_le_n_and_k_layout() {
+        let u = SlotAttestUnsigned {
+            slot_root: [0u8; 32],
+            cohort_id: [0u8; 32],
+            setup_id: [0u8; 32],
+            n: 0x0403_0201,
+            k: 0x0807_0605,
+        };
+        let b = u.to_bytes();
+        assert_eq!(&b[96..100], &[0x01, 0x02, 0x03, 0x04]);
+        assert_eq!(&b[100..104], &[0x05, 0x06, 0x07, 0x08]);
+    }
+
+    #[test]
+    fn unsigned_from_bytes_rejects_wrong_length() {
+        let err = SlotAttestUnsigned::from_bytes(&[0u8; 103]).unwrap_err();
+        assert_eq!(
+            err,
+            SlotAttestError::MalformedLength {
+                got: 103,
+                expected: 104,
+            }
+        );
+    }
+
+    #[test]
+    fn signed_round_trip_and_verify() {
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let pk = kp.x_only_public_key().0;
+        let u = make_unsigned(0x42);
+        let attest = u.sign(&secp, &kp);
+        attest.verify(&pk).expect("valid sig");
+
+        let bytes = attest.to_bytes();
+        assert_eq!(bytes.len(), SlotAttest::SIZE);
+        let parsed = SlotAttest::from_bytes(&bytes).unwrap();
+        assert_eq!(parsed, attest);
+        parsed
+            .verify(&pk)
+            .expect("round-tripped attest still verifies");
+    }
+
+    #[test]
+    fn signed_from_bytes_rejects_wrong_length() {
+        let err = SlotAttest::from_bytes(&[0u8; 167]).unwrap_err();
+        assert_eq!(
+            err,
+            SlotAttestError::MalformedLength {
+                got: 167,
+                expected: 168,
+            }
+        );
+    }
+
+    #[test]
+    fn tampered_unsigned_field_fails_verify() {
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let pk = kp.x_only_public_key().0;
+        let u = make_unsigned(0x10);
+        let attest = u.sign(&secp, &kp);
+
+        // Mutate every byte position in the 104-byte unsigned payload and
+        // confirm verify rejects.
+        for byte_idx in 0..SlotAttestUnsigned::SIZE {
+            let mut bytes = attest.to_bytes();
+            bytes[byte_idx] ^= 0x01;
+            // Parses fine — bytes are well-formed length.
+            let tampered = SlotAttest::from_bytes(&bytes).unwrap();
+            let err = tampered.verify(&pk).unwrap_err();
+            assert!(
+                matches!(
+                    err,
+                    SlotAttestError::InvalidSignature | SlotAttestError::MalformedSignature
+                ),
+                "byte {byte_idx}: expected verify rejection, got {err:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn tampered_signature_byte_fails_verify() {
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let pk = kp.x_only_public_key().0;
+        let attest = make_unsigned(0x77).sign(&secp, &kp);
+
+        for byte_idx in SlotAttestUnsigned::SIZE..SlotAttest::SIZE {
+            let mut bytes = attest.to_bytes();
+            bytes[byte_idx] ^= 0x01;
+            let tampered = SlotAttest::from_bytes(&bytes).unwrap();
+            assert!(tampered.verify(&pk).is_err(), "byte {byte_idx}");
+        }
+    }
+
+    #[test]
+    fn wrong_pubkey_fails_verify() {
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let attest = make_unsigned(0x33).sign(&secp, &kp);
+        let other_kp = {
+            let sk = SecretKey::from_slice(&[0x55u8; 32]).unwrap();
+            Keypair::from_secret_key(&secp, &sk)
+        };
+        let other_pk = other_kp.x_only_public_key().0;
+        assert_eq!(
+            attest.verify(&other_pk),
+            Err(SlotAttestError::InvalidSignature)
+        );
+    }
+
+    #[test]
+    fn op_return_payload_size_and_round_trip() {
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let pk = kp.x_only_public_key().0;
+        let u = make_unsigned(0x99);
+        let attest = u.sign(&secp, &kp);
+
+        let payload = attest.op_return_payload();
+        assert_eq!(payload.len(), 68);
+        assert!(
+            payload.len() <= 80,
+            "OP_RETURN must fit standard 80-byte cap"
+        );
+        assert_eq!(&payload[..4], &OP_RETURN_MAGIC);
+        assert_eq!(&payload[4..], &attest.sig);
+
+        let recovered = SlotAttest::from_op_return_with_unsigned(&payload, u, &pk).unwrap();
+        assert_eq!(recovered, attest);
+    }
+
+    #[test]
+    fn op_return_rejects_bad_magic() {
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let pk = kp.x_only_public_key().0;
+        let u = make_unsigned(0xaa);
+        let attest = u.sign(&secp, &kp);
+        let mut payload = attest.op_return_payload();
+        payload[0] = b'X';
+        let err = SlotAttest::from_op_return_with_unsigned(&payload, u, &pk).unwrap_err();
+        assert_eq!(err, SlotAttestError::MalformedSignature);
+    }
+
+    #[test]
+    fn op_return_rejects_wrong_unsigned_payload() {
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let pk = kp.x_only_public_key().0;
+        let u = make_unsigned(0xaa);
+        let other = make_unsigned(0xbb);
+        let attest = u.sign(&secp, &kp);
+        let payload = attest.op_return_payload();
+        let err = SlotAttest::from_op_return_with_unsigned(&payload, other, &pk).unwrap_err();
+        assert_eq!(err, SlotAttestError::InvalidSignature);
+    }
+
+    #[test]
+    fn signing_is_deterministic_no_aux_rand() {
+        // BIP-340 with `sign_schnorr_no_aux_rand` is deterministic; same
+        // (sk, msg) → same sig. This pins the property and lets us produce
+        // golden fixtures in #669 if needed.
+        let secp = Secp256k1::new();
+        let kp = fixed_keypair();
+        let u = make_unsigned(0x01);
+        let a1 = u.sign(&secp, &kp);
+        let a2 = u.sign(&secp, &kp);
+        assert_eq!(a1.sig, a2.sig);
+    }
+}

--- a/crates/dark-psar/src/boarding.rs
+++ b/crates/dark-psar/src/boarding.rs
@@ -1,9 +1,9 @@
 //! Boarding flows (issues #670 user-side and #671 ASP-side).
 //!
-//! This module owns the *coordination* between the [`cohort`] /
-//! [`attest`] / [`slot_tree`] pieces and the cryptographic primitives
-//! in `dark_von_musig2`. The user-side flow is `user_board` (#670);
-//! the ASP-side flow `asp_board` (#671) lives later in this file.
+//! This module owns the *coordination* between the `cohort`, `attest`,
+//! and `slot_tree` modules and the cryptographic primitives in
+//! `dark_von_musig2`. The user-side flow is `user_board` (#670); the
+//! ASP-side flow `asp_board` (#671) lives later in this file.
 //!
 //! # Conventions
 //!

--- a/crates/dark-psar/src/boarding.rs
+++ b/crates/dark-psar/src/boarding.rs
@@ -1,0 +1,521 @@
+//! Boarding flows (issues #670 user-side and #671 ASP-side).
+//!
+//! This module owns the *coordination* between the [`cohort`] /
+//! [`attest`] / [`slot_tree`] pieces and the cryptographic primitives
+//! in `dark_von_musig2`. The user-side flow is `user_board` (#670);
+//! the ASP-side flow `asp_board` (#671) lives later in this file.
+//!
+//! # Conventions
+//!
+//! - Every cohort member's `pk_user` is a 32-byte BIP-340 x-only
+//!   public key with **assumed even parity**. Keypairs that yield
+//!   odd parity (`secp256k1::Keypair::x_only_public_key().1 ==
+//!   Parity::Odd`) are rejected with [`PsarError::OddParity`]; the
+//!   caller must negate the secret to renormalize.
+//! - The ASP's signing key plays two roles: it signs [`SlotAttest`]
+//!   with `Schnorr` (BIP-340) and it acts as the operator in the
+//!   VON-MuSig2 protocol. Both consume the same x-only pubkey `pk_asp`,
+//!   lifted internally to its even-parity compressed form for
+//!   `dark_von_musig2::sign::build_key_agg_ctx`.
+//!
+//! # Schedule witness
+//!
+//! `UserBoardingArtifact::schedule_witness` is a hash-chain commitment
+//! over Λ:
+//!
+//! ```text
+//! h_0    = SHA256(b"DarkPsarLambdaWitnessV1" || setup_id || n_LE_u32)
+//! h_t    = SHA256(h_{t-1} || R_{t,1} || π_{t,1} || R_{t,2} || π_{t,2})
+//! witness = h_n
+//! ```
+//!
+//! The chain is deterministic in Λ — the ASP can recompute it at
+//! collection time (#671) to verify the user actually consumed the
+//! published schedule. Tampering with any byte of any Λ entry yields
+//! a different `witness`.
+
+use dark_von_musig2::nonces::PubNonce;
+use dark_von_musig2::presign::{presign_horizon, PreSigned};
+use dark_von_musig2::setup::PublishedSchedule;
+use dark_von_musig2::sign::{build_key_agg_ctx, PartialSignature};
+use rand::Rng;
+use secp256k1::{Keypair, Parity, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
+use sha2::{Digest, Sha256};
+
+use crate::attest::SlotAttest;
+use crate::cohort::Cohort;
+use crate::error::PsarError;
+use crate::message::derive_message_for_epoch;
+use crate::slot_tree::SlotRoot;
+
+/// Tag for the schedule-witness hash chain.
+pub const SCHEDULE_WITNESS_TAG: &[u8] = b"DarkPsarLambdaWitnessV1";
+
+/// Per-user boarding output handed back to the ASP for collection.
+#[derive(Clone, Debug)]
+pub struct UserBoardingArtifact {
+    pub slot_index: u32,
+    pub n: u32,
+    /// Per-epoch pre-signed material; `presigned[t-1]` covers epoch `t`.
+    pub presigned: Vec<PreSigned>,
+    /// Hash-chain commitment proving the user verified Λ; see module docs.
+    pub schedule_witness: [u8; 32],
+}
+
+impl UserBoardingArtifact {
+    /// Decompose into the parallel `(pub_nonce, partial_sig)` lists the
+    /// ASP-side flow keeps in `ActiveCohort`.
+    pub fn split(&self) -> (Vec<PubNonce>, Vec<PartialSignature>) {
+        let nonces = self.presigned.iter().map(|p| p.pub_nonce.clone()).collect();
+        let sigs = self.presigned.iter().map(|p| p.partial_sig).collect();
+        (nonces, sigs)
+    }
+}
+
+/// User-side boarding (#670).
+///
+/// Given the cohort, the on-chain [`SlotAttest`] (verified against the
+/// ASP's BIP-340 pubkey), the published Λ, and the user's keypair:
+///
+/// 1. Verify `attest` against `pk_asp` and check it agrees with the
+///    cohort metadata (`n`, `k`, `cohort_id`).
+/// 2. Recompute the slot root over `cohort.members` and check it
+///    matches `attest.unsigned.slot_root`.
+/// 3. Verify `cohort.members[slot_index].pk_user` matches the
+///    keypair's x-only pubkey (and parity is even).
+/// 4. Verify every entry of Λ via `dark_von::wrapper::verify`,
+///    surfacing the offending `(epoch, slot)` if any fails.
+/// 5. Derive `m_t = derive_message_for_epoch(slot_root, cohort_id,
+///    setup_id, t)` for `t ∈ [1, n]`.
+/// 6. Pre-sign the horizon via
+///    `dark_von_musig2::presign::presign_horizon` (`presign_horizon`
+///    re-verifies Λ — the explicit pre-check above is what produces
+///    the `(epoch, slot)`-tagged error).
+/// 7. Return [`UserBoardingArtifact`] with the pre-signed material and
+///    the schedule witness.
+pub fn user_board<R: Rng + ?Sized>(
+    cohort: &Cohort,
+    attest: &SlotAttest,
+    pk_asp: &XOnlyPublicKey,
+    schedule: &PublishedSchedule,
+    user_kp: &Keypair,
+    slot_index: u32,
+    rng: &mut R,
+) -> Result<UserBoardingArtifact, PsarError> {
+    // ─── Cohort / attestation / horizon agreement ────────────────────
+    if attest.unsigned.cohort_id != cohort.id {
+        return Err(PsarError::AttestationFieldMismatch {
+            field: "cohort_id",
+            attest_value: 0,
+            cohort_value: 0,
+        });
+    }
+    if attest.unsigned.n != cohort.horizon.n {
+        return Err(PsarError::AttestationFieldMismatch {
+            field: "n",
+            attest_value: attest.unsigned.n,
+            cohort_value: cohort.horizon.n,
+        });
+    }
+    if attest.unsigned.k != cohort.k() {
+        return Err(PsarError::AttestationFieldMismatch {
+            field: "k",
+            attest_value: attest.unsigned.k,
+            cohort_value: cohort.k(),
+        });
+    }
+    if schedule.n != cohort.horizon.n {
+        return Err(PsarError::HorizonDisagrees {
+            schedule_n: schedule.n,
+            cohort_n: cohort.horizon.n,
+        });
+    }
+    let mut setup_id = [0u8; 32];
+    if schedule.setup_id.len() != 32 {
+        return Err(PsarError::AttestationFieldMismatch {
+            field: "setup_id_length",
+            attest_value: schedule.setup_id.len() as u32,
+            cohort_value: 32,
+        });
+    }
+    setup_id.copy_from_slice(&schedule.setup_id);
+    if attest.unsigned.setup_id != setup_id {
+        return Err(PsarError::AttestationFieldMismatch {
+            field: "setup_id",
+            attest_value: 0,
+            cohort_value: 0,
+        });
+    }
+
+    // ─── Attestation signature ────────────────────────────────────────
+    attest
+        .verify(pk_asp)
+        .map_err(|_| PsarError::AttestationVerify)?;
+
+    // ─── Slot-root recomputation ──────────────────────────────────────
+    let recomputed = SlotRoot::compute(&cohort.members);
+    if recomputed.0 != attest.unsigned.slot_root {
+        return Err(PsarError::SlotRootMismatch);
+    }
+
+    // ─── Slot membership / pubkey match ───────────────────────────────
+    let member = cohort
+        .members
+        .get(slot_index as usize)
+        .ok_or(PsarError::SlotIndexOutOfRange {
+            slot_index,
+            k: cohort.k(),
+        })?;
+    if member.slot_index != slot_index {
+        return Err(PsarError::SlotIndexOutOfRange {
+            slot_index,
+            k: cohort.k(),
+        });
+    }
+    let (user_xonly, parity) = user_kp.x_only_public_key();
+    if parity == Parity::Odd {
+        return Err(PsarError::OddParity);
+    }
+    if user_xonly.serialize() != member.pk_user {
+        return Err(PsarError::PubkeyMismatch { slot_index });
+    }
+
+    // ─── Λ pre-verification with (epoch, slot) reporting ──────────────
+    verify_lambda_entries(pk_asp, schedule, &setup_id)?;
+
+    // ─── KeyAggCtx + messages + presign ───────────────────────────────
+    let pk_asp_full = lift_xonly_to_even(pk_asp);
+    let pk_user_full = user_kp.public_key();
+    let ctx = build_key_agg_ctx(&[pk_asp_full, pk_user_full])
+        .map_err(|e| PsarError::VonMusig2(dark_von_musig2::VonMusig2Error::Bip327(e)))?;
+
+    let messages: Vec<[u8; 32]> = (1..=schedule.n)
+        .map(|t| derive_message_for_epoch(&attest.unsigned.slot_root, &cohort.id, &setup_id, t))
+        .collect();
+
+    let user_sk = SecretKey::from_keypair(user_kp);
+    let presigned = presign_horizon(&user_sk, &pk_asp_full, &ctx, schedule, &messages, rng)?;
+
+    // ─── Schedule witness ─────────────────────────────────────────────
+    let schedule_witness = compute_schedule_witness(schedule);
+
+    Ok(UserBoardingArtifact {
+        slot_index,
+        n: schedule.n,
+        presigned,
+        schedule_witness,
+    })
+}
+
+/// Pre-flight verification of every `(epoch, slot)` pair in Λ.
+///
+/// `presign_horizon` already runs the same check, but it surfaces a
+/// generic `VonMusig2Error::DarkVon` without the offending coordinates.
+/// Doing it here lets the user (and the test in #670) see exactly which
+/// entry is broken.
+fn verify_lambda_entries(
+    pk_asp: &XOnlyPublicKey,
+    schedule: &PublishedSchedule,
+    setup_id: &[u8; 32],
+) -> Result<(), PsarError> {
+    let pk_asp_full = lift_xonly_to_even(pk_asp);
+    let public = schedule.to_dark_von()?;
+    for t in 1..=public.n {
+        for b in [1u8, 2u8] {
+            let entry = public
+                .entry(t, b)
+                .ok_or(PsarError::ScheduleInvalid { epoch: t, slot: b })?;
+            let x = dark_von::hash::h_nonce(setup_id, t, b);
+            dark_von::wrapper::verify(&pk_asp_full, &x, &entry.r_point, &entry.proof)
+                .map_err(|_| PsarError::ScheduleInvalid { epoch: t, slot: b })?;
+        }
+    }
+    Ok(())
+}
+
+fn lift_xonly_to_even(pk: &XOnlyPublicKey) -> PublicKey {
+    let xb = pk.serialize();
+    let mut compressed = [0u8; 33];
+    compressed[0] = 0x02;
+    compressed[1..].copy_from_slice(&xb);
+    PublicKey::from_slice(&compressed).expect("x-only lifts to a valid even-parity point")
+}
+
+fn compute_schedule_witness(schedule: &PublishedSchedule) -> [u8; 32] {
+    let mut acc: [u8; 32] = {
+        let mut h = Sha256::new();
+        h.update(SCHEDULE_WITNESS_TAG);
+        h.update(&schedule.setup_id);
+        h.update(schedule.n.to_le_bytes());
+        h.finalize().into()
+    };
+    for entry in &schedule.entries {
+        let mut h = Sha256::new();
+        h.update(acc);
+        h.update(&entry.r1);
+        h.update(&entry.proof1);
+        h.update(&entry.r2);
+        h.update(&entry.proof2);
+        acc = h.finalize().into();
+    }
+    acc
+}
+
+/// Re-export of the secp context type used internally — keeps the
+/// boarding test harness terse.
+pub fn new_secp() -> Secp256k1<secp256k1::All> {
+    Secp256k1::new()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::attest::{SlotAttest, SlotAttestUnsigned};
+    use crate::cohort::{Cohort, CohortMember, HibernationHorizon};
+    use crate::slot_tree::SlotRoot;
+    use dark_von_musig2::setup::Setup;
+    use rand::rngs::StdRng;
+    use rand::SeedableRng;
+    use secp256k1::{Keypair, Secp256k1, SecretKey};
+
+    /// Find a SecretKey with even-parity x-only pubkey by counter-seeding.
+    fn even_parity_keypair(secp: &Secp256k1<secp256k1::All>, seed: u8) -> Keypair {
+        for offset in 0u32..1000 {
+            let mut bytes = [seed; 32];
+            // Avoid the all-equal trap by mixing in the offset.
+            bytes[28..32].copy_from_slice(&offset.to_le_bytes());
+            if let Ok(sk) = SecretKey::from_slice(&bytes) {
+                let kp = Keypair::from_secret_key(secp, &sk);
+                if kp.x_only_public_key().1 == Parity::Even {
+                    return kp;
+                }
+            }
+        }
+        panic!("no even-parity keypair found within counter range; should be ~50% probable");
+    }
+
+    fn cohort_with_keypairs(
+        k: u32,
+        horizon: HibernationHorizon,
+    ) -> (Cohort, Vec<Keypair>, [u8; 32]) {
+        let secp = Secp256k1::new();
+        let mut keypairs = Vec::with_capacity(k as usize);
+        let mut members = Vec::with_capacity(k as usize);
+        for i in 0..k {
+            let kp = even_parity_keypair(&secp, (i + 1) as u8);
+            let xonly = kp.x_only_public_key().0.serialize();
+            keypairs.push(kp);
+            members.push(CohortMember {
+                user_id: [i as u8 + 0x80; 32],
+                pk_user: xonly,
+                slot_index: i,
+            });
+        }
+        let cohort_id = [0xab; 32];
+        let cohort = Cohort::new(cohort_id, members, horizon).expect("cohort");
+        (cohort, keypairs, cohort_id)
+    }
+
+    fn build_attest_and_schedule(
+        cohort: &Cohort,
+        asp_kp: &Keypair,
+    ) -> (SlotAttest, PublishedSchedule, [u8; 32]) {
+        let secp = Secp256k1::new();
+        let asp_sk = SecretKey::from_keypair(asp_kp);
+        let setup_id_bytes = [0xc4u8; 32];
+        let (schedule, _retained) =
+            Setup::run(&asp_sk, &setup_id_bytes, cohort.horizon.n).expect("setup");
+        let slot_root = SlotRoot::compute(&cohort.members).0;
+        let unsigned = SlotAttestUnsigned {
+            slot_root,
+            cohort_id: cohort.id,
+            setup_id: setup_id_bytes,
+            n: cohort.horizon.n,
+            k: cohort.k(),
+        };
+        let attest = unsigned.sign(&secp, asp_kp);
+        (attest, schedule, setup_id_bytes)
+    }
+
+    #[test]
+    fn user_board_happy_path_k10_n4() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let asp_xonly = asp_kp.x_only_public_key().0;
+        let horizon = HibernationHorizon::new(4, 12).unwrap();
+        let (cohort, keypairs, _cohort_id) = cohort_with_keypairs(10, horizon);
+        let (attest, schedule, _setup_id) = build_attest_and_schedule(&cohort, &asp_kp);
+
+        let user_idx = 3u32;
+        let user_kp = &keypairs[user_idx as usize];
+
+        let mut rng = StdRng::seed_from_u64(0xface);
+        let artifact = user_board(
+            &cohort, &attest, &asp_xonly, &schedule, user_kp, user_idx, &mut rng,
+        )
+        .expect("user_board");
+
+        assert_eq!(artifact.slot_index, user_idx);
+        assert_eq!(artifact.n, 4);
+        assert_eq!(artifact.presigned.len(), 4);
+        // Every PreSigned must carry well-formed bytes.
+        for ps in &artifact.presigned {
+            assert_eq!(ps.pub_nonce.to_bytes().len(), 66);
+            assert_eq!(ps.partial_sig.to_bytes().len(), 32);
+        }
+
+        // The schedule witness is deterministic in Λ.
+        let again = user_board(
+            &cohort, &attest, &asp_xonly, &schedule, user_kp, user_idx, &mut rng,
+        )
+        .expect("second run");
+        assert_eq!(artifact.schedule_witness, again.schedule_witness);
+    }
+
+    #[test]
+    fn user_board_aborts_on_mutated_lambda() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let asp_xonly = asp_kp.x_only_public_key().0;
+        let horizon = HibernationHorizon::new(4, 12).unwrap();
+        let (cohort, keypairs, _) = cohort_with_keypairs(10, horizon);
+        let (attest, mut schedule, _) = build_attest_and_schedule(&cohort, &asp_kp);
+
+        // Mutate a single byte of the proof in epoch 2, slot 1.
+        schedule.entries[1].proof1[0] ^= 0x01;
+
+        let mut rng = StdRng::seed_from_u64(0xbeef);
+        let err = user_board(
+            &cohort,
+            &attest,
+            &asp_xonly,
+            &schedule,
+            &keypairs[3],
+            3,
+            &mut rng,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, PsarError::ScheduleInvalid { epoch: 2, slot: 1 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn user_board_rejects_mismatched_slot_index() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let asp_xonly = asp_kp.x_only_public_key().0;
+        let horizon = HibernationHorizon::new(4, 12).unwrap();
+        let (cohort, keypairs, _) = cohort_with_keypairs(10, horizon);
+        let (attest, schedule, _) = build_attest_and_schedule(&cohort, &asp_kp);
+
+        let mut rng = StdRng::seed_from_u64(1);
+        let err = user_board(
+            &cohort,
+            &attest,
+            &asp_xonly,
+            &schedule,
+            &keypairs[3],
+            5,
+            &mut rng,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(err, PsarError::PubkeyMismatch { slot_index: 5 }),
+            "got {err:?}"
+        );
+    }
+
+    #[test]
+    fn user_board_rejects_out_of_range_slot() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let asp_xonly = asp_kp.x_only_public_key().0;
+        let horizon = HibernationHorizon::new(4, 12).unwrap();
+        let (cohort, keypairs, _) = cohort_with_keypairs(10, horizon);
+        let (attest, schedule, _) = build_attest_and_schedule(&cohort, &asp_kp);
+
+        let mut rng = StdRng::seed_from_u64(2);
+        let err = user_board(
+            &cohort,
+            &attest,
+            &asp_xonly,
+            &schedule,
+            &keypairs[3],
+            99,
+            &mut rng,
+        )
+        .unwrap_err();
+        assert!(matches!(err, PsarError::SlotIndexOutOfRange { .. }));
+    }
+
+    #[test]
+    fn user_board_rejects_horizon_mismatch() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let asp_xonly = asp_kp.x_only_public_key().0;
+        let horizon = HibernationHorizon::new(4, 12).unwrap();
+        let (cohort, keypairs, _) = cohort_with_keypairs(10, horizon);
+        let (attest, _schedule, setup_id) = build_attest_and_schedule(&cohort, &asp_kp);
+        // Build a schedule with a different horizon.
+        let asp_sk = SecretKey::from_keypair(&asp_kp);
+        let (other_schedule, _) = Setup::run(&asp_sk, &setup_id, 8).unwrap();
+
+        let mut rng = StdRng::seed_from_u64(3);
+        let err = user_board(
+            &cohort,
+            &attest,
+            &asp_xonly,
+            &other_schedule,
+            &keypairs[3],
+            3,
+            &mut rng,
+        )
+        .unwrap_err();
+        assert!(matches!(
+            err,
+            PsarError::HorizonDisagrees {
+                schedule_n: 8,
+                cohort_n: 4,
+            }
+        ));
+    }
+
+    #[test]
+    fn user_board_rejects_tampered_attest_signature() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let asp_xonly = asp_kp.x_only_public_key().0;
+        let horizon = HibernationHorizon::new(4, 12).unwrap();
+        let (cohort, keypairs, _) = cohort_with_keypairs(10, horizon);
+        let (mut attest, schedule, _) = build_attest_and_schedule(&cohort, &asp_kp);
+        attest.sig[0] ^= 0x01;
+
+        let mut rng = StdRng::seed_from_u64(4);
+        let err = user_board(
+            &cohort,
+            &attest,
+            &asp_xonly,
+            &schedule,
+            &keypairs[3],
+            3,
+            &mut rng,
+        )
+        .unwrap_err();
+        assert!(matches!(err, PsarError::AttestationVerify), "got {err:?}");
+    }
+
+    #[test]
+    fn schedule_witness_changes_when_lambda_mutates() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let asp_sk = SecretKey::from_keypair(&asp_kp);
+        let setup_id = [0xc4u8; 32];
+        let (mut schedule, _) = Setup::run(&asp_sk, &setup_id, 4).unwrap();
+        let w0 = compute_schedule_witness(&schedule);
+        schedule.entries[0].r1[0] ^= 0x01;
+        let w1 = compute_schedule_witness(&schedule);
+        assert_ne!(w0, w1);
+    }
+}

--- a/crates/dark-psar/src/boarding.rs
+++ b/crates/dark-psar/src/boarding.rs
@@ -42,7 +42,7 @@ use rand::Rng;
 use secp256k1::{Keypair, Parity, PublicKey, Secp256k1, SecretKey, XOnlyPublicKey};
 use sha2::{Digest, Sha256};
 
-use crate::attest::SlotAttest;
+use crate::attest::{SlotAttest, SlotAttestUnsigned};
 use crate::cohort::Cohort;
 use crate::error::PsarError;
 use crate::message::derive_message_for_epoch;
@@ -265,6 +265,148 @@ fn compute_schedule_witness(schedule: &PublishedSchedule) -> [u8; 32] {
 /// boarding test harness terse.
 pub fn new_secp() -> Secp256k1<secp256k1::All> {
     Secp256k1::new()
+}
+
+// ───────────────────────────────────────────────────────────────────────────
+// ASP-side flow (#671)
+// ───────────────────────────────────────────────────────────────────────────
+
+use std::collections::HashMap;
+
+use dark_von_musig2::setup::{RetainedScalars, Setup};
+
+use crate::cohort::{BoardingState, CohortMember, HibernationHorizon};
+use crate::slot_tree::SlotTree;
+
+/// The artifact of a successful ASP-side boarding flow.
+///
+/// `RetainedScalars` carries the operator-only scalars `{r_{t,b}}` and
+/// auto-zeroizes on drop; do not serialize or transport this struct
+/// outside the ASP's process.
+pub struct ActiveCohort {
+    pub cohort: Cohort,
+    pub retained: RetainedScalars,
+    pub schedule: PublishedSchedule,
+    pub setup_id: [u8; 32],
+    pub slot_root: SlotRoot,
+    pub attest: SlotAttest,
+    /// 32-byte raw txid of the on-chain publication, if step 4 of the
+    /// flow ran (regtest only). `None` for off-chain-only flows used by
+    /// unit tests and the K=100/N=12 happy path.
+    pub publish_txid: Option<[u8; 32]>,
+    /// User boarding artifacts keyed by `user_id`.
+    pub artifacts: HashMap<[u8; 32], UserBoardingArtifact>,
+}
+
+/// ASP-side boarding (#671).
+///
+/// This is the off-chain orchestration entry point: it runs Setup,
+/// builds the slot tree, signs `SlotAttest`, and drives every member
+/// through `user_board`, producing an [`ActiveCohort`] in the
+/// `Active` state. On-chain publication of `SlotAttest` (step 4 of
+/// the issue text) is decoupled into [`asp_publish_attest`] so this
+/// function stays buildable without the `regtest` feature; the test
+/// harness at K=100/N=12 exercises the off-chain path.
+///
+/// The convenience signature accepts user keypairs alongside members
+/// — phase 5 (CLI) will replace this with a network-driven collector
+/// that streams `UserBoardingArtifact`s back from each user.
+pub fn asp_board<R: Rng + ?Sized>(
+    asp_kp: &Keypair,
+    cohort_id: [u8; 32],
+    members_and_keys: Vec<(CohortMember, Keypair)>,
+    horizon: HibernationHorizon,
+    setup_id: [u8; 32],
+    publish_txid: Option<[u8; 32]>,
+    rng: &mut R,
+) -> Result<ActiveCohort, PsarError> {
+    if members_and_keys.is_empty() {
+        return Err(PsarError::EmptyCohort);
+    }
+
+    let secp = Secp256k1::new();
+    let asp_xonly = asp_kp.x_only_public_key().0;
+    let (members, user_keys): (Vec<_>, Vec<_>) = members_and_keys.into_iter().unzip();
+
+    // ─── 1. Cohort + state machine ───────────────────────────────────
+    let mut cohort = Cohort::new(cohort_id, members, horizon)?;
+
+    // ─── 2. Setup phase: Λ + retained scalars ────────────────────────
+    let asp_sk = SecretKey::from_keypair(asp_kp);
+    let (schedule, retained) = Setup::run(&asp_sk, &setup_id, horizon.n)?;
+
+    // ─── 3. Slot tree + SlotAttest signing ───────────────────────────
+    let tree = SlotTree::from_members(&cohort.members);
+    let slot_root = tree.root();
+    let unsigned = SlotAttestUnsigned {
+        slot_root: slot_root.0,
+        cohort_id,
+        setup_id,
+        n: horizon.n,
+        k: cohort.k(),
+    };
+    let attest = unsigned.sign(&secp, asp_kp);
+    cohort.slot_root = Some(slot_root.0);
+    cohort.transition(BoardingState::Committed)?;
+
+    // ─── 4. (External) publish SlotAttest on regtest ─────────────────
+    // Caller wires this via asp_publish_attest behind the `regtest`
+    // feature. The optional `publish_txid` argument captures the
+    // returned Txid.
+
+    // ─── 5. Drive each user through user_board ───────────────────────
+    let mut artifacts: HashMap<[u8; 32], UserBoardingArtifact> = HashMap::new();
+    // Iterate by slot_index from the cohort's authoritative member
+    // list so the per-user keypair lookup matches the slot it occupies.
+    let user_kps_by_slot: HashMap<u32, &Keypair> = cohort
+        .members
+        .iter()
+        .zip(user_keys.iter())
+        .map(|(m, kp)| (m.slot_index, kp))
+        .collect();
+    for member in &cohort.members {
+        let kp = user_kps_by_slot
+            .get(&member.slot_index)
+            .ok_or(PsarError::PubkeyMismatch {
+                slot_index: member.slot_index,
+            })?;
+        let artifact = user_board(
+            &cohort,
+            &attest,
+            &asp_xonly,
+            &schedule,
+            kp,
+            member.slot_index,
+            rng,
+        )?;
+        artifacts.insert(member.user_id, artifact);
+    }
+    cohort.transition(BoardingState::Active)?;
+
+    Ok(ActiveCohort {
+        cohort,
+        retained,
+        schedule,
+        setup_id,
+        slot_root,
+        attest,
+        publish_txid,
+        artifacts,
+    })
+}
+
+/// Publish an `ActiveCohort`'s [`SlotAttest`] on-chain via OP_RETURN
+/// and stamp the resulting txid into `publish_txid`. Behind the
+/// `regtest` feature.
+#[cfg(feature = "regtest")]
+pub fn asp_publish_attest(
+    client: &bitcoincore_rpc::Client,
+    active: &mut ActiveCohort,
+) -> Result<bitcoin::Txid, crate::publish::PublishError> {
+    use bitcoin::hashes::Hash;
+    let txid = crate::publish::publish_slot_attest(client, &active.attest)?;
+    active.publish_txid = Some(*txid.as_raw_hash().as_byte_array());
+    Ok(txid)
 }
 
 #[cfg(test)]
@@ -517,5 +659,147 @@ mod tests {
         schedule.entries[0].r1[0] ^= 0x01;
         let w1 = compute_schedule_witness(&schedule);
         assert_ne!(w0, w1);
+    }
+
+    // ─── ASP-side flow tests (#671) ────────────────────────────────────
+
+    fn cohort_with_kp_pairs(k: u32) -> (Vec<(CohortMember, Keypair)>, [u8; 32]) {
+        let secp = Secp256k1::new();
+        let mut out = Vec::with_capacity(k as usize);
+        for i in 0..k {
+            let kp = even_parity_keypair(&secp, (i + 1) as u8);
+            let xonly = kp.x_only_public_key().0.serialize();
+            out.push((
+                CohortMember {
+                    user_id: [(i & 0xff) as u8; 32],
+                    pk_user: xonly,
+                    slot_index: i,
+                },
+                kp,
+            ));
+        }
+        // Spread user_ids beyond `K=255` so tests never duplicate them.
+        for (idx, (m, _)) in out.iter_mut().enumerate() {
+            m.user_id[0] = ((idx >> 8) & 0xff) as u8;
+            m.user_id[1] = (idx & 0xff) as u8;
+        }
+        (out, [0xab; 32])
+    }
+
+    #[test]
+    fn asp_board_happy_path_k4_n2() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let horizon = HibernationHorizon::new(2, 12).unwrap();
+        let (members_kps, cohort_id) = cohort_with_kp_pairs(4);
+        let mut rng = StdRng::seed_from_u64(0xdead_beef);
+        let active = asp_board(
+            &asp_kp,
+            cohort_id,
+            members_kps,
+            horizon,
+            [0xc4; 32],
+            None,
+            &mut rng,
+        )
+        .expect("asp_board");
+
+        assert_eq!(active.cohort.k(), 4);
+        assert_eq!(active.cohort.state(), BoardingState::Active);
+        assert_eq!(active.artifacts.len(), 4);
+        assert_eq!(active.schedule.n, 2);
+        assert!(active.publish_txid.is_none());
+        // Schedule witness across all artifacts is identical (same Λ).
+        let witnesses: std::collections::HashSet<[u8; 32]> = active
+            .artifacts
+            .values()
+            .map(|a| a.schedule_witness)
+            .collect();
+        assert_eq!(witnesses.len(), 1, "all users should witness the same Λ");
+    }
+
+    #[test]
+    fn asp_board_rejects_empty_member_set() {
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let horizon = HibernationHorizon::new(2, 12).unwrap();
+        let mut rng = StdRng::seed_from_u64(1);
+        let result = asp_board(
+            &asp_kp,
+            [0; 32],
+            Vec::new(),
+            horizon,
+            [0xc4; 32],
+            None,
+            &mut rng,
+        );
+        match result {
+            Err(PsarError::EmptyCohort) => {}
+            Err(other) => panic!("expected EmptyCohort, got {other:?}"),
+            Ok(_) => panic!("expected EmptyCohort error, got Ok"),
+        }
+    }
+
+    #[test]
+    fn asp_board_k100_n12_under_60_seconds() {
+        // Issue #671 acceptance: K=100, N=12 ASP-side flow runs to
+        // ActiveCohort under 60 s on dev hardware.
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0xaa);
+        let horizon = HibernationHorizon::new(12, 12).unwrap();
+        let (members_kps, cohort_id) = cohort_with_kp_pairs(100);
+        let mut rng = StdRng::seed_from_u64(0xdada);
+
+        let start = std::time::Instant::now();
+        let active = asp_board(
+            &asp_kp,
+            cohort_id,
+            members_kps,
+            horizon,
+            [0xc4; 32],
+            None,
+            &mut rng,
+        )
+        .expect("asp_board K=100 N=12");
+        let elapsed = start.elapsed();
+
+        assert_eq!(active.cohort.k(), 100);
+        assert_eq!(active.cohort.state(), BoardingState::Active);
+        assert_eq!(active.artifacts.len(), 100);
+        for art in active.artifacts.values() {
+            assert_eq!(art.n, 12);
+            assert_eq!(art.presigned.len(), 12);
+        }
+        assert!(
+            elapsed.as_secs() < 60,
+            "K=100/N=12 took {elapsed:?} (acceptance budget: 60 s)"
+        );
+    }
+
+    #[test]
+    fn asp_board_persists_into_in_memory_store() {
+        use crate::store::{ActiveCohortStore, InMemoryActiveCohortStore};
+        let secp = Secp256k1::new();
+        let asp_kp = even_parity_keypair(&secp, 0x77);
+        let horizon = HibernationHorizon::new(2, 12).unwrap();
+        let (members_kps, cohort_id) = cohort_with_kp_pairs(3);
+        let mut rng = StdRng::seed_from_u64(2);
+        let active = asp_board(
+            &asp_kp,
+            cohort_id,
+            members_kps,
+            horizon,
+            [0xc4; 32],
+            Some([0x42; 32]),
+            &mut rng,
+        )
+        .unwrap();
+
+        let mut store = InMemoryActiveCohortStore::new();
+        store.save(active).unwrap();
+        let loaded = store.load(&cohort_id).expect("loaded");
+        assert_eq!(loaded.cohort.k(), 3);
+        assert_eq!(loaded.publish_txid, Some([0x42; 32]));
+        assert_eq!(store.all().len(), 1);
     }
 }

--- a/crates/dark-psar/src/cohort.rs
+++ b/crates/dark-psar/src/cohort.rs
@@ -279,10 +279,8 @@ mod tests {
     #[test]
     fn cohort_new_rejects_empty_member_list() {
         let h = HibernationHorizon::new(1, 12).unwrap();
-        assert_eq!(
-            Cohort::new([0u8; 32], vec![], h),
-            Err(PsarError::EmptyCohort)
-        );
+        let err = Cohort::new([0u8; 32], vec![], h).unwrap_err();
+        assert!(matches!(err, PsarError::EmptyCohort));
     }
 
     #[test]
@@ -319,7 +317,7 @@ mod tests {
             slot_index: 1,
         };
         let err = Cohort::new([0u8; 32], vec![member(9, 0), dup], h).unwrap_err();
-        assert_eq!(err, PsarError::DuplicateUserId);
+        assert!(matches!(err, PsarError::DuplicateUserId));
     }
 
     #[test]
@@ -341,13 +339,13 @@ mod tests {
         let h = HibernationHorizon::new(1, 12).unwrap();
         let mut c = Cohort::new([0u8; 32], vec![member(1, 0)], h).unwrap();
         let err = c.transition(BoardingState::Active).unwrap_err();
-        assert_eq!(
+        assert!(matches!(
             err,
             PsarError::InvalidBoardingState {
                 from: BoardingState::Forming,
                 to: BoardingState::Active,
             }
-        );
+        ));
     }
 
     #[test]

--- a/crates/dark-psar/src/cohort.rs
+++ b/crates/dark-psar/src/cohort.rs
@@ -1,0 +1,394 @@
+//! Cohort and horizon types (issue #666).
+//!
+//! A *cohort* is the set of users boarded together for one PSAR
+//! lifecycle: their identities, the slot they occupy in the cohort's
+//! Merkle tree (see `slot_tree`, #667), and the horizon `N` of
+//! per-epoch renewals they pre-signed.
+//!
+//! The horizon `N` is a **runtime parameter** carried by
+//! [`HibernationHorizon`] and validated against `max_n` at construction
+//! time. The type layer does not pin a particular `N`: callers — paper
+//! benchmarks at `N ∈ {4, 12, 50}`, integration tests at `N=12`,
+//! production at whatever the operator chooses — all flow through the
+//! same types.
+//!
+//! [`BoardingState`] enforces a one-way state machine:
+//!
+//! ```text
+//! Forming → Committed → Active → Concluded
+//! ```
+//!
+//! Any other transition (including same-state transitions) returns
+//! [`PsarError::InvalidBoardingState`]. The `Cohort` value owns the
+//! state and exposes [`Cohort::transition`] as the only mutator.
+
+use serde::{Deserialize, Serialize};
+
+use crate::error::PsarError;
+
+/// Maximum `max_n` accepted by [`HibernationHorizon::new`].
+///
+/// Mirrors `dark_von::schedule::MAX_HORIZON` semantically (256 slots);
+/// pinning the cap here keeps `dark_psar` independent of the VON crate
+/// for the type layer. Callers that want a tighter local cap can
+/// always pick a smaller `max_n`.
+pub const MAX_HORIZON: u32 = 256;
+
+/// Maximum cohort size accepted by [`Cohort::new`].
+///
+/// PSAR's design point is `K ∈ {100, 1000, 10000}` (paper §4); we cap
+/// at 1<<20 = 1 048 576 to keep the slot-Merkle-tree depth bounded
+/// without baking a small constant in. Callers benchmarking larger
+/// cohorts can lift this cap in a follow-up.
+pub const MAX_COHORT_SIZE: u32 = 1 << 20;
+
+/// A user in the cohort.
+///
+/// `user_id` is an opaque 32-byte identifier (typically the SHA-256 of
+/// a user-provided handle or the operator's row id); `pk_user` is the
+/// user's BIP-340 x-only public key as raw bytes (32 B);
+/// `slot_index` is the user's position in the cohort's slot tree
+/// (#667), constrained to `[0, K)` where `K = members.len()`.
+///
+/// We avoid pulling in `bitcoin::key::XOnlyPublicKey` here so this
+/// crate stays buildable without any of the Bitcoin / `secp256k1`
+/// stack — that dependency lands in `slot_tree.rs` (#667) where the
+/// hash construction needs it.
+#[derive(Clone, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct CohortMember {
+    /// 32-byte opaque user identifier.
+    pub user_id: [u8; 32],
+    /// 32-byte BIP-340 x-only public key.
+    pub pk_user: [u8; 32],
+    /// Position in the cohort slot tree.
+    pub slot_index: u32,
+}
+
+/// Hibernation horizon: how many epochs of renewals this cohort has
+/// pre-signed.
+///
+/// `n` is the active horizon (`n ≥ 1`); `max_n` is the per-cohort cap
+/// validated against [`MAX_HORIZON`]. Both are runtime values; nothing
+/// in the type layer pins a constant `N`.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub struct HibernationHorizon {
+    pub n: u32,
+    pub max_n: u32,
+}
+
+impl HibernationHorizon {
+    /// Construct a horizon, validating `1 ≤ n ≤ max_n ≤ MAX_HORIZON`.
+    pub fn new(n: u32, max_n: u32) -> Result<Self, PsarError> {
+        if max_n == 0 || max_n > MAX_HORIZON {
+            return Err(PsarError::HorizonOutOfRange {
+                n: max_n,
+                max_n: MAX_HORIZON,
+            });
+        }
+        if n == 0 || n > max_n {
+            return Err(PsarError::HorizonOutOfRange { n, max_n });
+        }
+        Ok(Self { n, max_n })
+    }
+}
+
+/// One-way lifecycle of a cohort.
+///
+/// `Forming` is the only state in which new members can be added.
+/// `Committed` is reached once the slot Merkle tree has been built and
+/// the [`SlotAttest`](crate) has been published (phase 3, #667–#669).
+/// `Active` is reached once every user has handed back their
+/// pre-signed material (phase 3, #670–#671). `Concluded` is reached
+/// once all `N` epochs have been processed (phase 4, #672–#675).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum BoardingState {
+    Forming,
+    Committed,
+    Active,
+    Concluded,
+}
+
+impl BoardingState {
+    /// `true` iff `self → next` is a legal transition.
+    fn allows(self, next: BoardingState) -> bool {
+        matches!(
+            (self, next),
+            (BoardingState::Forming, BoardingState::Committed)
+                | (BoardingState::Committed, BoardingState::Active)
+                | (BoardingState::Active, BoardingState::Concluded)
+        )
+    }
+}
+
+/// A cohort with `K` members boarding for a hibernation horizon of `N`.
+///
+/// Construction validates the horizon, member-count cap, slot-index
+/// uniqueness and range, and `user_id` uniqueness. The slot Merkle root
+/// is filled in once the slot tree (#667) commits — until then it is
+/// `None` and the state stays `Forming`.
+#[derive(Clone, Debug, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Cohort {
+    /// Caller-supplied 32-byte cohort identifier (typically the SHA-256
+    /// of `setup_id || start_height` or similar — bound to a value the
+    /// ASP commits to before the cohort starts forming).
+    pub id: [u8; 32],
+    pub members: Vec<CohortMember>,
+    pub horizon: HibernationHorizon,
+    /// Filled in by `slot_tree::SlotRoot::compute` (#667) when the
+    /// cohort transitions `Forming → Committed`.
+    pub slot_root: Option<[u8; 32]>,
+    state: BoardingState,
+}
+
+impl Cohort {
+    /// Build a `Forming` cohort, validating member-set invariants.
+    ///
+    /// Fails with [`PsarError::EmptyCohort`] on an empty member list,
+    /// [`PsarError::TooManyMembers`] above [`MAX_COHORT_SIZE`],
+    /// [`PsarError::DuplicateSlotIndex`] / [`PsarError::SlotIndexOutOfRange`]
+    /// on slot-index issues, or [`PsarError::DuplicateUserId`] on
+    /// repeated `user_id`. The horizon must already be valid (built
+    /// via [`HibernationHorizon::new`]).
+    pub fn new(
+        id: [u8; 32],
+        members: Vec<CohortMember>,
+        horizon: HibernationHorizon,
+    ) -> Result<Self, PsarError> {
+        if members.is_empty() {
+            return Err(PsarError::EmptyCohort);
+        }
+        let k = members.len() as u64;
+        if k > MAX_COHORT_SIZE as u64 {
+            return Err(PsarError::TooManyMembers {
+                k: members.len() as u32,
+                max_k: MAX_COHORT_SIZE,
+            });
+        }
+        let k_u32 = members.len() as u32;
+        // O(K log K) uniqueness via sort-projected indices; we copy
+        // 32-byte user_ids out for ordering since CohortMember is
+        // borrowed elsewhere.
+        let mut slots: Vec<u32> = members.iter().map(|m| m.slot_index).collect();
+        slots.sort_unstable();
+        for window in slots.windows(2) {
+            if window[0] == window[1] {
+                return Err(PsarError::DuplicateSlotIndex {
+                    slot_index: window[0],
+                });
+            }
+        }
+        for &s in &slots {
+            if s >= k_u32 {
+                return Err(PsarError::SlotIndexOutOfRange {
+                    slot_index: s,
+                    k: k_u32,
+                });
+            }
+        }
+        let mut user_ids: Vec<[u8; 32]> = members.iter().map(|m| m.user_id).collect();
+        user_ids.sort_unstable();
+        for window in user_ids.windows(2) {
+            if window[0] == window[1] {
+                return Err(PsarError::DuplicateUserId);
+            }
+        }
+        Ok(Self {
+            id,
+            members,
+            horizon,
+            slot_root: None,
+            state: BoardingState::Forming,
+        })
+    }
+
+    /// Number of members `K`.
+    pub fn k(&self) -> u32 {
+        self.members.len() as u32
+    }
+
+    /// Current lifecycle state.
+    pub fn state(&self) -> BoardingState {
+        self.state
+    }
+
+    /// Move to `next`, enforcing the legal transition table.
+    pub fn transition(&mut self, next: BoardingState) -> Result<(), PsarError> {
+        if !self.state.allows(next) {
+            return Err(PsarError::InvalidBoardingState {
+                from: self.state,
+                to: next,
+            });
+        }
+        self.state = next;
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn member(seed: u8, slot: u32) -> CohortMember {
+        CohortMember {
+            user_id: [seed; 32],
+            pk_user: [seed.wrapping_add(1); 32],
+            slot_index: slot,
+        }
+    }
+
+    #[test]
+    fn horizon_new_accepts_typical_paper_values() {
+        for n in [1u32, 4, 12, 50, 256] {
+            let h = HibernationHorizon::new(n, 256).expect("valid horizon");
+            assert_eq!(h.n, n);
+            assert_eq!(h.max_n, 256);
+        }
+    }
+
+    #[test]
+    fn horizon_new_rejects_zero_n() {
+        let err = HibernationHorizon::new(0, 12).unwrap_err();
+        assert!(matches!(err, PsarError::HorizonOutOfRange { n: 0, .. }));
+    }
+
+    #[test]
+    fn horizon_new_rejects_n_above_max_n() {
+        let err = HibernationHorizon::new(13, 12).unwrap_err();
+        assert!(matches!(
+            err,
+            PsarError::HorizonOutOfRange { n: 13, max_n: 12 }
+        ));
+    }
+
+    #[test]
+    fn horizon_new_rejects_max_n_above_global_cap() {
+        let err = HibernationHorizon::new(1, MAX_HORIZON + 1).unwrap_err();
+        assert!(matches!(err, PsarError::HorizonOutOfRange { .. }));
+    }
+
+    #[test]
+    fn cohort_new_happy_path_two_members() {
+        let h = HibernationHorizon::new(4, 12).unwrap();
+        let c = Cohort::new([0x11; 32], vec![member(1, 0), member(2, 1)], h).unwrap();
+        assert_eq!(c.k(), 2);
+        assert_eq!(c.state(), BoardingState::Forming);
+        assert!(c.slot_root.is_none());
+    }
+
+    #[test]
+    fn cohort_new_rejects_empty_member_list() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        assert_eq!(
+            Cohort::new([0u8; 32], vec![], h),
+            Err(PsarError::EmptyCohort)
+        );
+    }
+
+    #[test]
+    fn cohort_new_rejects_duplicate_slot_index() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        let err = Cohort::new([0u8; 32], vec![member(1, 0), member(2, 0)], h).unwrap_err();
+        assert!(matches!(
+            err,
+            PsarError::DuplicateSlotIndex { slot_index: 0 }
+        ));
+    }
+
+    #[test]
+    fn cohort_new_rejects_slot_index_out_of_range() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        // Two members but slot_index = 2 (must be in [0, 2)).
+        let err = Cohort::new([0u8; 32], vec![member(1, 0), member(2, 2)], h).unwrap_err();
+        assert!(matches!(
+            err,
+            PsarError::SlotIndexOutOfRange {
+                slot_index: 2,
+                k: 2
+            }
+        ));
+    }
+
+    #[test]
+    fn cohort_new_rejects_duplicate_user_id() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        // Same user_id, distinct slots — the user-id dedup must still catch it.
+        let dup = CohortMember {
+            user_id: [9u8; 32],
+            pk_user: [10u8; 32],
+            slot_index: 1,
+        };
+        let err = Cohort::new([0u8; 32], vec![member(9, 0), dup], h).unwrap_err();
+        assert_eq!(err, PsarError::DuplicateUserId);
+    }
+
+    #[test]
+    fn boarding_state_legal_transitions_full_cycle() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        let mut c = Cohort::new([0u8; 32], vec![member(1, 0)], h).unwrap();
+        for next in [
+            BoardingState::Committed,
+            BoardingState::Active,
+            BoardingState::Concluded,
+        ] {
+            c.transition(next).expect("legal transition");
+            assert_eq!(c.state(), next);
+        }
+    }
+
+    #[test]
+    fn boarding_state_rejects_skip_forming_to_active() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        let mut c = Cohort::new([0u8; 32], vec![member(1, 0)], h).unwrap();
+        let err = c.transition(BoardingState::Active).unwrap_err();
+        assert_eq!(
+            err,
+            PsarError::InvalidBoardingState {
+                from: BoardingState::Forming,
+                to: BoardingState::Active,
+            }
+        );
+    }
+
+    #[test]
+    fn boarding_state_rejects_self_transition() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        let mut c = Cohort::new([0u8; 32], vec![member(1, 0)], h).unwrap();
+        let err = c.transition(BoardingState::Forming).unwrap_err();
+        assert!(matches!(err, PsarError::InvalidBoardingState { .. }));
+    }
+
+    #[test]
+    fn boarding_state_rejects_backward_transition() {
+        let h = HibernationHorizon::new(1, 12).unwrap();
+        let mut c = Cohort::new([0u8; 32], vec![member(1, 0)], h).unwrap();
+        c.transition(BoardingState::Committed).unwrap();
+        let err = c.transition(BoardingState::Forming).unwrap_err();
+        assert!(matches!(err, PsarError::InvalidBoardingState { .. }));
+    }
+
+    proptest! {
+        #[test]
+        fn horizon_serde_round_trip(n in 1u32..=256, max_n in 1u32..=256) {
+            // Discard generator pairs where n > max_n.
+            prop_assume!(n <= max_n);
+            let h = HibernationHorizon::new(n, max_n).expect("valid horizon");
+            let json = serde_json::to_string(&h).unwrap();
+            let parsed: HibernationHorizon = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(parsed, h);
+        }
+
+        #[test]
+        fn boarding_state_serde_round_trip(s in 0u8..4u8) {
+            let state = match s {
+                0 => BoardingState::Forming,
+                1 => BoardingState::Committed,
+                2 => BoardingState::Active,
+                _ => BoardingState::Concluded,
+            };
+            let json = serde_json::to_string(&state).unwrap();
+            let parsed: BoardingState = serde_json::from_str(&json).unwrap();
+            prop_assert_eq!(parsed, state);
+        }
+    }
+}

--- a/crates/dark-psar/src/error.rs
+++ b/crates/dark-psar/src/error.rs
@@ -4,7 +4,7 @@ use thiserror::Error;
 
 use crate::cohort::BoardingState;
 
-#[derive(Debug, Error, PartialEq, Eq)]
+#[derive(Debug, Error)]
 #[non_exhaustive]
 pub enum PsarError {
     #[error("horizon n={n} is outside [1, {max_n}]")]
@@ -30,4 +30,32 @@ pub enum PsarError {
         from: BoardingState,
         to: BoardingState,
     },
+
+    #[error("schedule entry invalid at epoch {epoch}, slot {slot}")]
+    ScheduleInvalid { epoch: u32, slot: u8 },
+
+    #[error("slot {slot_index} commits to a different pubkey than the user's keypair")]
+    PubkeyMismatch { slot_index: u32 },
+
+    #[error("slot root in attestation does not match recomputed slot root")]
+    SlotRootMismatch,
+
+    #[error("attestation signature failed to verify")]
+    AttestationVerify,
+
+    #[error("schedule horizon n={schedule_n} disagrees with cohort horizon n={cohort_n}")]
+    HorizonDisagrees { schedule_n: u32, cohort_n: u32 },
+
+    #[error("attestation field {field} disagrees with cohort: attest={attest_value}, cohort={cohort_value}")]
+    AttestationFieldMismatch {
+        field: &'static str,
+        attest_value: u32,
+        cohort_value: u32,
+    },
+
+    #[error("dark-von-musig2 error during boarding")]
+    VonMusig2(#[from] dark_von_musig2::VonMusig2Error),
+
+    #[error("user keypair has odd parity; PSAR requires BIP-340 even-parity normalization")]
+    OddParity,
 }

--- a/crates/dark-psar/src/error.rs
+++ b/crates/dark-psar/src/error.rs
@@ -1,0 +1,33 @@
+//! Crate error type.
+
+use thiserror::Error;
+
+use crate::cohort::BoardingState;
+
+#[derive(Debug, Error, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PsarError {
+    #[error("horizon n={n} is outside [1, {max_n}]")]
+    HorizonOutOfRange { n: u32, max_n: u32 },
+
+    #[error("cohort has no members")]
+    EmptyCohort,
+
+    #[error("cohort member count {k} exceeds maximum {max_k}")]
+    TooManyMembers { k: u32, max_k: u32 },
+
+    #[error("duplicate slot index {slot_index} in cohort")]
+    DuplicateSlotIndex { slot_index: u32 },
+
+    #[error("duplicate user id in cohort")]
+    DuplicateUserId,
+
+    #[error("slot index {slot_index} is out of range for cohort of size {k}")]
+    SlotIndexOutOfRange { slot_index: u32, k: u32 },
+
+    #[error("invalid boarding-state transition from {from:?} to {to:?}")]
+    InvalidBoardingState {
+        from: BoardingState,
+        to: BoardingState,
+    },
+}

--- a/crates/dark-psar/src/lib.rs
+++ b/crates/dark-psar/src/lib.rs
@@ -27,10 +27,12 @@ pub mod message;
 #[cfg(feature = "regtest")]
 pub mod publish;
 pub mod slot_tree;
+pub mod store;
 
 pub use attest::{SlotAttest, SlotAttestError, SlotAttestUnsigned};
-pub use boarding::{user_board, UserBoardingArtifact};
+pub use boarding::{asp_board, user_board, ActiveCohort, UserBoardingArtifact};
 pub use cohort::{BoardingState, Cohort, CohortMember, HibernationHorizon};
 pub use error::PsarError;
 pub use message::derive_message_for_epoch;
 pub use slot_tree::{Side, Slot, SlotInclusionProof, SlotRoot, SlotTree};
+pub use store::{ActiveCohortStore, InMemoryActiveCohortStore};

--- a/crates/dark-psar/src/lib.rs
+++ b/crates/dark-psar/src/lib.rs
@@ -20,13 +20,17 @@
 #![forbid(unsafe_code)]
 
 pub mod attest;
+pub mod boarding;
 pub mod cohort;
 pub mod error;
+pub mod message;
 #[cfg(feature = "regtest")]
 pub mod publish;
 pub mod slot_tree;
 
 pub use attest::{SlotAttest, SlotAttestError, SlotAttestUnsigned};
+pub use boarding::{user_board, UserBoardingArtifact};
 pub use cohort::{BoardingState, Cohort, CohortMember, HibernationHorizon};
 pub use error::PsarError;
+pub use message::derive_message_for_epoch;
 pub use slot_tree::{Side, Slot, SlotInclusionProof, SlotRoot, SlotTree};

--- a/crates/dark-psar/src/lib.rs
+++ b/crates/dark-psar/src/lib.rs
@@ -19,10 +19,12 @@
 
 #![forbid(unsafe_code)]
 
+pub mod attest;
 pub mod cohort;
 pub mod error;
 pub mod slot_tree;
 
+pub use attest::{SlotAttest, SlotAttestError, SlotAttestUnsigned};
 pub use cohort::{BoardingState, Cohort, CohortMember, HibernationHorizon};
 pub use error::PsarError;
 pub use slot_tree::{Side, Slot, SlotInclusionProof, SlotRoot, SlotTree};

--- a/crates/dark-psar/src/lib.rs
+++ b/crates/dark-psar/src/lib.rs
@@ -1,0 +1,26 @@
+//! PSAR boarding-and-horizon protocol layer.
+//!
+//! Phase 3 (#666–#671) lands the structures the ASP and users need to
+//! agree on a *cohort* — a set of users boarded together for a horizon
+//! of `N` epochs — without baking `N` into the type system. The crate
+//! is consumed by phases 4 (per-epoch processing) and 5 (CLI / demo
+//! integration); it has no dependency on the rest of the workspace
+//! beyond [`dark_von`] and [`dark_von_musig2`] in the boarding modules.
+//!
+//! Crate-level invariants:
+//!
+//! - `#![forbid(unsafe_code)]`.
+//! - Public functions return `Result<_, PsarError>` per
+//!   `docs/conventions/errors.md`.
+//! - **No `const N`**. The horizon `N` flows through
+//!   [`cohort::HibernationHorizon`] and is validated against a
+//!   per-cohort `max_n` cap; nothing in the type layer fixes a
+//!   particular `N`.
+
+#![forbid(unsafe_code)]
+
+pub mod cohort;
+pub mod error;
+
+pub use cohort::{BoardingState, Cohort, CohortMember, HibernationHorizon};
+pub use error::PsarError;

--- a/crates/dark-psar/src/lib.rs
+++ b/crates/dark-psar/src/lib.rs
@@ -21,6 +21,8 @@
 
 pub mod cohort;
 pub mod error;
+pub mod slot_tree;
 
 pub use cohort::{BoardingState, Cohort, CohortMember, HibernationHorizon};
 pub use error::PsarError;
+pub use slot_tree::{Side, Slot, SlotInclusionProof, SlotRoot, SlotTree};

--- a/crates/dark-psar/src/lib.rs
+++ b/crates/dark-psar/src/lib.rs
@@ -22,6 +22,8 @@
 pub mod attest;
 pub mod cohort;
 pub mod error;
+#[cfg(feature = "regtest")]
+pub mod publish;
 pub mod slot_tree;
 
 pub use attest::{SlotAttest, SlotAttestError, SlotAttestUnsigned};

--- a/crates/dark-psar/src/message.rs
+++ b/crates/dark-psar/src/message.rs
@@ -1,0 +1,95 @@
+//! Per-epoch message derivation `m_t` (issue #670).
+//!
+//! For each epoch `t ∈ [1, n]` the user pre-signs and the operator
+//! signs against a deterministic 32-byte digest `m_t`. Phase 3 derives
+//! `m_t` from the cohort context and epoch counter alone:
+//!
+//! ```text
+//! m_t = tagged_hash(
+//!     b"DarkPsarMsgV1",
+//!     slot_root (32 B) || cohort_id (32 B) || setup_id (32 B) || t (4 B LE u32)
+//! )
+//! ```
+//!
+//! Phase 4 (#672) will add the *cohort batch tree structure* into the
+//! preimage, binding `m_t` to the user's specific position in the
+//! cohort's UTXO output tree. To keep the wire format orthogonal, that
+//! work will use a distinct tag (`b"DarkPsarMsgV2"` or similar) so the
+//! V1 inputs we lock here never collide with the V2 inputs.
+
+use sha2::{Digest, Sha256};
+
+pub const MESSAGE_TAG: &[u8] = b"DarkPsarMsgV1";
+
+/// Derive the per-epoch message digest `m_t`.
+pub fn derive_message_for_epoch(
+    slot_root: &[u8; 32],
+    cohort_id: &[u8; 32],
+    setup_id: &[u8; 32],
+    t: u32,
+) -> [u8; 32] {
+    let tag_hash = Sha256::digest(MESSAGE_TAG);
+    let mut hasher = Sha256::new();
+    hasher.update(tag_hash);
+    hasher.update(tag_hash);
+    hasher.update(slot_root);
+    hasher.update(cohort_id);
+    hasher.update(setup_id);
+    hasher.update(t.to_le_bytes());
+    hasher.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn pinned_tag_value() {
+        assert_eq!(MESSAGE_TAG, b"DarkPsarMsgV1");
+    }
+
+    #[test]
+    fn determinism() {
+        let s = [0x11; 32];
+        let c = [0x22; 32];
+        let i = [0x33; 32];
+        assert_eq!(
+            derive_message_for_epoch(&s, &c, &i, 7),
+            derive_message_for_epoch(&s, &c, &i, 7),
+        );
+    }
+
+    #[test]
+    fn distinct_inputs_distinct_outputs() {
+        let s = [0x11; 32];
+        let c = [0x22; 32];
+        let i = [0x33; 32];
+        assert_ne!(
+            derive_message_for_epoch(&s, &c, &i, 1),
+            derive_message_for_epoch(&s, &c, &i, 2),
+        );
+        assert_ne!(
+            derive_message_for_epoch(&s, &c, &i, 1),
+            derive_message_for_epoch(&[0x99; 32], &c, &i, 1),
+        );
+        assert_ne!(
+            derive_message_for_epoch(&s, &c, &i, 1),
+            derive_message_for_epoch(&s, &[0xaa; 32], &i, 1),
+        );
+        assert_ne!(
+            derive_message_for_epoch(&s, &c, &i, 1),
+            derive_message_for_epoch(&s, &c, &[0xbb; 32], 1),
+        );
+    }
+
+    #[test]
+    fn t_endianness_is_little() {
+        let s = [0u8; 32];
+        let c = [0u8; 32];
+        let i = [0u8; 32];
+        assert_ne!(
+            derive_message_for_epoch(&s, &c, &i, 1),
+            derive_message_for_epoch(&s, &c, &i, 0x0100_0000),
+        );
+    }
+}

--- a/crates/dark-psar/src/publish.rs
+++ b/crates/dark-psar/src/publish.rs
@@ -1,0 +1,257 @@
+//! Regtest publication of a [`SlotAttest`] via OP_RETURN (issue #669).
+//!
+//! Behind the `regtest` feature flag — production publication needs
+//! a different path (e.g. Taproot annex, commit-then-reveal) since
+//! mainnet OP_RETURN standardness still caps single payloads. The
+//! flow here is:
+//!
+//! 1. List unspent UTXOs from the bitcoind wallet (`listunspent`).
+//! 2. Pick the first UTXO with `value ≥ attest_amount + change_dust + fee`.
+//! 3. Build a single-input, two-output raw tx:
+//!    - `output[0]`: 0-value OP_RETURN with
+//!      [`SlotAttest::op_return_payload`] (68 B).
+//!    - `output[1]`: P2WPKH change back to a fresh wallet address.
+//! 4. Sign via `signrawtransactionwithwallet` (the bitcoind wallet
+//!    holds the input UTXO's key).
+//! 5. Broadcast via `sendrawtransaction`.
+//!
+//! # Deviation from issue text
+//!
+//! Issue #669 prescribes
+//! `publish_slot_attest(client: &BitcoinCoreRpc, wallet: &DarkWallet, ...)`.
+//! We drop the `&DarkWallet` parameter: bitcoind's wallet (the one
+//! Nigiri seeds and the one this RPC client is bound to) holds the
+//! key for the spending UTXO and signs via RPC. Pulling the BDK-based
+//! `dark-wallet` crate into `dark-psar` purely for a regtest helper
+//! contradicts the issue's own "lean toward focused builder"
+//! direction. The integration test wires bitcoind's wallet via the
+//! same `BITCOIN_RPC_URL` convention `tests/e2e_regtest.rs` already
+//! uses.
+
+use bitcoin::absolute::LockTime;
+use bitcoin::transaction::{Sequence, Version};
+use bitcoin::{Amount, OutPoint, ScriptBuf, Transaction, TxIn, TxOut, Txid, Witness};
+use bitcoincore_rpc::json::ListUnspentResultEntry;
+use bitcoincore_rpc::{Client, RpcApi};
+use thiserror::Error;
+
+use crate::attest::SlotAttest;
+
+/// Errors raised by [`publish_slot_attest`].
+#[derive(Debug, Error)]
+#[non_exhaustive]
+pub enum PublishError {
+    #[error("rpc error")]
+    Rpc(#[from] bitcoincore_rpc::Error),
+
+    #[error("no spendable UTXO with value ≥ {required} sat (largest available: {largest} sat)")]
+    InsufficientFunds { required: u64, largest: u64 },
+
+    #[error("rpc returned an unsigned tx; bitcoind wallet does not own the input")]
+    SigningFailed,
+
+    #[error("address parse error")]
+    AddressParse,
+}
+
+/// Static fee floor (10_000 sats) — generous for a 1-in / 2-out P2WPKH
+/// + OP_RETURN tx on regtest, where actual mining cost is `0`.
+pub const STATIC_FEE_SATS: u64 = 10_000;
+
+/// Dust floor for the change output (P2WPKH minimum economic output).
+pub const CHANGE_DUST_SATS: u64 = 546;
+
+/// Publish a [`SlotAttest`] into a regtest OP_RETURN.
+///
+/// # Assumptions
+///
+/// - The bitcoind wallet bound to `client` is loaded.
+/// - The wallet holds at least one confirmed UTXO with
+///   `value ≥ STATIC_FEE_SATS + CHANGE_DUST_SATS`.
+/// - The caller mines the resulting transaction (e.g. via
+///   `generatetoaddress`) to confirm.
+pub fn publish_slot_attest(client: &Client, attest: &SlotAttest) -> Result<Txid, PublishError> {
+    let utxo = pick_funded_utxo(client)?;
+
+    let payload = attest.op_return_payload();
+    let op_return_script = ScriptBuf::new_op_return(payload);
+
+    let change_addr = client
+        .get_new_address(None, None)?
+        .assume_checked()
+        .script_pubkey();
+
+    let utxo_value = utxo.amount.to_sat();
+    let change_value =
+        utxo_value
+            .checked_sub(STATIC_FEE_SATS)
+            .ok_or(PublishError::InsufficientFunds {
+                required: STATIC_FEE_SATS + CHANGE_DUST_SATS,
+                largest: utxo_value,
+            })?;
+
+    let unsigned = Transaction {
+        version: Version::TWO,
+        lock_time: LockTime::ZERO,
+        input: vec![TxIn {
+            previous_output: OutPoint::new(utxo.txid, utxo.vout),
+            script_sig: ScriptBuf::new(),
+            sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+            witness: Witness::new(),
+        }],
+        output: vec![
+            TxOut {
+                value: Amount::ZERO,
+                script_pubkey: op_return_script,
+            },
+            TxOut {
+                value: Amount::from_sat(change_value),
+                script_pubkey: change_addr,
+            },
+        ],
+    };
+
+    let signed = client.sign_raw_transaction_with_wallet(&unsigned, None, None)?;
+    if !signed.complete {
+        return Err(PublishError::SigningFailed);
+    }
+    let signed_tx: Transaction =
+        bitcoin::consensus::deserialize(&signed.hex).map_err(|_| PublishError::SigningFailed)?;
+    let txid = client.send_raw_transaction(&signed_tx)?;
+    Ok(txid)
+}
+
+fn pick_funded_utxo(client: &Client) -> Result<ListUnspentResultEntry, PublishError> {
+    let required = STATIC_FEE_SATS + CHANGE_DUST_SATS;
+    let utxos = client.list_unspent(Some(1), None, None, None, None)?;
+    let mut best_value = 0u64;
+    let chosen = utxos.into_iter().find(|u| {
+        let v = u.amount.to_sat();
+        if v > best_value {
+            best_value = v;
+        }
+        v >= required
+    });
+    chosen.ok_or(PublishError::InsufficientFunds {
+        required,
+        largest: best_value,
+    })
+}
+
+/// Decode the `[ "PSAR" magic | 64 B sig ]` payload from a
+/// transaction's OP_RETURN output, if any.
+///
+/// Iterates `tx.output` and returns the first OP_RETURN script whose
+/// pushed data starts with [`crate::attest::OP_RETURN_MAGIC`]. Returns
+/// `None` if no such output is present.
+pub fn decode_slot_attest_op_return(tx: &Transaction) -> Option<Vec<u8>> {
+    use bitcoin::script::Instruction;
+    for out in &tx.output {
+        if !out.script_pubkey.is_op_return() {
+            continue;
+        }
+        let mut iter = out.script_pubkey.instructions();
+        // Skip the OP_RETURN opcode itself.
+        let _ = iter.next();
+        if let Some(Ok(Instruction::PushBytes(data))) = iter.next() {
+            let bytes = data.as_bytes();
+            if bytes.len() == SlotAttest::OP_RETURN_SIZE
+                && bytes[..4] == crate::attest::OP_RETURN_MAGIC
+            {
+                return Some(bytes.to_vec());
+            }
+        }
+    }
+    None
+}
+
+#[cfg(test)]
+mod tests {
+    //! Pure-Rust tests (no Nigiri / bitcoind needed). The end-to-end
+    //! round-trip lives in `tests/e2e_psar_regtest.rs`.
+
+    use super::*;
+    use crate::attest::SlotAttestUnsigned;
+    use bitcoin::hashes::Hash;
+    use secp256k1::{Keypair, Secp256k1, SecretKey};
+
+    fn make_attest(seed: u8) -> SlotAttest {
+        let secp = Secp256k1::new();
+        let kp = Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[0xa7u8; 32]).unwrap());
+        SlotAttestUnsigned {
+            slot_root: [seed; 32],
+            cohort_id: [seed.wrapping_add(1); 32],
+            setup_id: [seed.wrapping_add(2); 32],
+            n: 12,
+            k: 100,
+        }
+        .sign(&secp, &kp)
+    }
+
+    #[test]
+    fn op_return_script_is_well_formed() {
+        let attest = make_attest(0x42);
+        let payload = attest.op_return_payload();
+        let script = ScriptBuf::new_op_return(payload);
+        assert!(script.is_op_return());
+        // Total script size = 1 (OP_RETURN) + 1 (push opcode for 68 B) + 68.
+        // For pushes ≤ 75 bytes, push opcode == data length byte itself.
+        assert_eq!(script.len(), 70);
+    }
+
+    #[test]
+    fn decode_slot_attest_op_return_round_trip() {
+        let attest = make_attest(0xab);
+        let payload = attest.op_return_payload();
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: vec![TxIn {
+                previous_output: OutPoint::new(bitcoin::Txid::from_byte_array([0u8; 32]), 0),
+                script_sig: ScriptBuf::new(),
+                sequence: Sequence::ENABLE_RBF_NO_LOCKTIME,
+                witness: Witness::new(),
+            }],
+            output: vec![
+                TxOut {
+                    value: Amount::ZERO,
+                    script_pubkey: ScriptBuf::new_op_return(payload),
+                },
+                TxOut {
+                    value: Amount::from_sat(1_000),
+                    script_pubkey: ScriptBuf::new(),
+                },
+            ],
+        };
+        let decoded = decode_slot_attest_op_return(&tx).expect("decoded payload present");
+        assert_eq!(decoded, payload.to_vec());
+    }
+
+    #[test]
+    fn decode_returns_none_when_no_op_return() {
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: vec![TxOut {
+                value: Amount::from_sat(1_000),
+                script_pubkey: ScriptBuf::new(),
+            }],
+        };
+        assert!(decode_slot_attest_op_return(&tx).is_none());
+    }
+
+    #[test]
+    fn decode_returns_none_for_op_return_without_magic() {
+        let tx = Transaction {
+            version: Version::TWO,
+            lock_time: LockTime::ZERO,
+            input: Vec::new(),
+            output: vec![TxOut {
+                value: Amount::ZERO,
+                script_pubkey: ScriptBuf::new_op_return([0u8; 68]),
+            }],
+        };
+        assert!(decode_slot_attest_op_return(&tx).is_none());
+    }
+}

--- a/crates/dark-psar/src/slot_tree.rs
+++ b/crates/dark-psar/src/slot_tree.rs
@@ -1,0 +1,547 @@
+//! Slot allocation Merkle tree (issue #667).
+//!
+//! Commits a cohort to its slot allocation: every member's
+//! `(slot_index, pk_user)` pair is hashed into a leaf, the leaves are
+//! combined into a binary Merkle tree, and the root is what the ASP
+//! signs in [`SlotAttest`](crate::attest) (#668) and publishes via
+//! [`publish`](crate::publish) (#669).
+//!
+//! # Wire format
+//!
+//! - Leaf preimage layout (37 B):
+//!
+//!   ```text
+//!   |  0x01 (LEAF_V1_PREFIX) |  4 B slot_index (LE u32) |  32 B pk_user  |
+//!   ```
+//!
+//! - Leaf hash: `tagged_hash(LEAF_V1_TAG, preimage)`
+//!   with `LEAF_V1_TAG = b"DarkPsarSlotV1"` per issue #667.
+//!
+//! - Branch hash: `tagged_hash(BRANCH_TAG, l || r)`
+//!   with `BRANCH_TAG = b"DarkPsarBranch"` per issue #667.
+//!
+//! Tagged hashes follow the BIP-340 construction
+//! `SHA256(SHA256(tag) || SHA256(tag) || msg)`. Tree shape mirrors
+//! `crates/dark-core/src/round_tree.rs`: pairs combine left-to-right;
+//! an unpaired right-most node at any level is promoted unchanged.
+//! The empty tree has the zero root `[0u8; 32]`.
+//!
+//! # Phase-3 scope vs phase-4 batch tree
+//!
+//! Issue #667 describes the leaf as `(slot_i, pk_{U_i}, tree_path_i)`.
+//! `tree_path_i` is the user's commitment to a position in the
+//! *batch* tree that phase 4 will land (#672). In phase 3 the batch
+//! tree does not exist yet, so the leaf encoding here is locked at
+//! `(slot_index, pk_user)`. Phase 4 will introduce a `LeafV2` /
+//! `LEAF_V2_PREFIX = 0x02` encoding with `tree_path` appended; the
+//! prefix-byte rail keeps the two encodings non-colliding (same
+//! pattern as `dark-core`'s `round_tree.rs`).
+
+use sha2::{Digest, Sha256};
+
+use crate::cohort::CohortMember;
+use crate::error::PsarError;
+
+/// Leading byte of the V1 (phase-3) leaf preimage.
+pub const LEAF_V1_PREFIX: u8 = 0x01;
+
+/// BIP-340 tagged-hash tag for the slot leaf (#667).
+pub const LEAF_V1_TAG: &[u8] = b"DarkPsarSlotV1";
+
+/// BIP-340 tagged-hash tag for the slot tree's branch nodes (#667).
+pub const BRANCH_TAG: &[u8] = b"DarkPsarBranch";
+
+/// A single slot leaf — the tree-side projection of a [`CohortMember`].
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct Slot {
+    pub slot_index: u32,
+    pub pk_user: [u8; 32],
+}
+
+impl Slot {
+    pub fn from_member(m: &CohortMember) -> Self {
+        Self {
+            slot_index: m.slot_index,
+            pk_user: m.pk_user,
+        }
+    }
+
+    /// Canonical 37-byte leaf preimage.
+    pub fn preimage(&self) -> [u8; 37] {
+        let mut out = [0u8; 37];
+        out[0] = LEAF_V1_PREFIX;
+        out[1..5].copy_from_slice(&self.slot_index.to_le_bytes());
+        out[5..37].copy_from_slice(&self.pk_user);
+        out
+    }
+
+    /// 32-byte tagged-hash leaf digest.
+    pub fn leaf_hash(&self) -> [u8; 32] {
+        tagged_hash(LEAF_V1_TAG, &self.preimage())
+    }
+}
+
+/// Slot Merkle root. Wraps a 32-byte digest so callers cannot mistake
+/// it for an arbitrary hash.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct SlotRoot(pub [u8; 32]);
+
+impl SlotRoot {
+    /// Compute the root over the cohort members' slots.
+    pub fn compute(members: &[CohortMember]) -> Self {
+        let leaves: Vec<[u8; 32]> = members
+            .iter()
+            .map(|m| Slot::from_member(m).leaf_hash())
+            .collect();
+        SlotRoot(merkle_root(&leaves))
+    }
+
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Which side of the parent the *sibling* sits on.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum Side {
+    /// Sibling is the left child (current node is the right child).
+    Left,
+    /// Sibling is the right child (current node is the left child).
+    Right,
+}
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ProofStep {
+    pub sibling: [u8; 32],
+    pub side: Side,
+}
+
+/// Inclusion proof for a single leaf in the slot Merkle tree.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct SlotInclusionProof {
+    pub leaf_index: u32,
+    pub steps: Vec<ProofStep>,
+}
+
+impl SlotInclusionProof {
+    /// Build the proof for `leaf_index` over the given cohort members.
+    pub fn generate(members: &[CohortMember], leaf_index: u32) -> Result<Self, PsarError> {
+        let tree = SlotTree::from_members(members);
+        tree.inclusion_proof(leaf_index)
+    }
+
+    /// `true` iff this proof attests `leaf` is committed in `slot_root`.
+    pub fn verify(&self, slot_root: &SlotRoot, leaf: &Slot) -> bool {
+        let mut acc = leaf.leaf_hash();
+        for step in &self.steps {
+            acc = match step.side {
+                Side::Left => branch_hash(&step.sibling, &acc),
+                Side::Right => branch_hash(&acc, &step.sibling),
+            };
+        }
+        acc == slot_root.0
+    }
+}
+
+/// In-memory binary Merkle tree over slot leaves.
+///
+/// Holds every level so inclusion proofs can be generated without
+/// re-hashing leaves.
+#[derive(Clone, Debug)]
+pub struct SlotTree {
+    levels: Vec<Vec<[u8; 32]>>,
+}
+
+impl SlotTree {
+    /// Build a tree from `members`. Order is preserved — the leaf at
+    /// position `i` corresponds to `members[i]`. Empty member sets
+    /// produce a tree with the zero root.
+    pub fn from_members(members: &[CohortMember]) -> Self {
+        let leaves: Vec<[u8; 32]> = members
+            .iter()
+            .map(|m| Slot::from_member(m).leaf_hash())
+            .collect();
+        Self::from_leaf_hashes(leaves)
+    }
+
+    /// Build a tree from already-computed leaf hashes. Used by tests
+    /// and by callers who have their own [`Slot`] values.
+    pub fn from_leaf_hashes(leaf_hashes: Vec<[u8; 32]>) -> Self {
+        if leaf_hashes.is_empty() {
+            return Self {
+                levels: vec![Vec::new()],
+            };
+        }
+        let mut levels: Vec<Vec<[u8; 32]>> = vec![leaf_hashes.clone()];
+        let mut current = leaf_hashes;
+        while current.len() > 1 {
+            let mut next = Vec::with_capacity(current.len() / 2 + 1);
+            let mut i = 0;
+            while i + 1 < current.len() {
+                next.push(branch_hash(&current[i], &current[i + 1]));
+                i += 2;
+            }
+            if !current.len().is_multiple_of(2) {
+                next.push(current[current.len() - 1]);
+            }
+            levels.push(next.clone());
+            current = next;
+        }
+        Self { levels }
+    }
+
+    pub fn len(&self) -> u32 {
+        self.levels.first().map(|l| l.len()).unwrap_or(0) as u32
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// `[0u8; 32]` for the empty tree; otherwise the top-level hash.
+    pub fn root(&self) -> SlotRoot {
+        let bytes = self
+            .levels
+            .last()
+            .and_then(|l| l.first())
+            .copied()
+            .unwrap_or([0u8; 32]);
+        SlotRoot(bytes)
+    }
+
+    pub fn inclusion_proof(&self, leaf_index: u32) -> Result<SlotInclusionProof, PsarError> {
+        let k = self.len();
+        if leaf_index >= k {
+            return Err(PsarError::SlotIndexOutOfRange {
+                slot_index: leaf_index,
+                k,
+            });
+        }
+        let mut steps = Vec::new();
+        let mut idx = leaf_index as usize;
+        for level in &self.levels[..self.levels.len().saturating_sub(1)] {
+            // Unpaired right-most node at this level: promoted unchanged.
+            // Skip emitting a sibling for it.
+            if idx == level.len() - 1 && !level.len().is_multiple_of(2) {
+                idx /= 2;
+                continue;
+            }
+            let idx_is_left_child = idx.is_multiple_of(2);
+            let sibling_idx = if idx_is_left_child { idx + 1 } else { idx - 1 };
+            let side = if idx_is_left_child {
+                Side::Right
+            } else {
+                Side::Left
+            };
+            steps.push(ProofStep {
+                sibling: level[sibling_idx],
+                side,
+            });
+            idx /= 2;
+        }
+        Ok(SlotInclusionProof { leaf_index, steps })
+    }
+}
+
+// --- Hash primitives -------------------------------------------------------
+
+/// BIP-340 tagged hash: `SHA256(SHA256(tag) || SHA256(tag) || msg)`.
+fn tagged_hash(tag: &[u8], msg: &[u8]) -> [u8; 32] {
+    let tag_hash = Sha256::digest(tag);
+    let mut hasher = Sha256::new();
+    hasher.update(tag_hash);
+    hasher.update(tag_hash);
+    hasher.update(msg);
+    hasher.finalize().into()
+}
+
+fn branch_hash(left: &[u8; 32], right: &[u8; 32]) -> [u8; 32] {
+    let mut buf = [0u8; 64];
+    buf[..32].copy_from_slice(left);
+    buf[32..].copy_from_slice(right);
+    tagged_hash(BRANCH_TAG, &buf)
+}
+
+fn merkle_root(leaves: &[[u8; 32]]) -> [u8; 32] {
+    if leaves.is_empty() {
+        return [0u8; 32];
+    }
+    let mut current: Vec<[u8; 32]> = leaves.to_vec();
+    while current.len() > 1 {
+        let mut next = Vec::with_capacity(current.len() / 2 + 1);
+        let mut i = 0;
+        while i + 1 < current.len() {
+            next.push(branch_hash(&current[i], &current[i + 1]));
+            i += 2;
+        }
+        if !current.len().is_multiple_of(2) {
+            next.push(current[current.len() - 1]);
+        }
+        current = next;
+    }
+    current[0]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn member(seed: u8, slot: u32) -> CohortMember {
+        CohortMember {
+            user_id: [seed; 32],
+            pk_user: [seed.wrapping_add(1); 32],
+            slot_index: slot,
+        }
+    }
+
+    fn members(k: u32) -> Vec<CohortMember> {
+        (0..k).map(|i| member(i as u8, i)).collect()
+    }
+
+    // --- Constants ---------------------------------------------------------
+
+    #[test]
+    fn pinned_tag_bytes() {
+        assert_eq!(LEAF_V1_PREFIX, 0x01);
+        assert_eq!(LEAF_V1_TAG, b"DarkPsarSlotV1");
+        assert_eq!(BRANCH_TAG, b"DarkPsarBranch");
+    }
+
+    // --- Encoding / determinism -------------------------------------------
+
+    #[test]
+    fn leaf_preimage_layout_locked() {
+        let s = Slot {
+            slot_index: 0x0403_0201,
+            pk_user: [0xab; 32],
+        };
+        let p = s.preimage();
+        assert_eq!(p[0], LEAF_V1_PREFIX);
+        assert_eq!(&p[1..5], &[0x01, 0x02, 0x03, 0x04]); // LE encoding
+        assert_eq!(&p[5..37], &[0xab; 32]);
+    }
+
+    #[test]
+    fn leaf_hash_is_deterministic() {
+        let s = Slot {
+            slot_index: 7,
+            pk_user: [0x11; 32],
+        };
+        assert_eq!(s.leaf_hash(), s.leaf_hash());
+    }
+
+    #[test]
+    fn leaf_hash_changes_with_slot_index() {
+        let s1 = Slot {
+            slot_index: 0,
+            pk_user: [0x11; 32],
+        };
+        let s2 = Slot {
+            slot_index: 1,
+            pk_user: [0x11; 32],
+        };
+        assert_ne!(s1.leaf_hash(), s2.leaf_hash());
+    }
+
+    #[test]
+    fn leaf_hash_changes_with_pubkey() {
+        let s1 = Slot {
+            slot_index: 0,
+            pk_user: [0x11; 32],
+        };
+        let s2 = Slot {
+            slot_index: 0,
+            pk_user: [0x12; 32],
+        };
+        assert_ne!(s1.leaf_hash(), s2.leaf_hash());
+    }
+
+    // --- Tree shape -------------------------------------------------------
+
+    #[test]
+    fn empty_tree_has_zero_root() {
+        let t = SlotTree::from_members(&[]);
+        assert!(t.is_empty());
+        assert_eq!(t.root(), SlotRoot([0u8; 32]));
+        assert_eq!(SlotRoot::compute(&[]), SlotRoot([0u8; 32]));
+    }
+
+    #[test]
+    fn single_leaf_root_equals_leaf_hash() {
+        let m = member(1, 0);
+        let expected = Slot::from_member(&m).leaf_hash();
+        let t = SlotTree::from_members(std::slice::from_ref(&m));
+        assert_eq!(t.root(), SlotRoot(expected));
+        assert_eq!(
+            SlotRoot::compute(std::slice::from_ref(&m)),
+            SlotRoot(expected)
+        );
+    }
+
+    #[test]
+    fn two_leaf_root_is_branch_hash() {
+        let ms = members(2);
+        let h0 = Slot::from_member(&ms[0]).leaf_hash();
+        let h1 = Slot::from_member(&ms[1]).leaf_hash();
+        let expected = branch_hash(&h0, &h1);
+        assert_eq!(SlotRoot::compute(&ms), SlotRoot(expected));
+    }
+
+    #[test]
+    fn three_leaf_root_promotes_unpaired() {
+        // level0: [h0, h1, h2]; level1: [b(h0,h1), h2]; root: b(b(h0,h1), h2)
+        let ms = members(3);
+        let h: Vec<_> = ms
+            .iter()
+            .map(|m| Slot::from_member(m).leaf_hash())
+            .collect();
+        let expected = branch_hash(&branch_hash(&h[0], &h[1]), &h[2]);
+        assert_eq!(SlotRoot::compute(&ms), SlotRoot(expected));
+    }
+
+    // --- Inclusion-proof round-trip ---------------------------------------
+
+    #[test]
+    fn inclusion_proof_round_trip_for_each_k() {
+        // K ∈ {1, 2, 3, 4, 7, 16} per issue #667 acceptance.
+        for k in [1u32, 2, 3, 4, 7, 16] {
+            let ms = members(k);
+            let root = SlotRoot::compute(&ms);
+            let tree = SlotTree::from_members(&ms);
+            for i in 0..k {
+                let proof = SlotInclusionProof::generate(&ms, i).expect("generate");
+                let leaf = Slot::from_member(&ms[i as usize]);
+                assert!(
+                    proof.verify(&root, &leaf),
+                    "K={k} idx={i}: proof should verify"
+                );
+                // Tree-side and free-fn-side proofs are equal.
+                let proof2 = tree.inclusion_proof(i).expect("tree proof");
+                assert_eq!(proof, proof2);
+            }
+        }
+    }
+
+    #[test]
+    fn proof_rejects_wrong_leaf() {
+        let ms = members(8);
+        let root = SlotRoot::compute(&ms);
+        let proof = SlotInclusionProof::generate(&ms, 3).unwrap();
+        // Leaf with the wrong slot_index for the proof position.
+        let bad = Slot {
+            slot_index: 0,
+            pk_user: ms[3].pk_user,
+        };
+        assert!(!proof.verify(&root, &bad));
+    }
+
+    #[test]
+    fn proof_rejects_wrong_root() {
+        let ms = members(8);
+        let proof = SlotInclusionProof::generate(&ms, 3).unwrap();
+        let leaf = Slot::from_member(&ms[3]);
+        let wrong_root = SlotRoot([0xff; 32]);
+        assert!(!proof.verify(&wrong_root, &leaf));
+    }
+
+    #[test]
+    fn inclusion_proof_index_out_of_range() {
+        let ms = members(4);
+        let tree = SlotTree::from_members(&ms);
+        assert!(matches!(
+            tree.inclusion_proof(4),
+            Err(PsarError::SlotIndexOutOfRange {
+                slot_index: 4,
+                k: 4
+            })
+        ));
+    }
+
+    // --- Mutation-sensitivity property test --------------------------------
+
+    proptest! {
+        #[test]
+        fn any_byte_mutation_in_proof_step_breaks_verify(
+            k in 2u32..=32u32,
+            mutate_step_idx in 0usize..32usize,
+            mutate_byte_idx in 0usize..32usize,
+            xor_byte in 1u8..=255u8,
+        ) {
+            let ms = members(k);
+            let root = SlotRoot::compute(&ms);
+            // Pick the middle leaf to ensure the proof has at least one step
+            // for K ≥ 2.
+            let leaf_index = k / 2;
+            let mut proof = SlotInclusionProof::generate(&ms, leaf_index).unwrap();
+            prop_assume!(!proof.steps.is_empty());
+            let step_idx = mutate_step_idx % proof.steps.len();
+            let byte_idx = mutate_byte_idx % 32;
+            // Capture original sibling, mutate, verify the mutated proof
+            // does not pass.
+            let leaf = Slot::from_member(&ms[leaf_index as usize]);
+            proof.steps[step_idx].sibling[byte_idx] ^= xor_byte;
+            prop_assert!(!proof.verify(&root, &leaf));
+        }
+
+        #[test]
+        fn pubkey_byte_mutation_changes_leaf_hash(
+            byte_idx in 0usize..32usize,
+            xor_byte in 1u8..=255u8,
+        ) {
+            let mut s = Slot {
+                slot_index: 9,
+                pk_user: [0x33; 32],
+            };
+            let h_before = s.leaf_hash();
+            s.pk_user[byte_idx] ^= xor_byte;
+            prop_assert_ne!(h_before, s.leaf_hash());
+        }
+    }
+
+    // --- Golden vectors ---------------------------------------------------
+    //
+    // Pin the root for K ∈ {1, 2, 3, 4, 7, 16} so any future change to the
+    // leaf encoding, branch tag, or tree shape surfaces immediately. These
+    // are computed from the same `members(k)` helper used elsewhere — the
+    // generator is deterministic and pinned by the test, so the byte-level
+    // values are reproducible.
+
+    fn golden_root_hex(k: u32) -> String {
+        hex::encode(SlotRoot::compute(&members(k)).0)
+    }
+
+    #[test]
+    fn golden_roots_are_pinned_and_distinct() {
+        // Distinctness check first: distinct K must produce distinct roots
+        // for this generator (since the leaf-set differs by ≥ 1 leaf).
+        let ks = [1u32, 2, 3, 4, 7, 16];
+        let roots: Vec<String> = ks.iter().map(|&k| golden_root_hex(k)).collect();
+        for (i, a) in roots.iter().enumerate() {
+            for b in &roots[i + 1..] {
+                assert_ne!(a, b, "two different K produced the same root");
+            }
+        }
+        // Pinned hex values — regenerating these is a wire-format change.
+        // (Recompute by running this test once with the assertions removed
+        // and copying the printed values back here.)
+        for (k, expected) in ks.iter().zip(GOLDEN_ROOT_HEX.iter()) {
+            assert_eq!(
+                golden_root_hex(*k),
+                *expected,
+                "golden root for K={k} drifted; encoding changed?"
+            );
+        }
+    }
+
+    /// Pinned roots in hex. See `golden_roots_are_pinned_and_distinct`.
+    /// Order matches `[1, 2, 3, 4, 7, 16]`.
+    const GOLDEN_ROOT_HEX: &[&str] = &[
+        "8bc3c85b10c5682eb12435c76c2554c9bcf82a16147e97a8f6b05a77d30ba8b6",
+        "8bdc5a940e03a26388fddd6ed283f5d14dda38cb3f32de9f5c20fba3ef5ee519",
+        "440a4f373b4fe0f047296ba244c1f87e4987a4cabb28426bffbd723dea8944c4",
+        "76cbf8777bddd49296266626893616823e2e8188b4988ae20a156cfbe58cd7df",
+        "408d0fbe9e759abedf3305f3c2a1ef529cbd0882c5fc276a9151195fc119788e",
+        "83d064216b26370d81f20a47507d2038ff58ff10bbace612ca0263cfcf17fdea",
+    ];
+}

--- a/crates/dark-psar/src/store.rs
+++ b/crates/dark-psar/src/store.rs
@@ -1,0 +1,52 @@
+//! Persistence trait for active cohorts (issue #671).
+//!
+//! `ActiveCohortStore` abstracts the on-disk side of an
+//! `ActiveCohort`. Phase 3 ships an in-memory implementation
+//! sufficient for the K=100 / N=12 happy-path test; a Postgres impl
+//! is out of scope for AFT and is a documented follow-up.
+
+use std::collections::HashMap;
+
+use crate::boarding::ActiveCohort;
+use crate::error::PsarError;
+
+/// Cohort identifier (the `Cohort::id` 32-byte tag) used as the
+/// store's primary key.
+pub type CohortId = [u8; 32];
+
+pub trait ActiveCohortStore {
+    fn save(&mut self, cohort: ActiveCohort) -> Result<(), PsarError>;
+    fn load(&self, id: &CohortId) -> Option<&ActiveCohort>;
+    fn all(&self) -> Vec<&ActiveCohort>;
+}
+
+/// In-memory store. The `RetainedScalars` inside each `ActiveCohort`
+/// auto-zeroize on drop (`secp256k1 = 0.29`), so dropping this store
+/// also wipes the per-cohort scalars.
+#[derive(Default)]
+pub struct InMemoryActiveCohortStore {
+    cohorts: HashMap<CohortId, ActiveCohort>,
+}
+
+impl InMemoryActiveCohortStore {
+    pub fn new() -> Self {
+        Self {
+            cohorts: HashMap::new(),
+        }
+    }
+}
+
+impl ActiveCohortStore for InMemoryActiveCohortStore {
+    fn save(&mut self, cohort: ActiveCohort) -> Result<(), PsarError> {
+        self.cohorts.insert(cohort.cohort.id, cohort);
+        Ok(())
+    }
+
+    fn load(&self, id: &CohortId) -> Option<&ActiveCohort> {
+        self.cohorts.get(id)
+    }
+
+    fn all(&self) -> Vec<&ActiveCohort> {
+        self.cohorts.values().collect()
+    }
+}

--- a/crates/dark-psar/tests/e2e_psar_regtest.rs
+++ b/crates/dark-psar/tests/e2e_psar_regtest.rs
@@ -1,0 +1,115 @@
+//! E2E regtest round-trip for [`SlotAttest`] OP_RETURN publication
+//! (issue #669).
+//!
+//! Requires a running Bitcoin regtest node — the
+//! [Nigiri](https://nigiri.vulpem.com/) defaults are honoured:
+//!
+//! ```bash
+//! nigiri start
+//! cargo test -p dark-psar --features regtest --test e2e_psar_regtest \
+//!     -- --ignored --test-threads=1
+//! ```
+//!
+//! Override the RPC URL with `BITCOIN_RPC_URL=http://user:pass@host:port`.
+//!
+//! All tests are `#[ignore]` so they are skipped during default
+//! `cargo test` runs.
+
+#![cfg(feature = "regtest")]
+
+use bitcoin::Amount;
+use bitcoincore_rpc::{Auth, Client, RpcApi};
+use dark_psar::attest::{SlotAttest, SlotAttestUnsigned};
+use dark_psar::publish::{decode_slot_attest_op_return, publish_slot_attest};
+use secp256k1::{Keypair, Secp256k1, SecretKey};
+
+const NIGIRI_DEFAULT_USER: &str = "admin1";
+const NIGIRI_DEFAULT_PASS: &str = "123";
+
+/// Strip an embedded `user:pass@` prefix from `https://user:pass@host:port`,
+/// returning `(scheme://host:port, user, pass)`. Designed for the Nigiri
+/// default URL format; we do not pull in the `url` crate for this.
+fn split_rpc_url(raw: &str) -> (String, String, String) {
+    let (scheme, rest) = raw
+        .split_once("://")
+        .map(|(s, r)| (format!("{s}://"), r.to_string()))
+        .unwrap_or_else(|| ("http://".into(), raw.into()));
+    let (creds, hostport) = match rest.split_once('@') {
+        Some((c, h)) => (Some(c), h),
+        None => (None, rest.as_str()),
+    };
+    let (user, pass) = creds
+        .map(|c| match c.split_once(':') {
+            Some((u, p)) => (u.to_string(), p.to_string()),
+            None => (c.to_string(), String::new()),
+        })
+        .unwrap_or((NIGIRI_DEFAULT_USER.into(), NIGIRI_DEFAULT_PASS.into()));
+    (format!("{scheme}{hostport}"), user, pass)
+}
+
+fn rpc_client() -> Client {
+    let raw = std::env::var("BITCOIN_RPC_URL").unwrap_or_else(|_| {
+        format!("http://{NIGIRI_DEFAULT_USER}:{NIGIRI_DEFAULT_PASS}@127.0.0.1:18443")
+    });
+    let (host, user, pass) = split_rpc_url(&raw);
+    Client::new(&host, Auth::UserPass(user, pass)).expect("rpc client")
+}
+
+fn ensure_funded(client: &Client) {
+    // If the wallet has no spendable UTXO, mine 101 blocks to itself.
+    let balance = client
+        .get_balance(None, None)
+        .unwrap_or(Amount::ZERO)
+        .to_sat();
+    if balance < 1_000_000 {
+        let addr = client
+            .get_new_address(None, None)
+            .expect("new address")
+            .assume_checked();
+        let _ = client.generate_to_address(101, &addr);
+    }
+}
+
+fn make_attest() -> (SlotAttest, secp256k1::XOnlyPublicKey) {
+    let secp = Secp256k1::new();
+    let kp = Keypair::from_secret_key(&secp, &SecretKey::from_slice(&[0xa7u8; 32]).unwrap());
+    let pk = kp.x_only_public_key().0;
+    let attest = SlotAttestUnsigned {
+        slot_root: [0xab; 32],
+        cohort_id: [0xcd; 32],
+        setup_id: [0xef; 32],
+        n: 12,
+        k: 100,
+    }
+    .sign(&secp, &kp);
+    (attest, pk)
+}
+
+#[test]
+#[ignore = "requires running Nigiri / regtest node — opt-in via --ignored"]
+fn op_return_publication_round_trip() {
+    let client = rpc_client();
+    // Sanity: make sure the wallet is funded before publishing.
+    ensure_funded(&client);
+
+    let (attest, pk) = make_attest();
+    let txid = publish_slot_attest(&client, &attest).expect("publish");
+
+    // Mine the publication into a block so `getrawtransaction` returns it
+    // without `txindex=1` enabled.
+    let mining_addr = client
+        .get_new_address(None, None)
+        .expect("new addr")
+        .assume_checked();
+    let _ = client.generate_to_address(1, &mining_addr);
+
+    let raw = client
+        .get_raw_transaction(&txid, None)
+        .expect("raw tx fetch");
+    let payload = decode_slot_attest_op_return(&raw).expect("op_return present");
+
+    // Recover and verify against the off-chain unsigned payload.
+    let recovered =
+        SlotAttest::from_op_return_with_unsigned(&payload, attest.unsigned, &pk).expect("verify");
+    assert_eq!(recovered, attest);
+}


### PR DESCRIPTION
## Summary
- New `crates/dark-psar` workspace crate (`#![forbid(unsafe_code)]`, 8 modules, 63 unit tests + 1 `#[ignore]` regtest integration test) implementing the PSAR boarding-and-horizon protocol layer on top of `dark-von` (#651–#658) and `dark-von-musig2` (#659–#665).
- Issues closed: #666 cohort/horizon types · #667 slot Merkle tree · #668 `SlotAttest` commitment + serialisation · #669 regtest OP_RETURN publication · #670 user-side boarding · #671 ASP-side boarding + `ActiveCohortStore`.
- K=100 / N=12 ASP-side acceptance gate passes in ~11 s on dev hardware (issue #671 budget: 60 s). Regtest OP_RETURN round-trip verified end-to-end against `nigiri start` on this machine; the test stays `#[ignore]` so it does not run by default.

## Architecture

```
   Cohort + members ──┐
                      │ slot_tree::SlotRoot::compute   ┌─► attest::SlotAttest (Schnorr/BIP-340)
                      ├──────────────────────────────► │
                      │                                └─► publish::publish_slot_attest (regtest)
   ASP keypair ───────┤                                       │
                      │ Setup::run (Λ + retained)             │  on-chain OP_RETURN (68 B compact)
                      └──► PublishedSchedule  ─┐               │
                                               │               ▼
   user_kp + slot ──────► boarding::user_board ── PreSigned[N] + schedule_witness
                                               │
                                               ▼
                          boarding::asp_board ─► ActiveCohort (state == Active)
                                               │
                                               ▼
                          ActiveCohortStore  (in-memory; Postgres TODO)
```

## Notable deviations from issue text (read the module docs)

- **#667**: the issue describes leaves as `(slot_i, pk_{U_i}, tree_path_i)`. Phase 3 has no batch tree yet (#672 lands it in phase 4), so the leaf preimage is locked at `0x01 || slot_index_LE_u32 || pk_user_32` (37 B). The leading `LEAF_V1_PREFIX = 0x01` rail keeps a future `LeafV2` encoding non-colliding with V1 — same pattern as `crates/dark-core/src/round_tree.rs`.
- **#668**: a single canonical encoding cannot meet the issue's "≤ 80 B after Schnorr sig" target — `slot_root + cohort_id + setup_id + n + k + sig` is unavoidably 168 B. Off-chain wire format is the full 168 B `SlotAttest::to_bytes()`; on-chain we emit a compact 68 B form `PSAR-magic [4] || sig [64]` via `SlotAttest::op_return_payload()`. Verifiers recover the attestation by combining the on-chain bytes with the off-chain unsigned payload (every cohort member already holds it from boarding).
- **#669**: dropped the `wallet: &DarkWallet` parameter from `publish_slot_attest`. bitcoind's wallet (the one Nigiri seeds and the RPC client is bound to) holds the spending UTXO key and signs via `signrawtransactionwithwallet`; pulling the BDK-based `dark-wallet` purely for a regtest helper would contradict the issue's own "lean toward focused builder" direction.
- **#670 / #671**: `PsarError` does **not** derive `PartialEq` / `Eq`. `#[from] VonMusig2Error` and `dark_von_musig2::PreSigned` are not equality-comparable; tests use `matches!` / explicit pattern matches instead.
- **General convention** (boarding module docs): every cohort member's `pk_user` is a 32 B BIP-340 x-only public key with assumed even parity. Keypairs whose natural `x_only_public_key().1 == Parity::Odd` are rejected with `PsarError::OddParity`; the caller must negate the secret to renormalize.

## Public surface (re-exported from `dark_psar`)

- `Cohort`, `CohortMember`, `HibernationHorizon`, `BoardingState`
- `Slot`, `SlotRoot`, `SlotInclusionProof`, `SlotTree`, `Side`
- `SlotAttest`, `SlotAttestUnsigned`, `SlotAttestError`
- `derive_message_for_epoch` (`message::MESSAGE_TAG = b"DarkPsarMsgV1"`)
- `user_board`, `asp_board`, `UserBoardingArtifact`, `ActiveCohort`
- `ActiveCohortStore`, `InMemoryActiveCohortStore`
- Behind `feature = "regtest"`: `publish::publish_slot_attest`, `publish::decode_slot_attest_op_return`, `boarding::asp_publish_attest`

## Test plan

- [ ] `cargo test -p dark-psar` — 63 unit tests pass (cohort 11 · slot_tree 12 + 2 proptests · attest 13 · message 4 · publish 4 · boarding 11), 0 ignored, 0 failed.
- [ ] `cargo test -p dark-psar --features regtest --test e2e_psar_regtest -- --ignored` against a running `nigiri start` — single round-trip publish + on-chain decode + recover SlotAttest succeeds (~28 s end-to-end including mining).
- [ ] `cargo clippy --all-targets --all-features -- -D warnings` — clean (matches CI's invocation; the workspace-wide `-p dark-psar --all-features` is also clean).
- [ ] `cargo fmt --all -- --check` — clean.
- [ ] Spot-check `crates/dark-psar/src/boarding.rs:user_board` — note the explicit Λ pre-verify loop that surfaces `PsarError::ScheduleInvalid { epoch, slot }`; `presign_horizon` re-verifies internally but only emits a generic `VonMusig2Error::DarkVon` without coordinates.
- [ ] Spot-check the K=100 / N=12 acceptance gate `boarding::tests::asp_board_k100_n12_under_60_seconds` — currently completes in ~11 s, ample headroom for the 60 s budget.
- [ ] Verify `crates/dark-psar/src/boarding.rs:lift_xonly_to_even` is the *only* x-only-to-compressed lift in this PR — every other Schnorr/MuSig2 key path consumes `Keypair::public_key()` directly.
- [ ] Optional: `/ultrareview <PR#>` — recommended; this is the first PSAR layer on top of the freshly-landed VON-MuSig2 substrate, so cross-module invariants (parity convention, schedule witness binding, slot-tree shape, OP_RETURN compact form) are exactly the kind of thing a multi-agent review tends to surface.

Closes #666, #667, #668, #669, #670, #671.