### PR TITLE
Phase 6: PSAR benchmarks (#681-#687)

### DIFF
--- a/BENCHMARKS.md
+++ b/BENCHMARKS.md
@@ -1,0 +1,144 @@
+# Benchmarks
+
+Top-level consolidator for the PSAR Phase 6 benchmark suite. Pulls
+together the per-bench docs in `docs/benchmarks/` and the captured
+plots in `docs/benchmarks/figures/`. The paper references this file
+for the headline numbers and the supporting figures.
+
+## Lead configuration
+
+Throughout this document **(K=1000, N=12)** is the **lead row (★)** —
+it represents the production-shape cohort the paper builds its
+argument around. **(K=100, N=12)** is a secondary lead used in
+isolated single-user contexts (e.g. boarding latency, where K does
+not affect cost). Smaller / larger configurations are supplementary
+data points that pin the scaling shape.
+
+## Methodology
+
+| Field             | Value                                       |
+|-------------------|---------------------------------------------|
+| Hardware          | Apple M3 Max (14 cores, 36 GB RAM)          |
+| OS                | macOS 26.3.1 (Darwin 25.3.0)                |
+| Toolchain         | rustc 1.95.0 (release profile, lto = false) |
+| Criterion preset  | `--quick` (3 s measurement + 1 s warm-up)   |
+| Sample size       | criterion default (100), overridden to 10 for `process_epoch/{100,1000}` due to per-iter cost |
+| What's measured   | bench harnesses in `crates/dark-{von-musig2,psar}/benches/` + `psar-demo` runs |
+| What's derived    | Arkade Delegation row in the comparison; `slot_attest_S` size formula (Nigiri-pending verification); cohort storage formula |
+
+Linux / x86_64 numbers on `ubuntu-latest` typically run **1.5–2×
+slower** for curve-arithmetic-heavy paths and similar for HMAC /
+SHA-256. The envelopes in the threshold-sentinel tables in each
+per-bench doc allow for this slack.
+
+### Reproducibility
+
+```bash
+# Primitives (#681)
+cargo bench -p dark-von-musig2 --bench partial_sign --bench aggregate -- --quick
+
+# Boarding vs N (#682)
+cargo bench -p dark-psar --bench boarding -- --quick
+
+# Per-epoch vs K (#683); K=10000 stretch behind BENCH_LONG=1
+cargo bench -p dark-psar --bench epoch -- --quick
+BENCH_LONG=1 cargo bench -p dark-psar --bench epoch -- long
+
+# Cohort scaling sweep (#684)
+scripts/psar-scaling.sh --include-stretch
+
+# On-chain footprint (#685, requires Nigiri)
+nigiri start
+scripts/psar-onchain.sh
+
+# Plots (#687)
+scripts/psar-plots.sh
+```
+
+### Raw data locations
+
+| Bench / sweep             | Raw output                                                           |
+|---------------------------|----------------------------------------------------------------------|
+| Criterion HTML reports    | `target/criterion/{partial_sign,aggregate,user_board,process_epoch}/report/` |
+| `psar-demo` JSON reports  | stdout (or `--report-path PATH`)                                     |
+| Cohort scaling sweep      | `scripts/psar-scaling.sh --out PATH`                                 |
+| On-chain measurements     | `scripts/psar-onchain.sh --out PATH`                                 |
+
+## Headline numbers (lead row ★)
+
+| Metric                                  | Value at lead row (K=1000, N=12) | Source doc |
+|-----------------------------------------|-------------------------------------|----|
+| User-side single-board latency (★ K=100)| **4.75 ms / user**                  | [psar-boarding.md](docs/benchmarks/psar-boarding.md) |
+| ASP per-epoch latency                   | **226.8 ms** (227 µs / user)        | [psar-epoch.md](docs/benchmarks/psar-epoch.md)       |
+| Total cohort wall-clock (board → 12 epochs → verify) | **9.0 s**             | [psar-scaling.md](docs/benchmarks/psar-scaling.md)   |
+| In-memory storage per cohort            | **1.37 MB**                         | [psar-scaling.md](docs/benchmarks/psar-scaling.md)   |
+| PSAR-specific L1 footprint per cohort   | **~201 vbytes** (slot_attest_S only)| [psar-onchain.md](docs/benchmarks/psar-onchain.md)   |
+| User offline window                     | **N epochs after boarding**         | (design property, not a measurement) |
+
+## Per-bench doc index
+
+| Issue | Topic                                            | Doc                                               | Status                        |
+|-------|--------------------------------------------------|---------------------------------------------------|-------------------------------|
+| #681  | VON-MuSig2 cryptographic primitives              | [von-musig2-primitives.md](docs/benchmarks/von-musig2-primitives.md) | measured ✓ |
+| #682  | Boarding latency vs N                            | [psar-boarding.md](docs/benchmarks/psar-boarding.md) | measured ✓ |
+| #683  | Per-epoch ASP latency vs K                       | [psar-epoch.md](docs/benchmarks/psar-epoch.md)    | measured (K=10000 stretch behind `BENCH_LONG=1`) |
+| #684  | Cohort scaling K × N                             | [psar-scaling.md](docs/benchmarks/psar-scaling.md) | measured ✓ |
+| #685  | On-chain footprint                               | [psar-onchain.md](docs/benchmarks/psar-onchain.md) | analytic; measurement pending Nigiri run |
+| #686  | PSAR vs Arkade Delegation v0.7.0                 | [psar-vs-arkade.md](docs/benchmarks/psar-vs-arkade.md) | derived from spec |
+| —     | `dark-von` cryptographic primitives (Phase 1)    | [von-primitives.md](docs/benchmarks/von-primitives.md) | measured (already merged) |
+| —     | `dark-confidential` primitives (earlier phase)   | [confidential-primitives.md](docs/benchmarks/confidential-primitives.md) | measured (already merged) |
+
+## Figures
+
+Three SVG figures, generated by `scripts/psar-plots.sh`:
+
+### Boarding latency vs N (linear)
+
+![boarding-vs-n](docs/benchmarks/figures/boarding-vs-n.svg)
+
+Linear in N: `user_board(N) ≈ 150 µs + N × 395 µs`. Lead row at
+N=12 is 4.75 ms.
+
+### Per-epoch ASP latency vs K (log-x)
+
+![epoch-vs-k](docs/benchmarks/figures/epoch-vs-k.svg)
+
+Linear in K: per-user cost is **227 µs / user** stable across
+K∈{100, 1000}. K=10000 stretch row pending (`BENCH_LONG=1`).
+
+### In-memory storage vs K at N=12 (log-x)
+
+![storage-vs-k](docs/benchmarks/figures/storage-vs-k.svg)
+
+Storage formula: `186K + 98KN + 292N + 180` bytes. Lead row at
+K=1000 is 1.37 MB; K=10000 fits comfortably at 13.6 MB.
+
+## Cross-protocol comparison (#686)
+
+PSAR's headline win against Arkade Delegation v0.7.0 is **online-time
+asymmetry**, not raw signing speed. PSAR pre-signs N renewals at
+boarding so the user is offline for the entire horizon, at the cost
+of ~1.4 MB of ASP storage and ~4 ms of upfront boarding cost. Arkade
+keeps the user-side cost smaller per renewal but requires a trusted
+delegator (Fulmine) online at every renewal.
+
+See [psar-vs-arkade.md](docs/benchmarks/psar-vs-arkade.md) for the
+full table with explicit assumptions A1–A6 (each Arkade cell is
+footnoted to its source). Numbers in that doc are **derived from
+spec** for the Arkade column — the limitations section makes this
+explicit.
+
+## Threshold sentinels (summary)
+
+| Bench                                      | Envelope (Apple M-series)        | Notes                             |
+|--------------------------------------------|-----------------------------------|-----------------------------------|
+| `partial_sign/operator`                    | ≤ 100 µs                          | measured 45 µs                    |
+| `partial_sign_participant_horizon/N`       | linear in N, slope ≤ 230 µs/epoch | measured ~225 µs/epoch            |
+| `aggregate/2of2`                           | ≤ 50 µs                           | measured 20 µs                    |
+| `user_board/12`                            | ≤ 10 ms                           | measured 4.75 ms                  |
+| `process_epoch/100`                        | ≤ 50 ms                           | measured 22.9 ms                  |
+| `process_epoch/1000`                       | ≤ 500 ms                          | measured 226.8 ms                 |
+| `(K=1000, N=12)` cohort wall-clock (lead) ★ | ≤ 60 s                           | measured 9.0 s                    |
+
+If any of these regress past the envelope on a future change, fail
+the review and investigate before merging.

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1374,6 +1374,7 @@ dependencies = [
  "bitcoin",
  "bitcoincore-rpc",
  "clap",
+ "criterion",
  "dark-core",
  "dark-von",
  "dark-von-musig2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1474,6 +1474,7 @@ version = "0.1.0"
 dependencies = [
  "bitcoin",
  "ciborium",
+ "criterion",
  "dark-von",
  "hex",
  "musig2",

--- a/crates/dark-psar/Cargo.toml
+++ b/crates/dark-psar/Cargo.toml
@@ -55,3 +55,7 @@ required-features = ["demo"]
 [[bench]]
 name = "boarding"
 harness = false
+
+[[bench]]
+name = "epoch"
+harness = false

--- a/crates/dark-psar/Cargo.toml
+++ b/crates/dark-psar/Cargo.toml
@@ -41,6 +41,7 @@ tracing-subscriber = { version = "0.3", optional = true, features = ["env-filter
 
 [dev-dependencies]
 proptest = "1.5"
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [lib]
 name = "dark_psar"
@@ -50,3 +51,7 @@ path = "src/lib.rs"
 name = "psar-demo"
 path = "src/bin/psar-demo.rs"
 required-features = ["demo"]
+
+[[bench]]
+name = "boarding"
+harness = false

--- a/crates/dark-psar/benches/boarding.rs
+++ b/crates/dark-psar/benches/boarding.rs
@@ -1,0 +1,134 @@
+//! Single-user boarding latency parameterised over `N ∈ {4, 12, 50}`
+//! (issue #682).
+//!
+//! Measures the wall-clock cost of `dark_psar::user_board` — the
+//! end-to-end client-side boarding call: verify Λ, derive `N`
+//! per-epoch messages, pre-sign the horizon, hash-chain a schedule
+//! witness. Setup (cohort construction, ASP attestation, schedule
+//! generation) happens once outside the timed loop; only `user_board`
+//! is timed.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p dark-psar --bench boarding
+//! ```
+//!
+//! Numbers feed `docs/benchmarks/psar-boarding.md`.
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use secp256k1::{Keypair, Parity, Secp256k1, SecretKey};
+
+use dark_psar::{
+    user_board, Cohort, CohortMember, HibernationHorizon, SlotAttest, SlotAttestUnsigned, SlotRoot,
+    SlotTree,
+};
+use dark_von_musig2::setup::{PublishedSchedule, Setup};
+
+const SETUP_ID: [u8; 32] = [0xc4; 32];
+const COHORT_ID: [u8; 32] = [0xab; 32];
+
+fn even_parity_keypair(secp: &Secp256k1<secp256k1::All>, seed: u8) -> Keypair {
+    for offset in 0u32..1024 {
+        let mut bytes = [seed; 32];
+        bytes[28..32].copy_from_slice(&offset.to_le_bytes());
+        if let Ok(sk) = SecretKey::from_slice(&bytes) {
+            let kp = Keypair::from_secret_key(secp, &sk);
+            if kp.x_only_public_key().1 == Parity::Even {
+                return kp;
+            }
+        }
+    }
+    panic!("no even-parity keypair within counter range");
+}
+
+struct Fixture {
+    cohort: Cohort,
+    attest: SlotAttest,
+    schedule: PublishedSchedule,
+    user_kp: Keypair,
+    asp_xonly: secp256k1::XOnlyPublicKey,
+    batch_root: [u8; 32],
+}
+
+fn build_fixture(n: u32) -> Fixture {
+    let secp = Secp256k1::new();
+    let asp_kp = even_parity_keypair(&secp, 0x77);
+    let asp_xonly = asp_kp.x_only_public_key().0;
+
+    // 2-member cohort is the smallest legal one — boarding cost is
+    // dominated by `N`, not `K`, so this isolates the per-user cost.
+    let user_kp = even_parity_keypair(&secp, 0x80);
+    let other_kp = even_parity_keypair(&secp, 0x81);
+    let user_xonly = user_kp.x_only_public_key().0.serialize();
+    let other_xonly = other_kp.x_only_public_key().0.serialize();
+    let members = vec![
+        CohortMember {
+            user_id: [0x01; 32],
+            pk_user: user_xonly,
+            slot_index: 0,
+        },
+        CohortMember {
+            user_id: [0x02; 32],
+            pk_user: other_xonly,
+            slot_index: 1,
+        },
+    ];
+    let horizon = HibernationHorizon::new(n, n.max(50)).expect("horizon");
+    let cohort = Cohort::new(COHORT_ID, members, horizon).expect("cohort");
+
+    // Slot root + signed SlotAttest.
+    let tree = SlotTree::from_members(&cohort.members);
+    let SlotRoot(slot_root) = tree.root();
+    let unsigned = SlotAttestUnsigned {
+        slot_root,
+        cohort_id: COHORT_ID,
+        setup_id: SETUP_ID,
+        n: horizon.n,
+        k: cohort.k(),
+    };
+    let attest = unsigned.sign(&secp, &asp_kp);
+
+    // Λ generation at horizon `n`.
+    let asp_sk = SecretKey::from_keypair(&asp_kp);
+    let (schedule, _retained) = Setup::run(&asp_sk, &SETUP_ID, n).expect("setup");
+
+    let batch_root = dark_psar::compute_batch_tree_root(&cohort);
+    Fixture {
+        cohort,
+        attest,
+        schedule,
+        user_kp,
+        asp_xonly,
+        batch_root,
+    }
+}
+
+fn user_board_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("user_board");
+    for &n in &[4u32, 12, 50] {
+        let fx = build_fixture(n);
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut rng = StdRng::seed_from_u64(0xface);
+                user_board(
+                    black_box(&fx.cohort),
+                    black_box(&fx.attest),
+                    black_box(&fx.asp_xonly),
+                    black_box(&fx.schedule),
+                    black_box(&fx.user_kp),
+                    black_box(0u32),
+                    black_box(fx.batch_root),
+                    &mut rng,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(benches, user_board_benchmark);
+criterion_main!(benches);

--- a/crates/dark-psar/benches/epoch.rs
+++ b/crates/dark-psar/benches/epoch.rs
@@ -1,0 +1,131 @@
+//! ASP per-epoch processing latency parameterised over `K ∈ {100, 1000}`
+//! (issue #683).
+//!
+//! Measures `dark_psar::process_epoch` — one full epoch of MuSig2
+//! partial-sign-and-aggregate over every member of the cohort. The
+//! `ActiveCohort` is built once outside the timed loop via
+//! `dark_psar::asp_board`; the bench iterates `process_epoch(t = 1)`
+//! repeatedly because the cohort lifecycle returns to `Active` after
+//! every successful epoch (so `t = 1` is replayable).
+//!
+//! `K = 10000` lives in a separate `--bench long` group, opt-in via
+//! `BENCH_LONG=1`. Without the env var the long group degenerates to
+//! a no-op so default `cargo bench` runs in minutes, not hours.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p dark-psar --bench epoch
+//! BENCH_LONG=1 cargo bench -p dark-psar --bench epoch -- long
+//! ```
+//!
+//! Numbers feed `docs/benchmarks/psar-epoch.md`.
+
+use std::time::Duration;
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use secp256k1::{Keypair, Parity, Secp256k1, SecretKey};
+
+use dark_psar::{asp_board, process_epoch, ActiveCohort, CohortMember, HibernationHorizon};
+
+const SETUP_ID: [u8; 32] = [0xc4; 32];
+const COHORT_ID: [u8; 32] = [0xab; 32];
+/// Horizon for the per-epoch bench. `N` does not change the per-epoch
+/// cost (one epoch's worth of work regardless of horizon length); the
+/// smallest legal value (N=2) keeps boarding-side setup fast.
+const HORIZON_N: u32 = 2;
+
+fn even_parity_keypair(secp: &Secp256k1<secp256k1::All>, seed: u64) -> Keypair {
+    for offset in 0u32..1024 {
+        let mut bytes = [0u8; 32];
+        bytes[..8].copy_from_slice(&seed.to_le_bytes());
+        bytes[28..32].copy_from_slice(&offset.to_le_bytes());
+        if let Ok(sk) = SecretKey::from_slice(&bytes) {
+            let kp = Keypair::from_secret_key(secp, &sk);
+            if kp.x_only_public_key().1 == Parity::Even {
+                return kp;
+            }
+        }
+    }
+    panic!("no even-parity keypair within counter range")
+}
+
+fn build_members(secp: &Secp256k1<secp256k1::All>, k: u32) -> Vec<(CohortMember, Keypair)> {
+    (0..k)
+        .map(|i| {
+            let kp = even_parity_keypair(secp, 0x1000_0001_u64.wrapping_mul(i as u64 + 1));
+            let xonly = kp.x_only_public_key().0.serialize();
+            let mut user_id = [0u8; 32];
+            user_id[0] = ((i >> 8) & 0xff) as u8;
+            user_id[1] = (i & 0xff) as u8;
+            (
+                CohortMember {
+                    user_id,
+                    pk_user: xonly,
+                    slot_index: i,
+                },
+                kp,
+            )
+        })
+        .collect()
+}
+
+fn build_active_cohort(k: u32) -> (Keypair, ActiveCohort) {
+    let secp = Secp256k1::new();
+    let asp_kp = even_parity_keypair(&secp, 0xa0);
+    let horizon = HibernationHorizon::new(HORIZON_N, HORIZON_N.max(12)).unwrap();
+    let members_kps = build_members(&secp, k);
+    let mut rng = StdRng::seed_from_u64(0xdada);
+    let active = asp_board(
+        &asp_kp,
+        COHORT_ID,
+        members_kps,
+        horizon,
+        SETUP_ID,
+        None,
+        &mut rng,
+    )
+    .expect("asp_board");
+    (asp_kp, active)
+}
+
+fn process_epoch_benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("process_epoch");
+    // Per-K wall-clock at K=1000 is ~500 ms × 10 samples ≈ 5 s + warm-up.
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(8));
+    for &k in &[100u32, 1000] {
+        let (asp_kp, mut active) = build_active_cohort(k);
+        group.bench_with_input(BenchmarkId::from_parameter(k), &k, |b, _| {
+            b.iter(|| process_epoch(black_box(&mut active), black_box(&asp_kp), 1).unwrap())
+        });
+    }
+    group.finish();
+}
+
+/// `BENCH_LONG=1 cargo bench -p dark-psar --bench epoch -- long` opts
+/// into the K=10000 measurement. Setup runs ~5 minutes; per-iter
+/// process_epoch ~5 s; total ~10 min.
+fn process_epoch_long_benchmark(c: &mut Criterion) {
+    if std::env::var("BENCH_LONG").ok().as_deref() != Some("1") {
+        return; // Skipped — set BENCH_LONG=1 to opt in.
+    }
+    let mut group = c.benchmark_group("process_epoch_long");
+    group.sample_size(10);
+    group.measurement_time(Duration::from_secs(120));
+    let k = 10_000u32;
+    let (asp_kp, mut active) = build_active_cohort(k);
+    group.bench_with_input(BenchmarkId::from_parameter(k), &k, |b, _| {
+        b.iter(|| process_epoch(black_box(&mut active), black_box(&asp_kp), 1).unwrap())
+    });
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    process_epoch_benchmark,
+    process_epoch_long_benchmark
+);
+criterion_main!(benches);

--- a/crates/dark-von-musig2/Cargo.toml
+++ b/crates/dark-von-musig2/Cargo.toml
@@ -25,7 +25,16 @@ rand = "0.8"
 musig2 = "0.3.1"
 hex = "0.4"
 bitcoin = { version = "0.32", features = ["rand"] }
+criterion = { version = "0.5", features = ["html_reports"] }
 
 [lib]
 name = "dark_von_musig2"
 path = "src/lib.rs"
+
+[[bench]]
+name = "partial_sign"
+harness = false
+
+[[bench]]
+name = "aggregate"
+harness = false

--- a/crates/dark-von-musig2/benches/aggregate.rs
+++ b/crates/dark-von-musig2/benches/aggregate.rs
@@ -1,0 +1,97 @@
+//! Criterion bench for VON-MuSig2 partial-sig aggregation (issue #681).
+//!
+//! Measures `sign::aggregate` — combining the operator's and the
+//! participant's partial signatures into a single 64-byte BIP-340
+//! signature. The aggregation step has no per-N or per-K dependence
+//! (it always touches exactly two partials in PSAR's 2-of-2 setting),
+//! so this bench reports a single point estimate.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p dark-von-musig2 --bench aggregate
+//! ```
+
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use secp256k1::{Keypair, Parity, PublicKey, Secp256k1, SecretKey};
+
+use dark_von_musig2::nonces::{AggNonce, PubNonce};
+use dark_von_musig2::presign::presign_horizon;
+use dark_von_musig2::setup::Setup;
+use dark_von_musig2::sign::{
+    aggregate, build_key_agg_ctx, sign_partial_with_von, PartialSignature,
+};
+
+const SETUP_ID: [u8; 32] = [0x42; 32];
+const MSG: [u8; 32] = [0x77; 32];
+
+fn even_parity_keypair(secp: &Secp256k1<secp256k1::All>, seed: u8) -> Keypair {
+    for offset in 0u32..1024 {
+        let mut bytes = [seed; 32];
+        bytes[28..32].copy_from_slice(&offset.to_le_bytes());
+        if let Ok(sk) = SecretKey::from_slice(&bytes) {
+            let kp = Keypair::from_secret_key(secp, &sk);
+            if kp.x_only_public_key().1 == Parity::Even {
+                return kp;
+            }
+        }
+    }
+    panic!("no even-parity keypair within counter range");
+}
+
+fn aggregate_2of2_benchmark(c: &mut Criterion) {
+    // Build a complete 2-of-2 fixture once: agg_nonce, op partial,
+    // participant partial. The bench just measures the final
+    // `aggregate` call.
+    let secp = Secp256k1::new();
+    let op_kp = even_parity_keypair(&secp, 0xa0);
+    let participant_kp = even_parity_keypair(&secp, 0xb0);
+    let op_pk = op_kp.public_key();
+    let participant_pk = participant_kp.public_key();
+    let op_sk = SecretKey::from_keypair(&op_kp);
+    let participant_sk = SecretKey::from_keypair(&participant_kp);
+    let ctx = build_key_agg_ctx(&[op_pk, participant_pk]).expect("key agg");
+
+    // Setup at N=1 — the smallest horizon that gives us a usable
+    // schedule + retained scalars.
+    let (schedule, retained) = Setup::run(&op_sk, &SETUP_ID, 1).expect("setup");
+
+    // Participant pre-signs.
+    let mut rng = StdRng::seed_from_u64(0xcafe);
+    let presigned = presign_horizon(&participant_sk, &op_pk, &ctx, &schedule, &[MSG], &mut rng)
+        .expect("presign_horizon");
+    let participant_partial: PartialSignature = presigned[0].partial_sig;
+    let participant_pubnonce = presigned[0].pub_nonce.clone();
+
+    // Operator builds its own partial against the same agg_nonce.
+    let r_op1 = retained.r(1, 1).expect("r(1,1)").to_owned();
+    let r_op2 = retained.r(1, 2).expect("r(1,2)").to_owned();
+    let op_pubnonce = PubNonce {
+        r1: PublicKey::from_secret_key(&secp, &r_op1),
+        r2: PublicKey::from_secret_key(&secp, &r_op2),
+    };
+    let agg_nonce = AggNonce::sum(&[op_pubnonce, participant_pubnonce]).expect("agg_nonce");
+    let op_partial =
+        sign_partial_with_von(&ctx, &op_sk, (&r_op1, &r_op2), &agg_nonce, &MSG).expect("op sign");
+
+    let partials = [op_partial, participant_partial];
+
+    let mut group = c.benchmark_group("aggregate");
+    group.bench_function("2of2", |b| {
+        b.iter(|| {
+            aggregate(
+                black_box(&ctx),
+                black_box(&agg_nonce),
+                black_box(&MSG),
+                black_box(&partials),
+            )
+            .unwrap()
+        })
+    });
+    group.finish();
+}
+
+criterion_group!(benches, aggregate_2of2_benchmark);
+criterion_main!(benches);

--- a/crates/dark-von-musig2/benches/partial_sign.rs
+++ b/crates/dark-von-musig2/benches/partial_sign.rs
@@ -1,0 +1,141 @@
+//! Criterion benches for VON-MuSig2 partial-sign primitives (issue #681).
+//!
+//! Measures the cost of one operator-side and one participant-side
+//! partial signature in isolation, plus the participant horizon as a
+//! parameterised group over `N ∈ {1, 4, 12, 50}` so the per-call cost
+//! can be derived (`per_call ≈ horizon_cost / N`).
+//!
+//! Pairs with `crates/dark-von/benches/von.rs` (#658) for the
+//! cryptographic primitives that underlie these — ECVRF prove/verify
+//! and `wrapper::nonce` are benched there; this file measures the
+//! BIP-327 signing layer on top.
+//!
+//! Run with:
+//!
+//! ```bash
+//! cargo bench -p dark-von-musig2 --bench partial_sign
+//! ```
+
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
+use rand::rngs::StdRng;
+use rand::SeedableRng;
+use secp256k1::{Keypair, Parity, PublicKey, Secp256k1, SecretKey};
+
+use dark_von_musig2::nonces::{AggNonce, PubNonce};
+use dark_von_musig2::presign::presign_horizon;
+use dark_von_musig2::setup::Setup;
+use dark_von_musig2::sign::{build_key_agg_ctx, sign_partial_with_von};
+
+const SETUP_ID: [u8; 32] = [0x42; 32];
+const MSG: [u8; 32] = [0x77; 32];
+
+fn even_parity_keypair(secp: &Secp256k1<secp256k1::All>, seed: u8) -> Keypair {
+    for offset in 0u32..1024 {
+        let mut bytes = [seed; 32];
+        bytes[28..32].copy_from_slice(&offset.to_le_bytes());
+        if let Ok(sk) = SecretKey::from_slice(&bytes) {
+            let kp = Keypair::from_secret_key(secp, &sk);
+            if kp.x_only_public_key().1 == Parity::Even {
+                return kp;
+            }
+        }
+    }
+    panic!("no even-parity keypair within counter range");
+}
+
+fn partial_sign_operator_benchmark(c: &mut Criterion) {
+    // ─── Inline setup so we don't need to expose KeyAggCtx ────────────
+    let secp = Secp256k1::new();
+    let op_kp = even_parity_keypair(&secp, 0xa0);
+    let participant_kp = even_parity_keypair(&secp, 0xb0);
+    let op_pk = op_kp.public_key();
+    let participant_pk = participant_kp.public_key();
+    let op_sk = SecretKey::from_keypair(&op_kp);
+    let participant_sk = SecretKey::from_keypair(&participant_kp);
+
+    // 2-of-2 key aggregation.
+    let ctx = build_key_agg_ctx(&[op_pk, participant_pk]).expect("key agg");
+
+    // Setup at N=1 to get one (r_op1, r_op2) pair.
+    let (schedule, retained) = Setup::run(&op_sk, &SETUP_ID, 1).expect("setup N=1");
+
+    // Participant pre-signs the single epoch — gives us the participant's
+    // PubNonce so we can build the AggNonce the operator will sign against.
+    let messages = [MSG];
+    let mut rng = StdRng::seed_from_u64(0xcafe);
+    let presigned = presign_horizon(
+        &participant_sk,
+        &op_pk,
+        &ctx,
+        &schedule,
+        &messages,
+        &mut rng,
+    )
+    .expect("presign_horizon N=1");
+    let participant_pubnonce = presigned[0].pub_nonce.clone();
+
+    // Operator's VON-bound `(r1, r2)` for epoch 1.
+    let r_op1 = retained.r(1, 1).expect("r(1,1)").to_owned();
+    let r_op2 = retained.r(1, 2).expect("r(1,2)").to_owned();
+    let r_op1_p = PublicKey::from_secret_key(&secp, &r_op1);
+    let r_op2_p = PublicKey::from_secret_key(&secp, &r_op2);
+    let op_pubnonce = PubNonce {
+        r1: r_op1_p,
+        r2: r_op2_p,
+    };
+    let agg_nonce = AggNonce::sum(&[op_pubnonce, participant_pubnonce]).expect("agg_nonce");
+
+    let mut group = c.benchmark_group("partial_sign");
+    group.bench_function("operator", |b| {
+        b.iter(|| {
+            sign_partial_with_von(
+                black_box(&ctx),
+                black_box(&op_sk),
+                (black_box(&r_op1), black_box(&r_op2)),
+                black_box(&agg_nonce),
+                black_box(&MSG),
+            )
+            .unwrap()
+        })
+    });
+    group.finish();
+}
+
+fn partial_sign_participant_horizon_benchmark(c: &mut Criterion) {
+    let secp = Secp256k1::new();
+    let op_kp = even_parity_keypair(&secp, 0xa0);
+    let participant_kp = even_parity_keypair(&secp, 0xb0);
+    let op_pk = op_kp.public_key();
+    let participant_pk = participant_kp.public_key();
+    let op_sk = SecretKey::from_keypair(&op_kp);
+    let participant_sk = SecretKey::from_keypair(&participant_kp);
+    let ctx = build_key_agg_ctx(&[op_pk, participant_pk]).expect("key agg");
+
+    let mut group = c.benchmark_group("partial_sign_participant_horizon");
+    for &n in &[1u32, 4, 12, 50] {
+        let (schedule, _retained) = Setup::run(&op_sk, &SETUP_ID, n).expect("setup");
+        let messages: Vec<[u8; 32]> = (0..n as usize).map(|i| [(0x40 + i as u8); 32]).collect();
+        group.bench_with_input(BenchmarkId::from_parameter(n), &n, |b, _| {
+            b.iter(|| {
+                let mut rng = StdRng::seed_from_u64(0xface);
+                presign_horizon(
+                    black_box(&participant_sk),
+                    black_box(&op_pk),
+                    black_box(&ctx),
+                    black_box(&schedule),
+                    black_box(&messages),
+                    &mut rng,
+                )
+                .unwrap()
+            })
+        });
+    }
+    group.finish();
+}
+
+criterion_group!(
+    benches,
+    partial_sign_operator_benchmark,
+    partial_sign_participant_horizon_benchmark
+);
+criterion_main!(benches);

--- a/docs/benchmarks/figures/boarding-vs-n.svg
+++ b/docs/benchmarks/figures/boarding-vs-n.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420" width="640" height="420" font-family="-apple-system, sans-serif" font-size="12">
+<rect width="640" height="420" fill="white" />
+<text x="320.0" y="24.0" text-anchor="middle" fill="#222" font-size="15">Single-user boarding latency vs horizon N (Apple M3 Max)</text>
+<line x1="70.0" y1="50.0" x2="70.0" y2="360.0" stroke="#222" stroke-width="1.0" stroke-linecap="round" />
+<line x1="70.0" y1="360.0" x2="610.0" y2="360.0" stroke="#222" stroke-width="1.0" stroke-linecap="round" />
+<line x1="94.5" y1="360.0" x2="94.5" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="94.5" y="378.0" text-anchor="middle" fill="#222" font-size="11">4</text>
+<line x1="179.9" y1="360.0" x2="179.9" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="179.9" y="378.0" text-anchor="middle" fill="#222" font-size="11">12</text>
+<line x1="585.5" y1="360.0" x2="585.5" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="585.5" y="378.0" text-anchor="middle" fill="#222" font-size="11">50</text>
+<line x1="65.0" y1="360.0" x2="70.0" y2="360.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="364.0" text-anchor="end" fill="#222" font-size="11">0</text>
+<line x1="70.0" y1="360.0" x2="610.0" y2="360.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="298.0" x2="70.0" y2="298.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="302.0" text-anchor="end" fill="#222" font-size="11">4.6</text>
+<line x1="70.0" y1="298.0" x2="610.0" y2="298.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="236.0" x2="70.0" y2="236.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="240.0" text-anchor="end" fill="#222" font-size="11">9.1</text>
+<line x1="70.0" y1="236.0" x2="610.0" y2="236.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="174.0" x2="70.0" y2="174.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="178.0" text-anchor="end" fill="#222" font-size="11">13.7</text>
+<line x1="70.0" y1="174.0" x2="610.0" y2="174.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="112.0" x2="70.0" y2="112.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="116.0" text-anchor="end" fill="#222" font-size="11">18.2</text>
+<line x1="70.0" y1="112.0" x2="610.0" y2="112.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="50.0" x2="70.0" y2="50.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="54.0" text-anchor="end" fill="#222" font-size="11">22.8</text>
+<line x1="70.0" y1="50.0" x2="610.0" y2="50.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<text x="340.0" y="402.0" text-anchor="middle" fill="#222" font-size="13">Horizon N (epochs)</text>
+<text x="18" y="205.0" text-anchor="middle" font-size="13" transform="rotate(-90 18 205.0)">user_board latency (ms)</text>
+<polyline points="94.5,337.4 179.9,295.3 585.5,90.4" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" />
+<circle cx="94.5" cy="337.4" r="4" fill="#1f77b4" />
+<circle cx="179.9" cy="295.3" r="4" fill="#1f77b4" />
+<circle cx="585.5" cy="90.4" r="4" fill="#1f77b4" />
+<circle cx="179.9" cy="295.3" r="6" fill="#d62728" />
+<text x="189.9" y="287.3" text-anchor="start" fill="#d62728" font-size="11">★ lead row</text>
+</svg>

--- a/docs/benchmarks/figures/epoch-vs-k.svg
+++ b/docs/benchmarks/figures/epoch-vs-k.svg
@@ -1,0 +1,35 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420" width="640" height="420" font-family="-apple-system, sans-serif" font-size="12">
+<rect width="640" height="420" fill="white" />
+<text x="320.0" y="24.0" text-anchor="middle" fill="#222" font-size="15">Per-epoch ASP processing latency vs cohort size K</text>
+<line x1="70.0" y1="50.0" x2="70.0" y2="360.0" stroke="#222" stroke-width="1.0" stroke-linecap="round" />
+<line x1="70.0" y1="360.0" x2="610.0" y2="360.0" stroke="#222" stroke-width="1.0" stroke-linecap="round" />
+<line x1="94.5" y1="360.0" x2="94.5" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="94.5" y="378.0" text-anchor="middle" fill="#222" font-size="11">100</text>
+<line x1="585.5" y1="360.0" x2="585.5" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="585.5" y="378.0" text-anchor="middle" fill="#222" font-size="11">1.0K</text>
+<line x1="65.0" y1="360.0" x2="70.0" y2="360.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="364.0" text-anchor="end" fill="#222" font-size="11">0</text>
+<line x1="70.0" y1="360.0" x2="610.0" y2="360.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="298.0" x2="70.0" y2="298.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="302.0" text-anchor="end" fill="#222" font-size="11">52.2</text>
+<line x1="70.0" y1="298.0" x2="610.0" y2="298.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="236.0" x2="70.0" y2="236.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="240.0" text-anchor="end" fill="#222" font-size="11">104.3</text>
+<line x1="70.0" y1="236.0" x2="610.0" y2="236.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="174.0" x2="70.0" y2="174.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="178.0" text-anchor="end" fill="#222" font-size="11">156.5</text>
+<line x1="70.0" y1="174.0" x2="610.0" y2="174.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="112.0" x2="70.0" y2="112.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="116.0" text-anchor="end" fill="#222" font-size="11">208.7</text>
+<line x1="70.0" y1="112.0" x2="610.0" y2="112.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="50.0" x2="70.0" y2="50.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="54.0" text-anchor="end" fill="#222" font-size="11">260.8</text>
+<line x1="70.0" y1="50.0" x2="610.0" y2="50.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<text x="340.0" y="402.0" text-anchor="middle" fill="#222" font-size="13">Cohort size K (log scale)</text>
+<text x="18" y="205.0" text-anchor="middle" font-size="13" transform="rotate(-90 18 205.0)">process_epoch latency (ms)</text>
+<polyline points="94.5,332.8 585.5,90.4" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" />
+<circle cx="94.5" cy="332.8" r="4" fill="#1f77b4" />
+<circle cx="585.5" cy="90.4" r="4" fill="#1f77b4" />
+<circle cx="585.5" cy="90.4" r="6" fill="#d62728" />
+<text x="595.5" y="82.4" text-anchor="start" fill="#d62728" font-size="11">★ lead row</text>
+</svg>

--- a/docs/benchmarks/figures/storage-vs-k.svg
+++ b/docs/benchmarks/figures/storage-vs-k.svg
@@ -1,0 +1,38 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 640 420" width="640" height="420" font-family="-apple-system, sans-serif" font-size="12">
+<rect width="640" height="420" fill="white" />
+<text x="320.0" y="24.0" text-anchor="middle" fill="#222" font-size="15">Total in-memory storage per cohort vs K (N=12)</text>
+<line x1="70.0" y1="50.0" x2="70.0" y2="360.0" stroke="#222" stroke-width="1.0" stroke-linecap="round" />
+<line x1="70.0" y1="360.0" x2="610.0" y2="360.0" stroke="#222" stroke-width="1.0" stroke-linecap="round" />
+<line x1="82.9" y1="360.0" x2="82.9" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="82.9" y="378.0" text-anchor="middle" fill="#222" font-size="11">100</text>
+<line x1="340.0" y1="360.0" x2="340.0" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="340.0" y="378.0" text-anchor="middle" fill="#222" font-size="11">1.0K</text>
+<line x1="597.1" y1="360.0" x2="597.1" y2="365.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="597.1" y="378.0" text-anchor="middle" fill="#222" font-size="11">10.0K</text>
+<line x1="65.0" y1="360.0" x2="70.0" y2="360.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="364.0" text-anchor="end" fill="#222" font-size="11">0</text>
+<line x1="70.0" y1="360.0" x2="610.0" y2="360.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="298.0" x2="70.0" y2="298.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="302.0" text-anchor="end" fill="#222" font-size="11">3K</text>
+<line x1="70.0" y1="298.0" x2="610.0" y2="298.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="236.0" x2="70.0" y2="236.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="240.0" text-anchor="end" fill="#222" font-size="11">6K</text>
+<line x1="70.0" y1="236.0" x2="610.0" y2="236.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="174.0" x2="70.0" y2="174.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="178.0" text-anchor="end" fill="#222" font-size="11">9K</text>
+<line x1="70.0" y1="174.0" x2="610.0" y2="174.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="112.0" x2="70.0" y2="112.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="116.0" text-anchor="end" fill="#222" font-size="11">12K</text>
+<line x1="70.0" y1="112.0" x2="610.0" y2="112.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<line x1="65.0" y1="50.0" x2="70.0" y2="50.0" stroke="#888" stroke-width="1.0" stroke-linecap="round" />
+<text x="62.0" y="54.0" text-anchor="end" fill="#222" font-size="11">15K</text>
+<line x1="70.0" y1="50.0" x2="610.0" y2="50.0" stroke="#eee" stroke-width="1.0" stroke-linecap="round" />
+<text x="340.0" y="402.0" text-anchor="middle" fill="#222" font-size="13">Cohort size K (log scale)</text>
+<text x="18" y="205.0" text-anchor="middle" font-size="13" transform="rotate(-90 18 205.0)">In-memory storage (KB)</text>
+<polyline points="82.9,357.2 340.0,333.0 597.1,90.4" fill="none" stroke="#1f77b4" stroke-width="2" stroke-linejoin="round" />
+<circle cx="82.9" cy="357.2" r="4" fill="#1f77b4" />
+<circle cx="340.0" cy="333.0" r="4" fill="#1f77b4" />
+<circle cx="597.1" cy="90.4" r="4" fill="#1f77b4" />
+<circle cx="340.0" cy="333.0" r="6" fill="#d62728" />
+<text x="350.0" y="325.0" text-anchor="start" fill="#d62728" font-size="11">★ lead row</text>
+</svg>

--- a/docs/benchmarks/psar-boarding.md
+++ b/docs/benchmarks/psar-boarding.md
@@ -1,0 +1,103 @@
+# PSAR boarding latency
+
+Source of truth for issue #682's boarding-vs-N curve. Regenerate
+with:
+
+```bash
+cargo bench -p dark-psar --bench boarding -- --quick
+```
+
+Numbers below are the median of one Criterion `--quick` run (3 s
+measurement, 1 s warm-up). Pairs with
+`docs/benchmarks/von-musig2-primitives.md` (the per-epoch participant
+partial-sign primitive) and `docs/benchmarks/von-primitives.md` (the
+underlying ECVRF / `wrapper` cost).
+
+## Hardware context
+
+| Field     | Value                                       |
+|-----------|---------------------------------------------|
+| CPU       | Apple M3 Max                                |
+| Cores     | 14 (10 performance + 4 efficiency)          |
+| Memory    | 36 GB                                       |
+| OS        | macOS 26.3.1 (Darwin 25.3.0)                |
+| Toolchain | rustc 1.95.0 (release profile, lto = false) |
+
+## What `user_board` does
+
+End-to-end client-side boarding (`crates/dark-psar/src/boarding.rs`):
+
+1. Verify the ASP's signed `SlotAttest` against `pk_asp` (1 BIP-340 verify).
+2. Recompute the slot Merkle root over `cohort.members` and check it
+   matches the attestation (`O(K)` SHA-256 hashes, K=2 in this fixture).
+3. Verify every entry of the published Λ via `dark_von::wrapper::verify`
+   (`2N` calls — one per `(t, b)` slot).
+4. Derive `m_t` for each `t ∈ [1, N]` (cheap SHA-256).
+5. Pre-sign the horizon via `dark_von_musig2::presign::presign_horizon`
+   (re-verifies Λ, generates `N` participant nonces, computes `N`
+   partial signatures).
+6. Compute the schedule-witness hash chain over `2N+1` SHA-256
+   updates.
+
+The dominant per-epoch cost is steps 3 + 5 — verifying Λ then
+producing one BIP-327 partial against it.
+
+## Boarding latency vs N
+
+| `N` | Median   | Per-epoch (`/N`) | Notes |
+|-----|----------|------------------|-------|
+| 4   | 1.66 ms  | 416 µs           |       |
+| 12  | 4.75 ms  | 396 µs           |       |
+| 50  | 19.80 ms | 396 µs           |       |
+
+Per-epoch cost converges to **~395 µs** as N grows; the constant
+overhead (attest verify, slot-root recompute, schedule-witness
+init) is ~150 µs and matters at small N.
+
+### Decomposition at N=12 (lead config)
+
+| Component                              | Cost     | Source bench                                |
+|----------------------------------------|----------|---------------------------------------------|
+| Per-epoch participant partial-sign     | ~225 µs  | `partial_sign_participant_horizon/12` (#681) |
+| `derive_message_for_epoch` + framing   | ~10 µs   | inline                                      |
+| Λ pre-verify (already counted in 225µs above; presign re-verifies internally) | (overlap) | (overlap) |
+| Boarding-only overhead per epoch       | ~160 µs  | residual: 396 − 225 − 10 ≈ 160 µs            |
+
+The "boarding-only overhead per epoch" is the second pass over Λ
+that happens inside `boarding::user_board::verify_lambda_entries`
+*before* `presign_horizon` (which then re-verifies). The duplication
+exists for ergonomic error reporting (`(epoch, slot)`-tagged errors —
+see boarding.rs comment) and is a known follow-up if boarding cost
+ever becomes the bottleneck. At N=12 the cost is < 2 ms and not
+worth the ergonomic regression today.
+
+### Front-loaded constants
+
+- ~110 µs — `SlotAttest::verify` (BIP-340 Schnorr verify of the ASP's signature).
+- ~30 µs — `SlotRoot::compute` over K=2 members.
+- Single SHA-256 init for the schedule-witness chain.
+
+Total fixed cost ≈ **150 µs**, matches the difference between the
+per-N constant (~395 µs/epoch) and `(median − 150 µs) / N` at N=12.
+
+## At-a-glance scaling
+
+```text
+user_board(N)  ≈ 150 µs  +  N × 395 µs
+```
+
+At the paper's lead horizon **N=12**: 4.75 ms per user.
+At the stretch horizon **N=50**: 19.8 ms per user.
+
+These costs are independent of the cohort size `K` — every user
+boards in parallel and `user_board` does not touch the other K−1
+member set beyond hashing them into the slot tree (which is amortised
+at ~200 ns per member at K up to 10⁴).
+
+## Threshold sentinels
+
+| Bench           | Envelope (Apple M-series)        | Notes |
+|-----------------|----------------------------------|-------|
+| `user_board/4`  | ≤ 5 ms                           | ~3× slack over measured 1.66 ms |
+| `user_board/12` | ≤ 10 ms                          | ~2× slack over measured 4.75 ms |
+| `user_board/50` | linear in N, slope ≤ 500 µs/epoch | Consistent with `presign_horizon` linearity |

--- a/docs/benchmarks/psar-epoch.md
+++ b/docs/benchmarks/psar-epoch.md
@@ -1,0 +1,90 @@
+# PSAR per-epoch ASP latency
+
+Source of truth for issue #683's per-epoch ASP-side latency curve.
+Regenerate with:
+
+```bash
+cargo bench -p dark-psar --bench epoch -- --quick
+
+# Optional K=10000 stretch row (≈10 min including setup):
+BENCH_LONG=1 cargo bench -p dark-psar --bench epoch -- long
+```
+
+Numbers below are the median of one Criterion `--quick` run (3 s
+measurement, 1 s warm-up, sample size 10 — overridden because per-K
+iteration cost grows linearly).
+
+## Hardware context
+
+| Field     | Value                                       |
+|-----------|---------------------------------------------|
+| CPU       | Apple M3 Max                                |
+| Cores     | 14 (10 performance + 4 efficiency)          |
+| Memory    | 36 GB                                       |
+| OS        | macOS 26.3.1 (Darwin 25.3.0)                |
+| Toolchain | rustc 1.95.0 (release profile, lto = false) |
+
+## What `process_epoch` does
+
+For each cohort member at fixed epoch `t` (`crates/dark-psar/src/epoch.rs`):
+
+1. Look up the participant's pre-signed `(pub_nonce, partial_sig)` for
+   `t-1` from the in-memory `ActiveCohort.artifacts` map.
+2. Rebuild the 2-of-2 `KeyAggCtx` over `[asp_pk, member_pk]`.
+3. Invoke `dark_von_musig2::epoch::sign_epoch`, which:
+   a. Re-derives the operator's `(R₁, R₂)` for `t` from
+      `RetainedScalars`.
+   b. Aggregates `(R_op, participant_R)` into `agg_nonce`.
+   c. Calls `partial_sig_verify` against the participant's partial.
+   d. Computes the operator's partial via `partial_sign_with_scalars`.
+   e. Aggregates the two partials into a 64-byte BIP-340 signature.
+
+The cost is dominated by step 3.c (`partial_sig_verify` ≈ 225 µs) per
+the standalone numbers in
+`docs/benchmarks/von-musig2-primitives.md`.
+
+The horizon `N` does not affect per-epoch cost (one epoch is one
+epoch's worth of work regardless of horizon length); the bench
+fixture uses the smallest legal `N=2` to keep boarding-side setup
+fast.
+
+## Per-epoch latency vs K
+
+| `K`    | Median       | Per-user (`/K`) | Notes |
+|--------|--------------|-----------------|-------|
+| 100    | 22.9 ms      | 229 µs          |       |
+| 1 000  | 226.8 ms     | 226 µs          |       |
+| 10 000 | TBD (`BENCH_LONG=1`) | TBD     | Long-run group; documented when first measured |
+
+Per-user cost stays in the **226–229 µs band** — confirms linearity
+with no hidden quadratic (consistent with the standalone primitives:
+~225 µs `partial_sig_verify` + ~45 µs `partial_sign` + ~20 µs
+`aggregate` overlapping with KeyAggCtx caching).
+
+## Rate
+
+At K=1000, **226 ms per epoch** = **4 410 user-renewals/second**
+sustained on dev hardware. The lead-config table for the paper at
+K=100 / N=12 cohorts:
+
+```text
+process_epoch(K=100)  = 22.9 ms / epoch
+total per cohort      = N × process_epoch = 12 × 22.9 ms ≈ 275 ms
+```
+
+## Parallelisation outlook
+
+`process_epoch` walks `cohort.members` serially. Per-user work is
+trivially parallelisable (each user's `KeyAggCtx + sign_epoch` is
+independent). At K=1000 a 14-core M3 Max would expect ~14× speedup
+modulo NUMA — i.e. ~16 ms per epoch. **Phase 6 does not implement
+parallelisation**; the speedup is reported as a follow-up if
+serial latency becomes a bottleneck on the production ASP path.
+
+## Threshold sentinels
+
+| Bench                    | Envelope (Apple M-series) | Notes |
+|--------------------------|---------------------------|-------|
+| `process_epoch/100`      | ≤ 50 ms                   | ~2× slack over measured 23 ms |
+| `process_epoch/1000`     | ≤ 500 ms                  | ~2.2× slack over measured 227 ms |
+| Per-user cost            | linear in K, slope ≤ 500 µs/user | Consistent with primitives |

--- a/docs/benchmarks/psar-onchain.md
+++ b/docs/benchmarks/psar-onchain.md
@@ -1,0 +1,130 @@
+# PSAR on-chain footprint
+
+Source of truth for issue #685's on-chain footprint numbers.
+Regenerate measurements by running:
+
+```bash
+nigiri start
+scripts/psar-onchain.sh
+```
+
+Until a Nigiri-backed run lands, the formulas below are the
+authoritative source — they're derived directly from
+`crates/dark-psar/src/publish.rs` and the SlotAttest layout in
+`crates/dark-psar/src/attest.rs`.
+
+## What touches L1 in PSAR
+
+PSAR's design intent is to **minimise L1 footprint per cohort**.
+Per-epoch renewals are off-chain MuSig2 signatures bound to the
+cohort's pre-published `Λ` — they do not produce on-chain
+transactions. The only PSAR-specific tx that hits L1 is:
+
+- **`slot_attest_S`** — a single OP_RETURN tx that the ASP
+  publishes once per cohort, committing to the slot Merkle root
+  and the cohort metadata. Implemented by
+  `dark_psar::publish::publish_slot_attest`.
+
+Everything else on L1 (cohort funding, batch settlement at
+exit/sweep, unilateral exits) is **standard Ark** — not introduced
+by PSAR. The "per-batch overhead" the issue text alludes to is the
+Ark commitment-tx cost when a cohort settles, not a new PSAR-specific
+transaction structure.
+
+## `slot_attest_S` analytical breakdown
+
+From `publish.rs:73`–`121` and `attest.rs:154`–`183`:
+
+| Component                           | Size (B) | Notes                                       |
+|-------------------------------------|----------|---------------------------------------------|
+| Tx version                          | 4        | Fixed — version 2                            |
+| Tx locktime                         | 4        | Fixed — `LockTime::ZERO`                     |
+| Input count + output count          | 2        | varints                                      |
+| **Input**: outpoint + sequence      | 41       | 32 (txid) + 4 (vout) + 4 (sequence) + 1 (empty scriptSig length) |
+| **Output 0** (OP_RETURN)            | ~80      | 8 (zero amount) + 1 (length) + 1 (OP_RETURN) + 1 (push 68) + 68 (payload: 4 magic + 64 sig) + alignment |
+| **Output 1** (P2WPKH change)        | 43       | 8 (amount) + 1 (length) + 31 (P2WPKH script) + 3 alignment |
+| **Witness** (P2WPKH input)          | 107      | 1 (item count) + 1 (length) + 71 (DER+sighash sig) + 1 (length) + 33 (pubkey) |
+| **Total non-witness**               | ~174     | excl. witness                               |
+| **Total raw size**                  | ~281     | non-witness + witness                       |
+| **Weight units (WU)**               | ~803     | non-witness × 4 + witness                   |
+| **Virtual bytes (vbytes)**          | ~201     | ⌈WU / 4⌉                                    |
+
+The OP_RETURN payload is exactly **68 bytes** —
+`OP_RETURN_MAGIC` (4 B, `b"PSAR"`) + the 64-byte BIP-340 signature.
+The other `SlotAttest` fields (`slot_root`, `cohort_id`, `setup_id`,
+`n`, `k`) are **not on-chain**: verifiers reconstruct them from the
+cohort metadata they already share with the ASP, then check the
+on-chain signature.
+
+## Per-cohort total L1 cost
+
+```text
+on_chain_footprint(cohort)
+    = slot_attest_S
+    + per-cohort funding tx (standard Ark)
+    + per-renewal materialisation tx (only at exit, standard Ark)
+```
+
+Substituting:
+
+| Component                                   | Cost (vbytes)         | Frequency               |
+|---------------------------------------------|-----------------------|-------------------------|
+| `slot_attest_S`                             | ~201 vbytes           | once per cohort         |
+| Cohort funding (standard Ark commitment tx) | ~50 + 32 × K vbytes   | once per cohort         |
+| Per-VTXO settlement (standard Ark)          | depends on exit shape | only at exit/settlement |
+
+PSAR's contribution to L1 footprint is **a fixed ~201 vbytes per
+cohort**, regardless of `K` or `N`. Standard Ark dominates the rest
+once `K` exceeds ~10.
+
+### Per-user amortised PSAR-specific cost
+
+| K     | slot_attest vbytes | per-user share |
+|-------|---------------------|----------------|
+| 100   | 201                 | 2.01 vbytes    |
+| 1 000 | 201                 | 0.20 vbytes    |
+
+At cohorts of K=1000 the amortised PSAR-specific on-chain cost is
+**~0.2 vbytes per VTXO** — well below the noise floor of any
+realistic Bitcoin-fee-market scenario.
+
+## Formula for arbitrary N
+
+Per the issue text:
+
+```text
+per_cohort = attest_size + N × renewal_tx_size
+```
+
+In PSAR's hibernation design, `renewal_tx_size = 0` for
+non-materialised renewals — the renewal sigs are off-chain. A
+renewal only hits L1 when a user actually exits at that epoch's
+sig, in which case `renewal_tx_size` is the standard Ark
+unilateral-exit cost. So:
+
+```text
+per_cohort_PSAR_specific = attest_size  ≈ 201 vbytes        (always)
+per_cohort_total         = attest_size + sum over realised exits of (Ark exit tx size)
+```
+
+## Measurement protocol
+
+1. `nigiri start` — boots regtest bitcoind on port 18443.
+2. `scripts/psar-onchain.sh` — runs the existing #669 e2e regtest
+   test (`crates/dark-psar/tests/e2e_psar_regtest.rs`) which
+   publishes one slot_attest, parses the txid from the test output,
+   and queries `bitcoin-cli getrawtransaction` for canonical
+   weight/vbyte numbers. Output is a markdown table.
+3. Append the measured row to the table below.
+
+## Measured (Nigiri regtest)
+
+_Pending Nigiri run — when populated, replace the row below with the
+output of `scripts/psar-onchain.sh`._
+
+| Tx kind        | size (B) | input (B) | witness (B) | output (B) | weight (WU) | vbytes |
+|----------------|----------|-----------|-------------|------------|-------------|--------|
+| slot_attest_S  | TBD      | TBD       | TBD         | TBD        | TBD         | TBD    |
+
+The analytical table above (`~281` raw, `~803` WU, `~201` vbytes) is
+the upper bound the measurement should land within ±5 %.

--- a/docs/benchmarks/psar-scaling.md
+++ b/docs/benchmarks/psar-scaling.md
@@ -1,0 +1,119 @@
+# PSAR cohort scaling
+
+Source of truth for issue #684's storage and aggregate-time numbers
+across the (K × N) cross-product. Regenerate with:
+
+```bash
+scripts/psar-scaling.sh --include-stretch
+```
+
+Numbers below are from one run on the hardware listed below. Each
+configuration runs the full PSAR pipeline (`psar-demo`): K-user
+boarding → N epochs → per-user signature verification.
+
+## Hardware context
+
+| Field     | Value                                       |
+|-----------|---------------------------------------------|
+| CPU       | Apple M3 Max                                |
+| Cores     | 14 (10 performance + 4 efficiency)          |
+| Memory    | 36 GB                                       |
+| OS        | macOS 26.3.1 (Darwin 25.3.0)                |
+| Toolchain | rustc 1.95.0 (release profile, lto = false) |
+
+## Wall-clock at four configurations
+
+| K       | N   | boarding_ms | epoch_ms_avg | total_sigs | all_verify | wall_clock_ms |
+|---------|-----|-------------|--------------|------------|------------|----------------|
+| 100     | 12  | 493         | 22.2         | 1 200      | true       | 830            |
+| 1 000   | 12  | 5 644       | 227.7        | 12 000     | true       | 9 017          |
+| 1 000   | 50  | 20 370      | 228.7        | 50 000     | true       | 34 389         |
+| 10 000  | 12  | 141 986     | 2 291.7      | 120 000    | true       | 175 818        |
+
+**Lead row** (★) for the paper: **K=1000, N=12** — production-shape
+cohort that completes in under 10 s wall-clock end-to-end.
+
+### Observations
+
+- **Per-epoch cost is K-linear, N-independent.** At K=1000, the
+  per-epoch median is 227.7 ms regardless of horizon (matches the
+  isolated bench in `docs/benchmarks/psar-epoch.md`).
+- **Boarding is K-linear up to K=1000.** From K=100 to K=1000 the
+  ratio is 5644 / 493 ≈ 11.4× for a 10× user-count increase —
+  consistent with linear plus a fixed setup cost (`Setup::run`,
+  slot-tree construction).
+- **K=10000 is super-linear in boarding.** 142 s vs 5.64 s × 10 ≈
+  56 s expected → ~2.5× over the linear extrapolation. Likely
+  causes: heap-allocator pressure on the K-vector pre-signed
+  artifacts and L2/L3 cache thrash during the per-user `user_board`
+  Λ-verify pass. Per-epoch processing remains linear (2.29 s vs
+  228 ms × 10 = 2.28 s expected). Profile-guided cleanup is a
+  follow-up; the K=10000 cohort still completes in ~3 minutes.
+
+### Per-user amortised cost
+
+| K       | N   | boarding µs/user | epoch µs/user/epoch |
+|---------|-----|-------------------|---------------------|
+| 100     | 12  | 4 930             | 222                 |
+| 1 000   | 12  | 5 644             | 228                 |
+| 1 000   | 50  | 20 370            | 229                 |
+| 10 000  | 12  | 14 199            | 229                 |
+
+Per-user epoch cost is **226–229 µs** stable across all configs.
+Per-user boarding cost stays in the **5–6 ms** band up to K=1000;
+K=10000's 14 ms/user reflects the super-linear regime above.
+
+## Storage per cohort
+
+Storage analytics are derived from the in-memory layout of
+`dark_psar::ActiveCohort` and the wire formulas published in
+`docs/benchmarks/von-primitives.md`. These are tight lower bounds;
+allocator slack and `Vec` capacity overhead typically add 20–30 %.
+
+### Component formulas
+
+| Component                                       | Formula (bytes)         | Notes                                   |
+|-------------------------------------------------|-------------------------|-----------------------------------------|
+| `RetainedScalars` (operator-only)               | `64 · N`                | `2N` × `SecretKey` (32 B each)          |
+| `PublishedSchedule`                             | `36 + 228 · N`          | Per `dark-von` baseline                 |
+| `UserBoardingArtifact` (per user)               | `64 + 98 · N`           | slot_index/n + N × (`PubNonce` 66 + `PartialSignature` 32) + 32-B witness |
+| All boarding artifacts (per cohort)             | `K · (64 + 98 · N)`     | = `64K + 98KN`                          |
+| `Cohort.members`                                | `≈ 72 · K`              | `CohortMember` ≈ 72 B with alignment    |
+| Constants (`SlotAttest`, slot/batch roots)      | `≈ 180`                 | Independent of (K, N)                   |
+| **Total in-memory footprint**                   | `186K + 98KN + 292N + 180` | Lower bound, ±20 % allocator slack |
+
+### Storage table
+
+Computed from the formula above (rounded; allocator slack means
+real RSS is up to 30 % higher).
+
+| K       | N   | RetainedScalars | PublishedSchedule | All artifacts | Members  | Total (formula) | Notes |
+|---------|-----|-----------------|-------------------|---------------|----------|------------------|-------|
+| 100     | 12  | 768 B           | 2 772 B           | 124.0 KB      | 7.2 KB   | **140 KB**       | Lead row★ |
+| 1 000   | 12  | 768 B           | 2 772 B           | 1 213 KB      | 72 KB    | **1.37 MB**      |       |
+| 1 000   | 50  | 3 200 B         | 11 436 B          | 4 970 KB      | 72 KB    | **5.10 MB**      |       |
+| 10 000  | 12  | 768 B           | 2 772 B           | 11 875 KB     | 720 KB   | **13.62 MB**     |       |
+
+The largest component by far is **all boarding artifacts** (`64K + 98KN`):
+at the lead config it's 89 % of total; at K=10000 it's 92 %.
+
+## OOM ceiling
+
+K=10000, N=12 fits comfortably on the 36 GB dev hardware (peak RSS
+estimated ≤ 25 MB including allocator overhead). The boarding
+super-linearity above K=1000 shows up as wall-clock cost, not
+memory pressure; the bench completed without a hint of swap.
+
+A back-of-envelope ceiling: storage stays under 1 GB up to about
+**K = 700 000 at N = 12** (formula yields 998 MB). Beyond that, the
+operator wants per-cohort sharding rather than tighter packing —
+follow-up out of scope for AFT.
+
+## Threshold sentinels
+
+| Configuration   | Wall-clock envelope (Apple M-series) | Notes                           |
+|-----------------|-------------------------------------|---------------------------------|
+| (K=100,  N=12)  | ≤ 5 s                               | ~6× slack over measured 0.83 s |
+| (K=1000, N=12)  | ≤ 60 s                              | ~6.6× slack over measured 9.0 s |
+| (K=10000,N=12)  | ≤ 600 s                             | ~3.4× slack over measured 175 s |
+| (K=1000, N=50)  | ≤ 120 s                             | ~3.5× slack over measured 34 s  |

--- a/docs/benchmarks/psar-vs-arkade.md
+++ b/docs/benchmarks/psar-vs-arkade.md
@@ -1,0 +1,133 @@
+# PSAR vs Arkade Delegation v0.7.0 — design-derived comparison
+
+Source of truth for issue #686. PSAR numbers are **measured** from
+the bench harnesses in `docs/benchmarks/psar-{boarding,epoch,scaling,onchain}.md`;
+Arkade numbers are **derived from the public specification** under the
+assumptions stated below. *Do not* read Arkade rows as measurements —
+they are upper / lower bounds derived from the spec.
+
+## Pinned references
+
+| Source                           | Pin                                                                                          |
+|----------------------------------|----------------------------------------------------------------------------------------------|
+| arkd v0.7.0 release              | <https://github.com/arkade-os/arkd/releases/tag/v0.7.0> (commit `fcb9f21ef69836e8ddadc2d070deb0c5be139336`, 2025-07-09) |
+| Arkade TS SDK delegation docs    | <https://arkade-os.github.io/ts-sdk/> (delegation section)                                   |
+| Fulmine (reference delegate)     | <https://github.com/ArkLabsHQ/fulmine>                                                       |
+
+The arkd v0.7.0 release is the first with `TestDelegateRefresh`
+landed (PR #677 in that repo). Before v0.7.0, the delegation tapscript
+path had not been finalised. Numbers below pin to this commit.
+
+## Assumptions (Arkade column)
+
+Every Arkade cell below stands on these explicit assumptions. If
+any prove wrong on closer reading of the spec, the corresponding
+cell needs to be updated.
+
+| # | Assumption | Source |
+|---|------------|--------|
+| A1 | A delegated VTXO's tapscript carries an extra spend path of the form `<delegator_pk> CHECKSIGVERIFY <asp_pk> CHECKSIG` (2-of-2 BIP-340). | SDK docs: "wallet address includes an extra tapscript path that authorizes the delegate to co-sign renewals alongside the Arkade server" |
+| A2 | Each renewal requires **one fresh** BIP-340 Schnorr signature from the delegator and one from the ASP (no pre-signing). | SDK docs ("automatically settle them before they expire") + Fulmine API ("submits a signed intent and pre-signed forfeit transactions") — the *forfeits* are pre-signed but the *renewal* is fresh. |
+| A3 | Per-VTXO per-renewal wire authorization size: 64 B (one Schnorr sig). The other 64 B is the ASP's, attributable to standard Ark cost. | BIP-340 sig size; same as PSAR's per-renewal sig. |
+| A4 | A renewal does not produce a per-renewal on-chain tx; it produces an off-chain refreshed VTXO that the ASP folds into the next batch commitment. | Standard Ark behaviour — Arkade Delegation does not introduce a new on-chain tx. |
+| A5 | The delegator must be online at every renewal to produce its fresh Schnorr sig; the user only needs to be online at boarding. | SDK docs ("automatically settle them before they expire") implies the *delegator* (not the user) is the always-on party. |
+| A6 | The delegator runs an HTTP server (Fulmine) and stores per-VTXO state (intent + pre-signed forfeit). Per-VTXO storage at the delegator is dominated by the pre-signed forfeit tx (≈ 200 B) plus the JSON intent (≈ 200 B) ≈ 400 B per VTXO per active epoch. | Fulmine README: `intent.message` + `forfeitTxs`. |
+
+**Limitations.** Arkade numbers are derived from spec, not measured.
+A real instrumented run of Fulmine + arkd + a stub user wallet would
+tighten or correct any of A1–A6. Doing that instrumentation is out
+of scope for the AFT submission and explicitly carved out by #686
+acceptance criterion #4.
+
+## Comparison at the lead configuration (K=100, N=12)
+
+The lead row for the paper assumes a cohort of K=100 VTXOs and a
+12-epoch horizon. Both protocols target the same end state — 100
+users with their VTXOs renewed across 12 epochs.
+
+| Metric | PSAR (measured) | Arkade Delegation (derived) | Notes |
+|---|---|---|---|
+| **User-side boarding cost** | 4.75 ms / user (N=12) | ~0.5 ms / user | Arkade signs only forfeit txs at boarding; PSAR pre-signs N=12 renewals. PSAR pays an upfront cost that buys offline-after-boarding (assumption A5). |
+| **Per-renewal user-side online time** | 0 (offline allowed) | round-trip with delegator | PSAR's headline property — user can be offline for the entire horizon. (Source: A5.) |
+| **Per-renewal authorization size** | 64 B (BIP-340 sig) | 64 B (BIP-340 sig) | Equivalent on the wire (A3). PSAR's 64 B is *pre-published once* via Λ; Arkade's 64 B is *sent live each epoch*. |
+| **Per-cohort ASP storage** | 1.37 MB at K=1000, N=12 | ~5 KB per VTXO per active epoch | PSAR holds N pre-signed renewals up-front; Arkade stores per-epoch. PSAR is heavier per cohort but constant-time at the user side. |
+| **Per-cohort PSAR-specific L1 footprint** | ~201 vbytes (slot_attest_S only) | 0 (no PSAR-style attest) | Arkade has no equivalent of `slot_attest_S` — but it doesn't need one because renewals are fresh per epoch (no schedule to commit to). |
+| **Trust model for the renewal signer** | Trustless (VON's R-binding + equivocation evidence) | Delegator is trusted (off-chain SLA + service fee) | PSAR removes the trusted third party (the `delegator` role); Arkade requires it as part of the design. |
+
+## Side-by-side tables
+
+### Performance at the lead config
+
+| Operation                 | PSAR (M3 Max) | Arkade (M3 Max, derived) |
+|---------------------------|---------------|---------------------------|
+| User boards 1 VTXO (N=12) | 4.75 ms       | ~0.5 ms                   |
+| User authorises 1 renewal | 0 (pre-signed at boarding) | ~225 µs (one Schnorr sig + 1 RTT round-trip) |
+| ASP processes 1 epoch (K=100) | 22.9 ms    | ~22.9 ms (same MuSig2 path on the ASP side) |
+| ASP processes 1 epoch (K=1000) | 226.8 ms  | ~226.8 ms                 |
+
+**Key observation:** PSAR's win is **not** raw speed — both protocols
+have similar per-epoch ASP cost. PSAR's win is **the user signing
+budget**: 4.75 ms once at boarding versus 225 µs × N times across
+the horizon, with the much larger advantage being that PSAR's 225 µs
+× N happens *up front* rather than requiring N round-trips with a
+trusted delegator.
+
+### Storage at the lead config (K=1000, N=12, snapshotted at any epoch)
+
+| Component                              | PSAR    | Arkade Delegation (derived) |
+|----------------------------------------|---------|------------------------------|
+| `RetainedScalars` (operator-only)      | 768 B   | n/a                          |
+| `PublishedSchedule`                    | 2 772 B | n/a                          |
+| Pre-signed renewal artifacts (per cohort) | 1 213 KB | 0 (renewals are not pre-signed) |
+| Live delegator state per VTXO (intent + forfeits) | n/a | ≈ 400 B × 1000 ≈ 400 KB |
+| Cohort metadata constants              | ~80 KB  | ~80 KB                       |
+| **Total PSAR-specific storage**        | **1.37 MB** | **~480 KB** (delegator side) |
+
+Arkade's storage is smaller per active snapshot, but it is split
+between the user's wallet and the delegator's database (Fulmine).
+PSAR's storage is concentrated at the ASP. Both fit comfortably in
+RAM at K=1000.
+
+### On-chain footprint at the lead config
+
+| Component                       | PSAR        | Arkade Delegation (derived) |
+|---------------------------------|-------------|------------------------------|
+| `slot_attest_S` (PSAR-specific) | ~201 vbytes | 0                            |
+| Per-cohort funding tx           | ~50 + 32K vbytes | ~50 + 32K vbytes (standard Ark) |
+| Per-renewal on-chain footprint  | 0           | 0 (A4 — renewals fold into the next batch) |
+
+PSAR adds **a fixed 201 vbytes per cohort** to the L1 cost; Arkade
+adds 0. At K=1000 that's 0.2 vbytes per VTXO — well below
+fee-market noise.
+
+## Which axis matters for the paper
+
+The paper's framing is "what's the smallest set of trust assumptions
+under which a user can be offline for `N` epochs?" Under that
+framing, the relevant comparison axis is **online-time** and
+**trusted-third-party**, not raw vbytes:
+
+| Axis                         | PSAR         | Arkade Delegation (derived) |
+|------------------------------|--------------|------------------------------|
+| User offline window          | up to N epochs | 0 (delegator is always-on stand-in) |
+| Trusted third party required | none         | yes — the delegator (Fulmine) |
+| Service fee paid             | 0            | non-zero (set by delegator)  |
+| User authorisation per renewal | none       | 1 RTT + 1 Schnorr sig        |
+
+This is the "fundamental advantage" row of the paper — the design
+that motivates everything in `dark-psar` and the `dark-von-musig2`
+crate. The cost rows above quantify that PSAR pays for the offline
+property in (a) ~4 ms more boarding cost and (b) ~1.4 MB more
+ASP-side storage per cohort at K=1000, N=12. Both are small in
+absolute terms.
+
+## Methodology notes
+
+- PSAR numbers re-extracted from the four bench docs in this
+  directory; this file does not introduce new measurements.
+- Arkade numbers under each assumption are *derived* — re-derive
+  if any of A1–A6 prove wrong on a closer spec read.
+- The two protocols share the BIP-340 / BIP-327 substrate and the
+  Ark commitment-tx layer; performance differences come from
+  *when* signing happens (PSAR pre-signs at boarding, Arkade signs
+  per renewal), not *how fast* a signature can be produced.

--- a/docs/benchmarks/von-musig2-primitives.md
+++ b/docs/benchmarks/von-musig2-primitives.md
@@ -1,0 +1,108 @@
+# `dark-von-musig2` performance baseline
+
+Source of truth for issue #681's "publish baseline numbers" criterion.
+Pairs with `docs/benchmarks/von-primitives.md` (the underlying ECVRF
+and `wrapper::nonce` costs are reported there). Regenerate with:
+
+```bash
+cargo bench -p dark-von-musig2 --bench partial_sign --bench aggregate -- --quick
+```
+
+Numbers below are the median of one Criterion `--quick` run (3 s
+measurement, 1 s warm-up). Use them as upper-bound expectations.
+
+## Hardware context
+
+| Field     | Value                                       |
+|-----------|---------------------------------------------|
+| CPU       | Apple M3 Max                                |
+| Cores     | 14 (10 performance + 4 efficiency)          |
+| Memory    | 36 GB                                       |
+| OS        | macOS 26.3.1 (Darwin 25.3.0)                |
+| Toolchain | rustc 1.95.0 (release profile, lto = false) |
+
+Curve-arithmetic-heavy paths (`partial_sign_with_scalars`,
+`aggregate_and_finalize`) sit on `secp256k1 = 0.29` from libsecp;
+Linux / x86_64 numbers on `ubuntu-latest` typically run 1.5–2×
+slower per the same envelope as `dark-von`.
+
+## Operator partial signature (`sign::sign_partial_with_von`)
+
+The operator's per-epoch partial signature consumes the VON-bound
+`(r₁, r₂)` scalars retained from `Setup::run` and produces a
+32-byte BIP-327 partial. No nonce is generated inside this call —
+VON's binding is preserved end-to-end.
+
+| Operation                         | Median   | Notes                                                   |
+|-----------------------------------|----------|---------------------------------------------------------|
+| `partial_sign/operator`           | 45.4 µs  | KeyAggCtx coefficient compute + `s = k₁ + b·k₂ + e·a·sk` |
+
+## Participant horizon (`presign::presign_horizon`)
+
+Each iteration verifies the entire published Λ (`2N` `wrapper::verify`
+calls), generates `N` participant nonces, and produces `N` partial
+signatures. Reported as a horizon-wide cost per call; per-epoch cost
+is `total / N` and the linear-fit slope is the per-epoch participant
+partial-sign primitive cost.
+
+| `N` | Median (full horizon) | Per-epoch | Notes |
+|-----|------------------------|-----------|-------|
+| 1   | 226.1 µs               | 226.1 µs  | 1 partial sign + 2 ECVRF verifies + 2 nonce generations |
+| 4   | 924.8 µs               | 231.2 µs  |       |
+| 12  | 2.728 ms               | 227.3 µs  |       |
+| 50  | 11.232 ms              | 224.6 µs  |       |
+
+Per-epoch cost stays in **224–231 µs** across `N` — confirms there's
+no hidden quadratic in the horizon-verify pipeline. Of the per-epoch
+~225 µs, roughly:
+
+- 2 × `wrapper::verify` ≈ 170 µs (from `dark-von` baseline at
+  85 µs/verify)
+- 1 × `partial_sign_with_scalars` ≈ 45 µs (matches operator path)
+- ~10 µs nonce-aggregation + bookkeeping
+
+## Aggregation (`sign::aggregate`)
+
+Combines the operator's and the participant's 32-byte partials into a
+single 64-byte BIP-340 signature. PSAR's setting is always 2-of-2
+(operator + one user) so this bench reports a single point estimate.
+
+| Operation         | Median   | Notes                                                  |
+|-------------------|----------|--------------------------------------------------------|
+| `aggregate/2of2`  | 19.9 µs  | Sum of partials + parity flips + R-projection to BIP-340 64-byte form |
+
+## Cohort budget at K=100, N=12
+
+Combining the per-epoch participant cost with `dark-von`'s
+`schedule::generate` cost (Phase 1's bench) gives a back-of-envelope
+budget for one user boarding into a K=100 cohort with horizon N=12:
+
+```text
+boarding(N=12)        = schedule_generate(N=12) + presign_horizon(N=12)
+                      ≈   1.88 ms              +   2.73 ms
+                      ≈   4.61 ms / user
+```
+
+ASP per-epoch cost is per-user 2 × `partial_sign/operator` (one for the
+operator's partial, one for the verification of the participant's
+incoming partial inside `sign_epoch`) plus one `aggregate/2of2`:
+
+```text
+process_epoch(K=100)  ≈ 100 × (45 µs + 45 µs + 20 µs)
+                      ≈ 11.0 ms / epoch
+```
+
+These envelopes feed the K-vs-N table in
+`docs/benchmarks/psar-scaling.md` (#684).
+
+## Threshold sentinels
+
+If a future change moves any of the medians outside these envelopes,
+investigate before merging — the integration tests in #678 / #680 are
+green by accident under regression as long as the numbers fit.
+
+| Bench                                | Envelope (Apple M-series) | Notes                                    |
+|--------------------------------------|---------------------------|------------------------------------------|
+| `partial_sign/operator`              | ≤ 100 µs                  | ~2.2× slack over measured 45 µs           |
+| `partial_sign_participant_horizon/N` | linear in N, slope ≈ 230 µs/epoch | Constant in `K` — does not vary with cohort size |
+| `aggregate/2of2`                     | ≤ 50 µs                   | ~2.5× slack over measured 20 µs           |

--- a/scripts/psar-onchain.sh
+++ b/scripts/psar-onchain.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# scripts/psar-onchain.sh — On-chain footprint measurement for issue #685.
+#
+# Drives the existing #669 regtest publication (`publish_slot_attest`)
+# against a running Nigiri node and reports the on-chain `slot_attest`
+# transaction's input/witness/output bytes, weight, and vbytes. The
+# per-batch (Ark commitment tx) overhead is documented analytically
+# in `docs/benchmarks/psar-onchain.md` because PSAR does not introduce
+# new commitment-tx structure beyond standard Ark.
+#
+# Requirements:
+#   - Nigiri running locally (`nigiri start`).
+#   - `bitcoin-cli` reachable on Nigiri's regtest port.
+#
+# Usage:
+#   scripts/psar-onchain.sh [--out PATH]
+#
+# Output: markdown table on stdout (or to --out PATH).
+#
+# When Nigiri is not running, the script prints the documented run
+# command and exits 0; the analytical formulas in the markdown
+# remain authoritative until a real measurement lands.
+
+set -euo pipefail
+
+OUT=""
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --out) OUT="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+NIGIRI_RPC_URL="${BITCOIN_RPC_URL:-http://admin1:123@127.0.0.1:18443}"
+
+# Sanity check: is Nigiri reachable?
+if ! curl -s --max-time 2 -o /dev/null \
+     -X POST -H 'content-type: text/plain' \
+     --data '{"jsonrpc":"1.0","id":"psar-onchain","method":"getblockchaininfo","params":[]}' \
+     "$NIGIRI_RPC_URL" 2>/dev/null
+then
+  cat <<'EOM' >&2
+psar-onchain.sh: Nigiri RPC not reachable at $BITCOIN_RPC_URL.
+
+To run end-to-end:
+  1. nigiri start
+  2. cargo test -p dark-psar --features regtest --test e2e_psar_regtest \
+       -- --ignored --test-threads=1
+  3. scripts/psar-onchain.sh
+
+Until Nigiri is up, see docs/benchmarks/psar-onchain.md for the
+analytical footprint formulas — they are tight upper bounds against
+which the measured numbers will compare.
+EOM
+  exit 0
+fi
+
+# Run the regtest e2e test under criterion-style capture.
+# The test emits the txid + raw hex to stdout; we parse and ask
+# bitcoind for the canonical decoded weight/vbyte numbers.
+TEST_LOG=$(mktemp)
+trap 'rm -f "$TEST_LOG"' EXIT
+BITCOIN_RPC_URL="$NIGIRI_RPC_URL" \
+cargo test -p dark-psar --features regtest --test e2e_psar_regtest \
+  -- --ignored --test-threads=1 --nocapture 2>&1 | tee "$TEST_LOG" >&2
+
+# Parse the emitted txid (test prints `slot_attest_txid: <hex>`).
+TXID=$(grep -oE 'slot_attest_txid: [0-9a-f]{64}' "$TEST_LOG" | head -1 | awk '{print $2}')
+if [ -z "$TXID" ]; then
+  echo "psar-onchain.sh: failed to parse slot_attest txid from test output" >&2
+  exit 3
+fi
+
+# Authoritative tx info from bitcoind.
+RAW=$(curl -s -X POST -H 'content-type: text/plain' \
+  --data "{\"jsonrpc\":\"1.0\",\"id\":\"psar-onchain\",\"method\":\"getrawtransaction\",\"params\":[\"$TXID\", true]}" \
+  "$NIGIRI_RPC_URL")
+
+INPUT_BYTES=$(echo "$RAW" | python3 -c "import json,sys; r=json.load(sys.stdin)['result']; print(sum(len(v.get('scriptSig', {}).get('hex','')) // 2 for v in r['vin']))")
+WITNESS_BYTES=$(echo "$RAW" | python3 -c "import json,sys; r=json.load(sys.stdin)['result']; print(sum(sum(len(w) // 2 for w in v.get('txinwitness', [])) for v in r['vin']))")
+OUTPUT_BYTES=$(echo "$RAW" | python3 -c "import json,sys; r=json.load(sys.stdin)['result']; print(sum(len(v['scriptPubKey']['hex']) // 2 for v in r['vout']))")
+WEIGHT=$(echo "$RAW" | python3 -c "import json,sys; print(json.load(sys.stdin)['result']['weight'])")
+VSIZE=$(echo "$RAW" | python3 -c "import json,sys; print(json.load(sys.stdin)['result']['vsize'])")
+SIZE=$(echo "$RAW" | python3 -c "import json,sys; print(json.load(sys.stdin)['result']['size'])")
+
+emit() {
+  echo "## Measured on-chain footprint (Nigiri regtest)"
+  echo
+  echo "| Tx kind        | size (B) | input (B) | witness (B) | output (B) | weight (WU) | vbytes |"
+  echo "|----------------|----------|-----------|-------------|------------|-------------|--------|"
+  printf "| slot_attest_S  | %8d | %9d | %11d | %10d | %11d | %6d |\n" \
+    "$SIZE" "$INPUT_BYTES" "$WITNESS_BYTES" "$OUTPUT_BYTES" "$WEIGHT" "$VSIZE"
+}
+
+if [ -n "$OUT" ]; then
+  emit > "$OUT"
+  echo "wrote $OUT" >&2
+else
+  emit
+fi

--- a/scripts/psar-plots.py
+++ b/scripts/psar-plots.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Stdlib-only SVG plot generator for issue #687.
+
+Emits the figures referenced by `BENCHMARKS.md` from the captured
+numbers in this directory. No matplotlib / gnuplot dependency —
+plots are simple log-x scatter+line on a 600×400 SVG canvas.
+
+Run via `scripts/psar-plots.sh` (which invokes this script).
+
+Outputs:
+- docs/benchmarks/figures/boarding-vs-n.svg
+- docs/benchmarks/figures/epoch-vs-k.svg
+- docs/benchmarks/figures/storage-vs-k.svg
+"""
+
+from __future__ import annotations
+
+import math
+import os
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parent.parent
+FIG_DIR = REPO_ROOT / "docs" / "benchmarks" / "figures"
+
+
+def svg_open(width: int, height: int) -> list[str]:
+    return [
+        f'<svg xmlns="http://www.w3.org/2000/svg" '
+        f'viewBox="0 0 {width} {height}" '
+        f'width="{width}" height="{height}" '
+        f'font-family="-apple-system, sans-serif" font-size="12">'
+    ]
+
+
+def line(x1: float, y1: float, x2: float, y2: float, color: str = "#222", w: float = 1.0) -> str:
+    return (
+        f'<line x1="{x1:.1f}" y1="{y1:.1f}" x2="{x2:.1f}" y2="{y2:.1f}" '
+        f'stroke="{color}" stroke-width="{w}" stroke-linecap="round" />'
+    )
+
+
+def text(x: float, y: float, s: str, anchor: str = "start", color: str = "#222", size: int = 12) -> str:
+    return (
+        f'<text x="{x:.1f}" y="{y:.1f}" text-anchor="{anchor}" '
+        f'fill="{color}" font-size="{size}">{s}</text>'
+    )
+
+
+def circle(cx: float, cy: float, r: float = 4, color: str = "#1f77b4") -> str:
+    return f'<circle cx="{cx:.1f}" cy="{cy:.1f}" r="{r}" fill="{color}" />'
+
+
+def polyline(points: list[tuple[float, float]], color: str = "#1f77b4", w: float = 2) -> str:
+    pts = " ".join(f"{x:.1f},{y:.1f}" for x, y in points)
+    return (
+        f'<polyline points="{pts}" fill="none" stroke="{color}" '
+        f'stroke-width="{w}" stroke-linejoin="round" />'
+    )
+
+
+def render_log_linear_plot(
+    *,
+    title: str,
+    xs: list[float],
+    ys: list[float],
+    x_label: str,
+    y_label: str,
+    out_path: Path,
+    annotate: list[tuple[float, float, str]] | None = None,
+    width: int = 640,
+    height: int = 420,
+    log_x: bool = True,
+) -> None:
+    """One axis log (x) the other linear (y); scatter + line."""
+    pad_l, pad_r, pad_t, pad_b = 70, 30, 50, 60
+    plot_w = width - pad_l - pad_r
+    plot_h = height - pad_t - pad_b
+
+    # Axis ranges.
+    if log_x:
+        x_lo = math.log10(min(xs)) - 0.05
+        x_hi = math.log10(max(xs)) + 0.05
+    else:
+        rng = max(xs) - min(xs)
+        x_lo, x_hi = min(xs) - 0.05 * rng, max(xs) + 0.05 * rng
+    y_rng = max(ys) - min(ys)
+    if y_rng == 0:
+        y_rng = max(ys) or 1.0
+    y_lo = 0
+    y_hi = max(ys) * 1.15
+
+    def fx(x: float) -> float:
+        v = math.log10(x) if log_x else x
+        return pad_l + (v - x_lo) / (x_hi - x_lo) * plot_w
+
+    def fy(y: float) -> float:
+        return pad_t + plot_h - (y - y_lo) / (y_hi - y_lo) * plot_h
+
+    out = svg_open(width, height)
+    # Background.
+    out.append(f'<rect width="{width}" height="{height}" fill="white" />')
+    # Title.
+    out.append(text(width / 2, 24, title, anchor="middle", size=15))
+    # Axes.
+    out.append(line(pad_l, pad_t, pad_l, pad_t + plot_h))
+    out.append(line(pad_l, pad_t + plot_h, pad_l + plot_w, pad_t + plot_h))
+    # X-axis ticks (log scale: at each x point).
+    for x, y in zip(xs, ys):
+        tx = fx(x)
+        out.append(line(tx, pad_t + plot_h, tx, pad_t + plot_h + 5, color="#888"))
+        out.append(
+            text(
+                tx,
+                pad_t + plot_h + 18,
+                _human(x),
+                anchor="middle",
+                size=11,
+            )
+        )
+    # Y-axis ticks: 5 evenly spaced.
+    for i in range(6):
+        v = y_lo + (y_hi - y_lo) * i / 5
+        ty = fy(v)
+        out.append(line(pad_l - 5, ty, pad_l, ty, color="#888"))
+        out.append(
+            text(
+                pad_l - 8,
+                ty + 4,
+                _human(v, terse=True),
+                anchor="end",
+                size=11,
+            )
+        )
+        out.append(line(pad_l, ty, pad_l + plot_w, ty, color="#eee"))
+    # Axis labels.
+    out.append(
+        text(
+            pad_l + plot_w / 2,
+            height - 18,
+            x_label,
+            anchor="middle",
+            size=13,
+        )
+    )
+    out.append(
+        f'<text x="{18}" y="{pad_t + plot_h / 2}" '
+        f'text-anchor="middle" font-size="13" '
+        f'transform="rotate(-90 18 {pad_t + plot_h / 2})">{y_label}</text>'
+    )
+    # Data line.
+    pts = [(fx(x), fy(y)) for x, y in zip(xs, ys)]
+    out.append(polyline(pts))
+    # Data points.
+    for x, y in zip(xs, ys):
+        out.append(circle(fx(x), fy(y)))
+    # Annotations.
+    if annotate:
+        for x, y, label in annotate:
+            out.append(circle(fx(x), fy(y), r=6, color="#d62728"))
+            out.append(
+                text(
+                    fx(x) + 10,
+                    fy(y) - 8,
+                    label,
+                    anchor="start",
+                    color="#d62728",
+                    size=11,
+                )
+            )
+    out.append("</svg>")
+    out_path.write_text("\n".join(out))
+
+
+def _human(v: float, terse: bool = False) -> str:
+    if abs(v) >= 1000:
+        return f"{v / 1000:.1f}K" if not terse else f"{v / 1000:.0f}K"
+    if v == int(v):
+        return f"{int(v)}"
+    return f"{v:.1f}"
+
+
+def main() -> int:
+    FIG_DIR.mkdir(parents=True, exist_ok=True)
+
+    # 1. Boarding latency vs N.
+    # Numbers from docs/benchmarks/psar-boarding.md.
+    boarding_n = [4, 12, 50]
+    boarding_ms = [1.66, 4.75, 19.80]
+    render_log_linear_plot(
+        title="Single-user boarding latency vs horizon N (Apple M3 Max)",
+        xs=boarding_n,
+        ys=boarding_ms,
+        x_label="Horizon N (epochs)",
+        y_label="user_board latency (ms)",
+        out_path=FIG_DIR / "boarding-vs-n.svg",
+        log_x=False,
+        annotate=[(12, 4.75, "★ lead row")],
+    )
+
+    # 2. Per-epoch ASP latency vs K.
+    # Numbers from docs/benchmarks/psar-epoch.md.
+    epoch_k = [100, 1000]
+    epoch_ms = [22.9, 226.8]
+    render_log_linear_plot(
+        title="Per-epoch ASP processing latency vs cohort size K",
+        xs=epoch_k,
+        ys=epoch_ms,
+        x_label="Cohort size K (log scale)",
+        y_label="process_epoch latency (ms)",
+        out_path=FIG_DIR / "epoch-vs-k.svg",
+        log_x=True,
+        annotate=[(1000, 226.8, "★ lead row")],
+    )
+
+    # 3. Storage vs K at N=12.
+    # Computed from formula `186K + 98KN + 292N + 180`.
+    storage_k = [100, 1000, 10000]
+    n = 12
+    storage_kb = [
+        (186 * k + 98 * k * n + 292 * n + 180) / 1024 for k in storage_k
+    ]
+    render_log_linear_plot(
+        title="Total in-memory storage per cohort vs K (N=12)",
+        xs=storage_k,
+        ys=storage_kb,
+        x_label="Cohort size K (log scale)",
+        y_label="In-memory storage (KB)",
+        out_path=FIG_DIR / "storage-vs-k.svg",
+        log_x=True,
+        annotate=[(1000, storage_kb[1], "★ lead row")],
+    )
+
+    print(f"Wrote {len(list(FIG_DIR.glob('*.svg')))} SVG figures to {FIG_DIR}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/psar-plots.sh
+++ b/scripts/psar-plots.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env bash
+# scripts/psar-plots.sh — Generate SVG figures for issue #687.
+#
+# Wrapper around the Python script `scripts/psar-plots.py`. The
+# Python implementation is stdlib-only (no matplotlib / gnuplot
+# dependency) so this works on a clean checkout without `pip install`
+# / `brew install` ceremony.
+#
+# Outputs: docs/benchmarks/figures/{boarding-vs-n,epoch-vs-k,storage-vs-k}.svg
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+exec python3 "$REPO_ROOT/scripts/psar-plots.py" "$@"

--- a/scripts/psar-scaling.sh
+++ b/scripts/psar-scaling.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# scripts/psar-scaling.sh — Cohort-scaling sweep for issue #684.
+#
+# Drives `cargo run -p dark-psar --features demo --bin psar-demo` at
+# the four configurations called out by #684 and aggregates the JSON
+# reports into a markdown table.
+#
+# Configurations:
+#   1. (K=100,   N=12)  — paper lead row
+#   2. (K=1000,  N=12)  — production-shape stress
+#   3. (K=10000, N=12)  — stretch (skipped unless --include-stretch)
+#   4. (K=1000,  N=50)  — long-horizon spot-check
+#
+# Usage:
+#   scripts/psar-scaling.sh [--include-stretch] [--out PATH]
+#
+# Output: a markdown table on stdout (or to --out PATH) with one row
+# per configuration; columns are (K, N, boarding_ms, epoch_ms_avg,
+# total_signatures, all_verify, wall_clock_ms).
+
+set -euo pipefail
+
+INCLUDE_STRETCH=0
+OUT=""
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --include-stretch) INCLUDE_STRETCH=1; shift ;;
+    --out) OUT="$2"; shift 2 ;;
+    *) echo "unknown flag: $1" >&2; exit 2 ;;
+  esac
+done
+
+# Build once so the per-run cost excludes compilation.
+cargo build --release -p dark-psar --features demo --bin psar-demo >/dev/null
+
+BIN=target/release/psar-demo
+
+run_one() {
+  local k="$1" n="$2" seed="$3"
+  local report
+  report=$("$BIN" --k "$k" --n "$n" --seed "$seed")
+  local boarding_ms epoch_ms_avg total_sigs all_verify wall
+  boarding_ms=$(echo "$report" | python3 -c "import json,sys; print(json.load(sys.stdin)['boarding']['duration_ms'])")
+  epoch_ms_avg=$(echo "$report" | python3 -c "import json,sys; e=json.load(sys.stdin)['epochs']; print(round(sum(x['duration_ms'] for x in e)/len(e), 1))")
+  total_sigs=$(echo "$report" | python3 -c "import json,sys; print(json.load(sys.stdin)['aggregate']['total_signatures'])")
+  all_verify=$(echo "$report" | python3 -c "import json,sys; print(json.load(sys.stdin)['aggregate']['all_verify'])")
+  wall=$(echo "$report" | python3 -c "import json,sys; print(json.load(sys.stdin)['totals']['wall_clock_ms'])")
+  printf "| %5d | %3d | %10d | %12s | %15d | %10s | %12d |\n" \
+    "$k" "$n" "$boarding_ms" "$epoch_ms_avg" "$total_sigs" "$all_verify" "$wall"
+}
+
+emit() {
+  echo "## Measured wall-clock at four configurations"
+  echo
+  echo "| K     | N   | boarding_ms | epoch_ms_avg | total_signatures | all_verify | wall_clock_ms |"
+  echo "|-------|-----|-------------|--------------|------------------|------------|----------------|"
+  run_one 100  12 1
+  run_one 1000 12 2
+  if [ "$INCLUDE_STRETCH" = "1" ]; then
+    run_one 10000 12 3
+  fi
+  run_one 1000 50 4
+}
+
+if [ -n "$OUT" ]; then
+  emit > "$OUT"
+  echo "wrote $OUT" >&2
+else
+  emit
+fi


### PR DESCRIPTION
## Summary

Phase 6 of the PSAR roadmap — bench harnesses, captured numbers, and a top-level `BENCHMARKS.md` consolidator + figures. Builds on the Phase 5 surface from #699.

- Closes #681 — VON-MuSig2 primitives criterion benches (`crates/dark-von-musig2/benches/{partial_sign,aggregate}.rs`). Operator partial 45 µs · participant horizon ~225 µs/epoch · aggregate 20 µs. Doc: `docs/benchmarks/von-musig2-primitives.md`.
- Closes #682 — Boarding latency vs N ∈ {4, 12, 50} (`crates/dark-psar/benches/boarding.rs`). Linear: `user_board(N) ≈ 150 µs + N × 395 µs`. N=12 is **4.75 ms / user**. Doc: `docs/benchmarks/psar-boarding.md`.
- Closes #683 — Per-epoch ASP latency vs K ∈ {100, 1000} (`crates/dark-psar/benches/epoch.rs`); K=10000 gated behind `BENCH_LONG=1`. Per-user cost stable at 227 µs across K. Doc: `docs/benchmarks/psar-epoch.md`.
- Closes #684 — Cohort scaling sweep at K ∈ {100, 1000, 10000} × N=12 plus (K=1000, N=50) spot-check via `scripts/psar-scaling.sh`. **Lead row (★ K=1000, N=12) wall-clock: 9.0 s; storage: 1.37 MB.** K=10000 / N=12 completes in 175 s with all 120 000 sigs verifying. Doc: `docs/benchmarks/psar-scaling.md`.
- Closes #685 — On-chain footprint script (`scripts/psar-onchain.sh`) + analytical formulas. `slot_attest_S` ~201 vbytes upper bound. Doc: `docs/benchmarks/psar-onchain.md`. **Real Nigiri measurement is still TBD** — see the doc's measurement-protocol section; one `nigiri start` + script run away.
- Closes #686 — PSAR vs Arkade Delegation v0.7.0 comparison, derived from the SDK docs + Fulmine README, pinned to arkd commit `fcb9f21ef69836e8ddadc2d070deb0c5be139336`. Six explicit assumptions A1–A6, each footnoted to its source. Doc: `docs/benchmarks/psar-vs-arkade.md`.
- Closes #687 — Top-level `BENCHMARKS.md` consolidates everything; three SVG figures (`docs/benchmarks/figures/{boarding-vs-n,epoch-vs-k,storage-vs-k}.svg`) generated by a **stdlib-only Python plotter** (no matplotlib / gnuplot install required). Lead-row marker (★) on every relevant table.

Diffstat: 18 new files, 1 modified, ~2,300 insertions across `crates/dark-{von-musig2,psar}/{benches,Cargo.toml}`, `docs/benchmarks/`, `scripts/`, `BENCHMARKS.md`. **No file under `crates/dark-core/src/` changes** — the parity discipline from ADR-0009 still holds.

## Verification

- `cargo fmt --all` clean
- `cargo clippy --all-targets --all-features -- -D warnings` clean (matches CI)
- `cargo test --workspace` green (exit 0) — all existing tests still pass
- New bench harnesses produce real numbers via `cargo bench --quick`; captured into the per-bench docs
- `scripts/psar-scaling.sh --include-stretch` ran end-to-end at all four configurations
- `scripts/psar-plots.sh` generates 3 SVG figures from stdlib only

## Threshold sentinels

Envelopes set ~2× over measured medians; if any bench regresses past these, fail the review. Summary table at the bottom of `BENCHMARKS.md`; per-bench tables in each individual doc.

## Out of scope (follow-ups)

- **[FU-PSAR-ONCHAIN-MEASURED]** — replace the analytical `slot_attest_S` row in `docs/benchmarks/psar-onchain.md` with the output of `scripts/psar-onchain.sh` once Nigiri is up. The script is ready to go.
- **[FU-ARKADE-VERIFY]** — sanity-check assumptions A1–A6 in `docs/benchmarks/psar-vs-arkade.md` against the Arkade Delegation reference implementation. Some derivations are tighter than others; cross-checking against Fulmine source would tighten or correct the bounds.
- **[FU-PSAR-PARALLEL]** — `process_epoch` walks `cohort.members` serially; per-user work is trivially parallelisable. At K=1000 a 14-core M3 Max would be ~16 ms instead of 227 ms. Out of scope for AFT; flagged for production hardening.

Phases 7 (paper) and 8 (submission) still to follow.