### PR TITLE
✨ feat(dark-psar): schedule-commitment Merkle root for cross-cohort accountability

### DIFF
--- a/crates/dark-psar/benches/boarding.rs
+++ b/crates/dark-psar/benches/boarding.rs
@@ -79,21 +79,24 @@ fn build_fixture(n: u32) -> Fixture {
     let horizon = HibernationHorizon::new(n, n.max(50)).expect("horizon");
     let cohort = Cohort::new(COHORT_ID, members, horizon).expect("cohort");
 
-    // Slot root + signed SlotAttest.
+    // Λ generation at horizon `n`.
+    let asp_sk = SecretKey::from_keypair(&asp_kp);
+    let (schedule, _retained) = Setup::run(&asp_sk, &SETUP_ID, n).expect("setup");
+
+    // Slot root + schedule root + signed SlotAttest.
     let tree = SlotTree::from_members(&cohort.members);
     let SlotRoot(slot_root) = tree.root();
+    let schedule_root =
+        dark_psar::compute_schedule_root(&COHORT_ID, &schedule).expect("schedule_root");
     let unsigned = SlotAttestUnsigned {
         slot_root,
         cohort_id: COHORT_ID,
         setup_id: SETUP_ID,
         n: horizon.n,
         k: cohort.k(),
+        schedule_root: schedule_root.0,
     };
     let attest = unsigned.sign(&secp, &asp_kp);
-
-    // Λ generation at horizon `n`.
-    let asp_sk = SecretKey::from_keypair(&asp_kp);
-    let (schedule, _retained) = Setup::run(&asp_sk, &SETUP_ID, n).expect("setup");
 
     let batch_root = dark_psar::compute_batch_tree_root(&cohort);
     Fixture {

--- a/crates/dark-psar/src/attest.rs
+++ b/crates/dark-psar/src/attest.rs
@@ -9,14 +9,21 @@
 //!
 //! # Wire format
 //!
-//! - **Unsigned payload** ([`SlotAttestUnsigned::SIZE`] = 104 B):
+//! - **Unsigned payload** ([`SlotAttestUnsigned::SIZE`] = 136 B):
 //!
 //!   ```text
-//!   |  32 B slot_root  |  32 B cohort_id  |  32 B setup_id  |  4 B n (LE u32)  |  4 B k (LE u32)  |
+//!   |  32 B slot_root  |  32 B cohort_id  |  32 B setup_id  |  4 B n (LE u32)  |  4 B k (LE u32)  |  32 B schedule_root  |
 //!   ```
 //!
-//! - **Signed payload** ([`SlotAttest::SIZE`] = 168 B): the unsigned
+//! - **Signed payload** ([`SlotAttest::SIZE`] = 200 B): the unsigned
 //!   payload followed by the 64-byte BIP-340 Schnorr signature.
+//!
+//! The `schedule_root` field commits the entire published Λ schedule
+//! per [`crate::schedule_root::compute_schedule_root`]. The ASP's
+//! BIP-340 signature on `slot_attest` therefore binds the schedule
+//! itself: two signed `slot_attest`s with the same `cohort_id` but
+//! different `schedule_root`s are publicly verifiable equivocation
+//! evidence.
 //!
 //! The signature is computed over the BIP-340 tagged hash of the
 //! unsigned payload with tag [`SLOT_ATTEST_TAG`]
@@ -82,13 +89,16 @@ pub struct SlotAttestUnsigned {
     pub setup_id: [u8; 32],
     pub n: u32,
     pub k: u32,
+    /// Merkle root over the published Λ entries; see
+    /// [`crate::schedule_root::compute_schedule_root`].
+    pub schedule_root: [u8; 32],
 }
 
 impl SlotAttestUnsigned {
     /// Serialised length of the unsigned payload.
-    pub const SIZE: usize = 32 + 32 + 32 + 4 + 4;
+    pub const SIZE: usize = 32 + 32 + 32 + 4 + 4 + 32;
 
-    /// Canonical 104-byte serialisation.
+    /// Canonical 136-byte serialisation.
     pub fn to_bytes(&self) -> [u8; Self::SIZE] {
         let mut out = [0u8; Self::SIZE];
         out[0..32].copy_from_slice(&self.slot_root);
@@ -96,6 +106,7 @@ impl SlotAttestUnsigned {
         out[64..96].copy_from_slice(&self.setup_id);
         out[96..100].copy_from_slice(&self.n.to_le_bytes());
         out[100..104].copy_from_slice(&self.k.to_le_bytes());
+        out[104..136].copy_from_slice(&self.schedule_root);
         out
     }
 
@@ -116,12 +127,15 @@ impl SlotAttestUnsigned {
         n_buf.copy_from_slice(&bytes[96..100]);
         let mut k_buf = [0u8; 4];
         k_buf.copy_from_slice(&bytes[100..104]);
+        let mut schedule_root = [0u8; 32];
+        schedule_root.copy_from_slice(&bytes[104..136]);
         Ok(Self {
             slot_root,
             cohort_id,
             setup_id,
             n: u32::from_le_bytes(n_buf),
             k: u32::from_le_bytes(k_buf),
+            schedule_root,
         })
     }
 
@@ -241,6 +255,7 @@ mod tests {
             setup_id: [seed.wrapping_add(2); 32],
             n: 12,
             k: 100,
+            schedule_root: [seed.wrapping_add(3); 32],
         }
     }
 
@@ -254,8 +269,8 @@ mod tests {
     fn pinned_constants() {
         assert_eq!(SLOT_ATTEST_TAG, b"DarkPsarSlotAttestV1");
         assert_eq!(OP_RETURN_MAGIC, *b"PSAR");
-        assert_eq!(SlotAttestUnsigned::SIZE, 104);
-        assert_eq!(SlotAttest::SIZE, 168);
+        assert_eq!(SlotAttestUnsigned::SIZE, 136);
+        assert_eq!(SlotAttest::SIZE, 200);
         assert_eq!(SlotAttest::OP_RETURN_SIZE, 68);
     }
 
@@ -276,6 +291,7 @@ mod tests {
             setup_id: [0u8; 32],
             n: 0x0403_0201,
             k: 0x0807_0605,
+            schedule_root: [0u8; 32],
         };
         let b = u.to_bytes();
         assert_eq!(&b[96..100], &[0x01, 0x02, 0x03, 0x04]);
@@ -284,12 +300,12 @@ mod tests {
 
     #[test]
     fn unsigned_from_bytes_rejects_wrong_length() {
-        let err = SlotAttestUnsigned::from_bytes(&[0u8; 103]).unwrap_err();
+        let err = SlotAttestUnsigned::from_bytes(&[0u8; 135]).unwrap_err();
         assert_eq!(
             err,
             SlotAttestError::MalformedLength {
-                got: 103,
-                expected: 104,
+                got: 135,
+                expected: 136,
             }
         );
     }
@@ -314,12 +330,12 @@ mod tests {
 
     #[test]
     fn signed_from_bytes_rejects_wrong_length() {
-        let err = SlotAttest::from_bytes(&[0u8; 167]).unwrap_err();
+        let err = SlotAttest::from_bytes(&[0u8; 199]).unwrap_err();
         assert_eq!(
             err,
             SlotAttestError::MalformedLength {
-                got: 167,
-                expected: 168,
+                got: 199,
+                expected: 200,
             }
         );
     }

--- a/crates/dark-psar/src/boarding.rs
+++ b/crates/dark-psar/src/boarding.rs
@@ -182,6 +182,19 @@ pub fn user_board<R: Rng + ?Sized>(
         return Err(PsarError::PubkeyMismatch { slot_index });
     }
 
+    // ─── Schedule-root binding ────────────────────────────────────────
+    // The ASP signed a schedule-commitment root into `slot_attest`; the
+    // user verifies the schedule they were handed matches that root.
+    // Two `slot_attest`s with the same `cohort_id` but different
+    // `schedule_root`s are publicly verifiable equivocation evidence
+    // (see `crate::schedule_root`).
+    let recomputed_schedule_root =
+        crate::schedule_root::compute_schedule_root(&cohort.id, schedule)
+            .map_err(|_| PsarError::ScheduleInvalid { epoch: 0, slot: 0 })?;
+    if recomputed_schedule_root.0 != attest.unsigned.schedule_root {
+        return Err(PsarError::ScheduleRootMismatch);
+    }
+
     // ─── Λ pre-verification with (epoch, slot) reporting ──────────────
     verify_lambda_entries(pk_asp, schedule, &setup_id)?;
 
@@ -344,7 +357,11 @@ pub fn asp_board<R: Rng + ?Sized>(
     let asp_sk = SecretKey::from_keypair(asp_kp);
     let (schedule, retained) = Setup::run(&asp_sk, &setup_id, horizon.n)?;
 
-    // ─── 3. Slot tree + SlotAttest signing ───────────────────────────
+    // ─── 3. Schedule commitment over Λ ───────────────────────────────
+    let schedule_root = crate::schedule_root::compute_schedule_root(&cohort_id, &schedule)
+        .expect("schedule_root over freshly-built Λ");
+
+    // ─── 4. Slot tree + SlotAttest signing ───────────────────────────
     let tree = SlotTree::from_members(&cohort.members);
     let slot_root = tree.root();
     let unsigned = SlotAttestUnsigned {
@@ -353,6 +370,7 @@ pub fn asp_board<R: Rng + ?Sized>(
         setup_id,
         n: horizon.n,
         k: cohort.k(),
+        schedule_root: schedule_root.0,
     };
     let attest = unsigned.sign(&secp, asp_kp);
     cohort.slot_root = Some(slot_root.0);
@@ -479,12 +497,15 @@ mod tests {
         let (schedule, _retained) =
             Setup::run(&asp_sk, &setup_id_bytes, cohort.horizon.n).expect("setup");
         let slot_root = SlotRoot::compute(&cohort.members).0;
+        let schedule_root = crate::schedule_root::compute_schedule_root(&cohort.id, &schedule)
+            .expect("schedule_root");
         let unsigned = SlotAttestUnsigned {
             slot_root,
             cohort_id: cohort.id,
             setup_id: setup_id_bytes,
             n: cohort.horizon.n,
             k: cohort.k(),
+            schedule_root: schedule_root.0,
         };
         let attest = unsigned.sign(&secp, asp_kp);
         (attest, schedule, setup_id_bytes)
@@ -528,6 +549,13 @@ mod tests {
 
     #[test]
     fn user_board_aborts_on_mutated_lambda() {
+        // Post schedule-root binding, *any* mutation to a published Λ
+        // entry — including a single proof byte — diverges from the
+        // root the ASP signed in the SlotAttest, so verification trips
+        // on `ScheduleRootMismatch` before the per-entry verify ever
+        // runs. The test still demonstrates that mutating Λ aborts
+        // boarding; it just catches the tampering at a stronger,
+        // commitment-level check.
         let secp = Secp256k1::new();
         let asp_kp = even_parity_keypair(&secp, 0x77);
         let asp_xonly = asp_kp.x_only_public_key().0;
@@ -551,7 +579,7 @@ mod tests {
         )
         .unwrap_err();
         assert!(
-            matches!(err, PsarError::ScheduleInvalid { epoch: 2, slot: 1 }),
+            matches!(err, PsarError::ScheduleRootMismatch),
             "got {err:?}"
         );
     }

--- a/crates/dark-psar/src/error.rs
+++ b/crates/dark-psar/src/error.rs
@@ -64,6 +64,9 @@ pub enum PsarError {
     #[error("slot root in attestation does not match recomputed slot root")]
     SlotRootMismatch,
 
+    #[error("schedule root in attestation does not match recomputed schedule root")]
+    ScheduleRootMismatch,
+
     #[error("attestation signature failed to verify")]
     AttestationVerify,
 

--- a/crates/dark-psar/src/lib.rs
+++ b/crates/dark-psar/src/lib.rs
@@ -33,6 +33,7 @@ pub mod message;
 pub mod publish;
 pub mod report;
 pub mod resurface;
+pub mod schedule_root;
 pub mod slot_tree;
 pub mod store;
 
@@ -50,5 +51,6 @@ pub use report::{
     run_demo, AggregateReport, BoardingReport, EpochReport, RunReport, TotalsReport, SCHEMA_VERSION,
 };
 pub use resurface::{user_resurface, ResurfaceArtifact};
+pub use schedule_root::{compute_schedule_root, ScheduleRoot, ScheduleRootError};
 pub use slot_tree::{Side, Slot, SlotInclusionProof, SlotRoot, SlotTree};
 pub use store::{ActiveCohortStore, CohortId, InMemoryActiveCohortStore};

--- a/crates/dark-psar/src/publish.rs
+++ b/crates/dark-psar/src/publish.rs
@@ -184,6 +184,7 @@ mod tests {
             setup_id: [seed.wrapping_add(2); 32],
             n: 12,
             k: 100,
+            schedule_root: [seed.wrapping_add(3); 32],
         }
         .sign(&secp, &kp)
     }

--- a/crates/dark-psar/src/schedule_root.rs
+++ b/crates/dark-psar/src/schedule_root.rs
@@ -1,0 +1,300 @@
+//! Schedule-commitment Merkle root over the published Λ entries.
+//!
+//! Each leaf binds a single `(cohort_id, setup_id, t, b, R, π)` tuple.
+//! The root is committed as a field of [`crate::SlotAttestUnsigned`], so
+//! the ASP's BIP-340 signature on `slot_attest` binds the entire
+//! per-cohort schedule. Two signed `slot_attest`s with the same
+//! `cohort_id` but different `schedule_root`s constitute publicly
+//! verifiable equivocation evidence — the operator has signed two
+//! conflicting schedules under the same long-term key.
+//!
+//! # Why this layer (not VRF uniqueness)
+//!
+//! ECVRF uniqueness binds `(pk, x) → unique (β, π)`. The wrapper from
+//! [`dark_von::wrapper`] uses `α' = x ∥ R` as the VRF input, so two
+//! distinct `R, R'` give two distinct VRF inputs and ECVRF uniqueness
+//! does not bound them per-slot. The wrapper provides
+//! *operator-certified-R* for each slot, not per-slot uniqueness.
+//! Per-slot binding is delivered at this layer: the schedule is
+//! collated, hashed into a Merkle tree, and the root is signed under
+//! the operator's BIP-340 attestation key. Equivocation moves from
+//! "two valid VRF proofs on different inputs" (allowed under VRF
+//! uniqueness) to "two BIP-340 signatures on conflicting schedule
+//! roots" (a Schnorr-key equivocation observable by anyone with both
+//! signed `slot_attest`s).
+//!
+//! # Wire format
+//!
+//! - Leaf preimage layout (130 B):
+//!
+//!   ```text
+//!   | 0x01 LEAF_V1 | cohort_id (32) | setup_id (32) | t LE u32 (4) | b u8 (1) | R (33) | sha256(π) (32) |
+//!   ```
+//!
+//!   The 81-byte VON proof `π` is hashed (SHA-256) into 32 bytes
+//!   inside the preimage to keep the leaf fixed-width and the tree
+//!   skim-friendly. Verifiers reconstruct `sha256(π)` from the
+//!   published Λ entry, no proof bytes embedded in the leaf preimage.
+//! - Leaf hash: `tagged_hash(SCHEDULE_LEAF_TAG, preimage)`
+//!   with `SCHEDULE_LEAF_TAG = b"DarkPsarScheduleLeafV1"`.
+//! - Branch hash: `tagged_hash(SCHEDULE_BRANCH_TAG, l ∥ r)`
+//!   with `SCHEDULE_BRANCH_TAG = b"DarkPsarScheduleBranchV1"`.
+//!
+//! Tree shape: standard binary Merkle (mirrors [`crate::slot_tree`]) —
+//! pairs combine left-to-right; an unpaired right-most node at any
+//! level is promoted unchanged. Empty entry list yields the zero root.
+//!
+//! Leaf order: for `t = 1, …, n` and `b = 1, 2`, leaves are emitted in
+//! the order `(t=1, b=1), (t=1, b=2), (t=2, b=1), …`.
+
+use sha2::{Digest, Sha256};
+
+use dark_von_musig2::setup::PublishedSchedule;
+
+/// Leading byte of the V1 schedule-leaf preimage.
+pub const LEAF_V1_PREFIX: u8 = 0x01;
+
+/// BIP-340 tagged-hash tag for schedule-tree leaves.
+pub const SCHEDULE_LEAF_TAG: &[u8] = b"DarkPsarScheduleLeafV1";
+
+/// BIP-340 tagged-hash tag for schedule-tree branch nodes.
+pub const SCHEDULE_BRANCH_TAG: &[u8] = b"DarkPsarScheduleBranchV1";
+
+/// 32-byte schedule-commitment root. Wraps a digest so callers cannot
+/// mistake it for any other 32-byte hash in the codebase.
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub struct ScheduleRoot(pub [u8; 32]);
+
+impl ScheduleRoot {
+    pub fn as_bytes(&self) -> &[u8; 32] {
+        &self.0
+    }
+}
+
+/// Compute `ScheduleRoot` over the entries of `schedule` for the given
+/// `cohort_id`. The leaves are emitted in `(t=1..n, b=1..2)` order.
+///
+/// The cohort id is folded into every leaf preimage, so two cohorts
+/// sharing a `schedule` (same `setup_id`, same horizon) yield distinct
+/// roots. This makes per-cohort accountability cheap: a verifier given
+/// `(cohort_id, schedule)` can recompute the root in
+/// `O(2N · sha256)`.
+pub fn compute_schedule_root(
+    cohort_id: &[u8; 32],
+    schedule: &PublishedSchedule,
+) -> Result<ScheduleRoot, ScheduleRootError> {
+    if schedule.setup_id.len() != 32 {
+        return Err(ScheduleRootError::MalformedSetupId {
+            got: schedule.setup_id.len(),
+        });
+    }
+    if schedule.entries.len() != schedule.n as usize {
+        return Err(ScheduleRootError::EntryCountMismatch {
+            entries: schedule.entries.len(),
+            n: schedule.n,
+        });
+    }
+    let mut setup_id_arr = [0u8; 32];
+    setup_id_arr.copy_from_slice(&schedule.setup_id);
+
+    let mut leaves = Vec::with_capacity(2 * schedule.entries.len());
+    for (idx, entry) in schedule.entries.iter().enumerate() {
+        let t = (idx as u32) + 1;
+        leaves.push(leaf_hash(
+            cohort_id,
+            &setup_id_arr,
+            t,
+            1,
+            &entry.r1,
+            &entry.proof1,
+        )?);
+        leaves.push(leaf_hash(
+            cohort_id,
+            &setup_id_arr,
+            t,
+            2,
+            &entry.r2,
+            &entry.proof2,
+        )?);
+    }
+    Ok(ScheduleRoot(merkle_root(&leaves)))
+}
+
+/// Construction errors for [`compute_schedule_root`].
+#[derive(Clone, Debug, thiserror::Error, PartialEq, Eq)]
+pub enum ScheduleRootError {
+    #[error("malformed setup_id: expected 32 bytes, got {got}")]
+    MalformedSetupId { got: usize },
+    #[error("entry count {entries} disagrees with n={n}")]
+    EntryCountMismatch { entries: usize, n: u32 },
+    #[error("malformed r_point: expected 33 bytes, got {got}")]
+    MalformedR { got: usize },
+    #[error("malformed proof: expected 81 bytes, got {got}")]
+    MalformedProof { got: usize },
+}
+
+fn leaf_hash(
+    cohort_id: &[u8; 32],
+    setup_id: &[u8; 32],
+    t: u32,
+    b: u8,
+    r: &[u8],
+    proof: &[u8],
+) -> Result<[u8; 32], ScheduleRootError> {
+    if r.len() != 33 {
+        return Err(ScheduleRootError::MalformedR { got: r.len() });
+    }
+    if proof.len() != 81 {
+        return Err(ScheduleRootError::MalformedProof { got: proof.len() });
+    }
+    let proof_digest: [u8; 32] = Sha256::digest(proof).into();
+    let mut preimage = [0u8; 1 + 32 + 32 + 4 + 1 + 33 + 32];
+    preimage[0] = LEAF_V1_PREFIX;
+    preimage[1..33].copy_from_slice(cohort_id);
+    preimage[33..65].copy_from_slice(setup_id);
+    preimage[65..69].copy_from_slice(&t.to_le_bytes());
+    preimage[69] = b;
+    preimage[70..103].copy_from_slice(r);
+    preimage[103..135].copy_from_slice(&proof_digest);
+    Ok(tagged_hash(SCHEDULE_LEAF_TAG, &preimage))
+}
+
+fn merkle_root(leaves: &[[u8; 32]]) -> [u8; 32] {
+    if leaves.is_empty() {
+        return [0u8; 32];
+    }
+    let mut layer: Vec<[u8; 32]> = leaves.to_vec();
+    while layer.len() > 1 {
+        let mut next = Vec::with_capacity(layer.len().div_ceil(2));
+        for chunk in layer.chunks(2) {
+            if chunk.len() == 2 {
+                let mut concat = [0u8; 64];
+                concat[..32].copy_from_slice(&chunk[0]);
+                concat[32..].copy_from_slice(&chunk[1]);
+                next.push(tagged_hash(SCHEDULE_BRANCH_TAG, &concat));
+            } else {
+                next.push(chunk[0]);
+            }
+        }
+        layer = next;
+    }
+    layer[0]
+}
+
+fn tagged_hash(tag: &[u8], msg: &[u8]) -> [u8; 32] {
+    let tag_hash = Sha256::digest(tag);
+    let mut h = Sha256::new();
+    h.update(tag_hash);
+    h.update(tag_hash);
+    h.update(msg);
+    h.finalize().into()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use dark_von_musig2::setup::{PublishedEntry, PublishedSchedule};
+
+    fn fake_entry(seed: u8) -> PublishedEntry {
+        PublishedEntry {
+            r1: vec![seed.wrapping_add(0x10); 33],
+            proof1: vec![seed.wrapping_add(0x20); 81],
+            r2: vec![seed.wrapping_add(0x30); 33],
+            proof2: vec![seed.wrapping_add(0x40); 81],
+        }
+    }
+
+    fn fake_schedule(n: u32) -> PublishedSchedule {
+        PublishedSchedule {
+            setup_id: vec![0xc4u8; 32],
+            n,
+            entries: (0..n as u8).map(fake_entry).collect(),
+        }
+    }
+
+    #[test]
+    fn schedule_root_is_deterministic() {
+        let cohort_id = [0xab; 32];
+        let s = fake_schedule(4);
+        let r1 = compute_schedule_root(&cohort_id, &s).unwrap();
+        let r2 = compute_schedule_root(&cohort_id, &s).unwrap();
+        assert_eq!(r1, r2);
+    }
+
+    #[test]
+    fn distinct_cohorts_yield_distinct_roots() {
+        let s = fake_schedule(4);
+        let r_a = compute_schedule_root(&[0x01; 32], &s).unwrap();
+        let r_b = compute_schedule_root(&[0x02; 32], &s).unwrap();
+        assert_ne!(r_a, r_b);
+    }
+
+    #[test]
+    fn distinct_setup_ids_yield_distinct_roots() {
+        let cohort_id = [0xab; 32];
+        let mut s_a = fake_schedule(4);
+        s_a.setup_id = vec![0x01; 32];
+        let mut s_b = fake_schedule(4);
+        s_b.setup_id = vec![0x02; 32];
+        let r_a = compute_schedule_root(&cohort_id, &s_a).unwrap();
+        let r_b = compute_schedule_root(&cohort_id, &s_b).unwrap();
+        assert_ne!(r_a, r_b);
+    }
+
+    #[test]
+    fn flipping_one_byte_of_a_proof_changes_the_root() {
+        let cohort_id = [0xab; 32];
+        let mut s = fake_schedule(3);
+        let r0 = compute_schedule_root(&cohort_id, &s).unwrap();
+        s.entries[1].proof1[0] ^= 0x01;
+        let r1 = compute_schedule_root(&cohort_id, &s).unwrap();
+        assert_ne!(r0, r1);
+    }
+
+    #[test]
+    fn flipping_one_byte_of_an_r_changes_the_root() {
+        let cohort_id = [0xab; 32];
+        let mut s = fake_schedule(3);
+        let r0 = compute_schedule_root(&cohort_id, &s).unwrap();
+        s.entries[2].r2[5] ^= 0xff;
+        let r1 = compute_schedule_root(&cohort_id, &s).unwrap();
+        assert_ne!(r0, r1);
+    }
+
+    #[test]
+    fn rejects_entry_count_mismatch() {
+        let mut s = fake_schedule(3);
+        s.n = 5;
+        let err = compute_schedule_root(&[0; 32], &s).unwrap_err();
+        assert!(matches!(
+            err,
+            ScheduleRootError::EntryCountMismatch { entries: 3, n: 5 }
+        ));
+    }
+
+    #[test]
+    fn rejects_malformed_r_length() {
+        let cohort_id = [0; 32];
+        let mut s = fake_schedule(2);
+        s.entries[0].r1 = vec![0u8; 32]; // 32 instead of 33
+        let err = compute_schedule_root(&cohort_id, &s).unwrap_err();
+        assert!(matches!(err, ScheduleRootError::MalformedR { got: 32 }));
+    }
+
+    #[test]
+    fn empty_schedule_n_zero_yields_zero_root() {
+        let s = PublishedSchedule {
+            setup_id: vec![0u8; 32],
+            n: 0,
+            entries: Vec::new(),
+        };
+        let r = compute_schedule_root(&[0; 32], &s).unwrap();
+        assert_eq!(r.0, [0u8; 32]);
+    }
+
+    #[test]
+    fn pinned_tags() {
+        assert_eq!(SCHEDULE_LEAF_TAG, b"DarkPsarScheduleLeafV1");
+        assert_eq!(SCHEDULE_BRANCH_TAG, b"DarkPsarScheduleBranchV1");
+    }
+}

--- a/crates/dark-psar/tests/e2e_psar_regtest.rs
+++ b/crates/dark-psar/tests/e2e_psar_regtest.rs
@@ -80,6 +80,7 @@ fn make_attest() -> (SlotAttest, secp256k1::XOnlyPublicKey) {
         setup_id: [0xef; 32],
         n: 12,
         k: 100,
+        schedule_root: [0x12; 32],
     }
     .sign(&secp, &kp);
     (attest, pk)

--- a/crates/dark-von/src/wrapper.rs
+++ b/crates/dark-von/src/wrapper.rs
@@ -22,6 +22,24 @@
 //! over `alpha' = x || R` binds the published `R` to the keypair and
 //! input. Equivocation is observable but not key-extractable — see
 //! ADR-0007 §"Equivocation".
+//!
+//! # Scope of binding
+//!
+//! What this wrapper guarantees is **per-input** binding: given a
+//! fixed `x`, the pair `(R, π)` an honest holder of `sk` can produce
+//! is canonical, and a forged `(R*, π*)` requires forging an ECVRF
+//! proof under `pk`. What it does *not* guarantee is **per-slot
+//! uniqueness** for any particular schedule — i.e. that the operator
+//! committed to using exactly these `x_{t,b}` for slot `t`. That
+//! property is delivered one layer up by the schedule commitment in
+//! `dark_psar::schedule_root`, which Merkle-hashes the published
+//! schedule `Λ = {(t, b, R, π)}` into a 32-byte root and signs it
+//! into the on-chain `SlotAttest` alongside `slot_root`. Tightening
+//! the wrapper to deliver per-slot uniqueness on its own (e.g. by
+//! deriving `r` from `β`) would expose `r` to anyone who can compute
+//! `β = ECVRF.proof_to_hash(π)` — which is publicly recoverable —
+//! and therefore break MuSig2 unforgeability. See ADR-0007 §"Scope
+//! of binding (clarification, 2026-05-01)".
 
 use hmac::{Hmac, Mac};
 use secp256k1::{PublicKey, SecretKey};

--- a/docs/adr/0007-von-wrapper-construction.md
+++ b/docs/adr/0007-von-wrapper-construction.md
@@ -276,6 +276,53 @@ extraction; **that is out of scope for VON-M1**.
   ≤200 B input), reopen this ADR — that would indicate accidental
   recomputation.
 
+## Scope of binding (clarification, 2026-05-01)
+
+The "Binding" property above guarantees that, for any *fixed* input
+`α' = x || R_compressed`, exactly one `(R, π)` an honest operator can
+produce passes `VON.Verify`. In other words, **the wrapper certifies
+that whoever holds `sk_VON` blessed `R` for input `x`** — not that
+`x` itself is the input the operator was *supposed to* use for any
+particular slot in a published schedule.
+
+That second property — *per-slot uniqueness*, i.e. "the operator
+committed to using exactly these `x_{t,b}` for each `t` in `[0, N)`,
+each `b ∈ {1, 2}`, for cohort `C`" — is **outside the scope of the
+wrapper** and is delivered one layer up by the **schedule
+commitment** in `dark_psar::schedule_root`. The published schedule
+`Λ = {(t, b, R, π)}` is hashed into a Merkle root over leaves
+`{1 || cohort_id || setup_id || t_LE || b || R || sha256(π)}` (BIP-340
+tagged hashes, `DarkPsarScheduleLeafV1` / `DarkPsarScheduleBranchV1`),
+and that root is signed into the `SlotAttest` the ASP publishes
+on-chain alongside `slot_root`. A user verifying boarding recomputes
+the schedule root from `Λ` and checks it equals
+`SlotAttestUnsigned.schedule_root`; mismatch aborts boarding before
+any per-entry `VON.Verify` runs.
+
+Why this split: trying to derive per-slot uniqueness *inside* the
+wrapper — for instance by making `r` a function of `β = ECVRF.proof_to_hash(π)`
+so that `R` is publicly recoverable from `(pk_VON, x)` alone — would
+make `r` recoverable to anyone who can compute `β`, and `β` is itself
+publicly computable from any valid `π`. That collapses Requirement 1
+(hidden `r`) and breaks MuSig2 unforgeability. The schedule-commitment
+approach keeps `r` secret, keeps the wrapper a clean ECVRF-binding
+primitive, and moves accountability into a place where it can be
+checked with a single 32-byte equality.
+
+In short:
+
+| Property | Layer | Mechanism |
+|---|---|---|
+| `r` hidden, `R = r·G` is canonical for `(sk_VON, x)` | `dark_von::wrapper` | HMAC + ECVRF over `x \|\| R` |
+| `(t, b) ↦ R_{t,b}` is committed for cohort `C` | `dark_psar::schedule_root` | Merkle root signed into `SlotAttest` |
+| Forking the schedule = signed equivocation evidence | `dark-psar` accountability | Two `SlotAttest`s with different `schedule_root` for the same `(cohort_id, setup_id)` |
+
+Theorem-style statements about the protocol that previously
+attributed per-slot uniqueness to the wrapper (e.g., earlier drafts
+of the AFT paper §5.2) should be read as covering the *combined*
+construction `wrapper + schedule_root + SlotAttest`, not the wrapper
+in isolation.
+
 ## References
 
 - Issue #654 (this ADR).


### PR DESCRIPTION
## Summary

Round-1 revision response to the AFT 2026 reviews of the VON paper. Adds a layer of cross-cohort accountability that the VON wrapper does not (and structurally cannot) provide on its own:

- New `dark_psar::schedule_root` module computing a BIP-340 tagged-hash Merkle root over the published Λ entries (leaf prefix `0x01`, tags `DarkPsarScheduleLeafV1` / `DarkPsarScheduleBranchV1`, leaf preimage 130 B = `prefix ‖ cohort_id ‖ setup_id ‖ t_LE ‖ b ‖ R ‖ sha256(π)`).
- Threaded into `SlotAttestUnsigned` as a 32-byte `schedule_root` field. The ASP signs this attestation under its long-term BIP-340 key, so two attestations bearing the same `cohort_id` but different schedule roots are publicly verifiable equivocation evidence under the operator's own Schnorr key — detectable by anyone with both attestations and standard BIP-340 verification.
- `asp_board` computes the root from the freshly-built schedule and embeds it in the attestation; `user_board` recomputes from `schedule` and rejects with new `PsarError::ScheduleRootMismatch` on any disagreement.

The VON wrapper in `dark_von::wrapper` is intentionally unchanged: HMAC-r + ECVRF over `α' = x ‖ R` provides per-input certification ("R was chosen by the holder of `sk_VON` for this `x`"), not per-slot uniqueness — and trying to make it provide per-slot uniqueness by deriving `r` from `β = ECVRF.proof_to_hash(π)` would expose `r` to anyone who can compute `β`, breaking MuSig2 unforgeability. ADR-0007 and the `wrapper.rs` module docs gain a "Scope of binding" note explaining the split and pointing to the schedule commitment as the layer that delivers per-slot accountability.

### Surface changes

- `SlotAttestUnsigned::SIZE`: 104 → 136 B (add 32 B `schedule_root`).
- `SlotAttest::SIZE`: 168 → 200 B.
- `SlotAttest::OP_RETURN_SIZE`: 68 B unchanged.
- New variant `PsarError::ScheduleRootMismatch`.
- 8 new unit tests under `schedule_root.rs` (determinism, distinct cohorts/setups, byte-flip detection, error paths, empty schedule, pinned tags).

## Test plan

- [x] `cargo fmt --all` clean
- [x] `cargo clippy --tests --benches -p dark-psar -p dark-von -- -D warnings` clean
- [x] `cargo test -p dark-psar --lib` (111 passed) including the updated `user_board_aborts_on_mutated_lambda` test (now trips `ScheduleRootMismatch` before reaching the per-entry verify, a strictly stronger detection than before)
- [x] `cargo test -p dark-von -p dark-von-musig2 -p dark-psar` (all green)
- [x] `cargo test --workspace --lib -- --skip ten_thousand_random_valid_txs_all_accepted` all green
- [ ] CI: full `cargo test --workspace` including the slow Bulletproofs proptest (verifies on CI runners)